### PR TITLE
Feature/#9 ESLint prefer absolute path 세팅

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,17 @@
       	"@typescript-eslint"
     ],
     "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            {
+              "group": ["../*"],
+              "message": "Usage of relative parent imports is not allowed."
+            }
+          ]
+        }
+      ],
       "react/react-in-jsx-scope": "off",
       "max-classes-per-file": "off",
       "class-methods-use-this": "off"


### PR DESCRIPTION
## #9 request

- 절대경로를 쓰도록 `../`을 사용하면 에러가 나게 만들었습니다.


## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes