### PR TITLE
[버스 페이지] 상단 카드 영역 및 상태 관리 로직 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import StorePage from 'pages/Store/StorePage';
 import Toast from 'components/common/Toast';
 import SignupPage from 'pages/Auth/SignupPage';
 import StoreDetailPage from 'pages/Store/StoreDetailPage';
+import BusPage from 'pages/BusPage';
 
 const useTokenState = () => {
   const [token, setToken] = useRecoilState(tokenState);
@@ -34,6 +35,7 @@ function App() {
         <Route path="/" element={<BoardPage />}>
           <Route path="/store" element={<StorePage />} />
           <Route path="/store/:id" element={<StoreDetailPage />} />
+          <Route path="/bus" element={<BusPage />} />
         </Route>
         <Route path="auth" element={token ? <Navigate replace to="/" /> : <AuthPage />}>
           <Route index element={<LoginPage />} />

--- a/src/api/bus/APIDetail.ts
+++ b/src/api/bus/APIDetail.ts
@@ -1,0 +1,43 @@
+import { APIRequest } from 'interfaces/APIRequest';
+import { HTTP_METHOD } from 'utils/ts/apiClient';
+import {
+  CoursesResponse, BusResponse, BusTimetableResponse, Direction, BusType,
+} from './entity';
+
+export class CourseList<R extends CoursesResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path = '/bus/courses';
+
+  response!: R;
+
+  auth = false;
+}
+
+export class BusInfo<R extends BusResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path: string;
+
+  response!: R;
+
+  auth = false;
+
+  constructor(type: string, depart: string, arrival: string) {
+    this.path = `/bus?bus_type=${type}&depart=${depart}&arrival=${arrival}`;
+  }
+}
+
+export class BusTimetableInfo<R extends BusTimetableResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path: string;
+
+  response!: R;
+
+  auth = false;
+
+  constructor(bus_type: BusType, direction: Direction, region: string) {
+    this.path = `/bus/timetable?bus_type=${bus_type}&direction=${direction}&region=${region}`;
+  }
+}

--- a/src/api/bus/entity.ts
+++ b/src/api/bus/entity.ts
@@ -1,0 +1,31 @@
+import { APIResponse } from 'interfaces/APIResponse';
+
+export type BusType = 'shuttle' | 'express' | 'city';
+
+export type Direction = 'from' | 'to';
+
+export type CoursesResponse = Array<{
+  bus_type: 'shuttle' | 'commuting'
+  direction: 'to' | 'from'
+  region: string
+}>;
+
+export interface BusResponse extends APIResponse {
+  bus_type: BusType
+  next_bus: {
+    remain_time: number
+  } | null
+  now_bus: {
+    remain_time: number
+  } | null
+}
+
+export type BusTimetableResponse = Array<BusRouteInfo>;
+
+interface BusRouteInfo {
+  route_name: string;
+  arrival_info: {
+    arrival_time: string;
+    node_name: string;
+  }[]
+}

--- a/src/api/bus/entity.ts
+++ b/src/api/bus/entity.ts
@@ -5,21 +5,21 @@ export type BusType = 'shuttle' | 'express' | 'city';
 export type Direction = 'from' | 'to';
 
 export type CoursesResponse = Array<{
-  bus_type: 'shuttle' | 'commuting'
-  direction: 'to' | 'from'
-  region: string
+  bus_type: 'shuttle' | 'commuting';
+  direction: 'to' | 'from';
+  region: string;
 }>;
 
 export interface BusResponse extends APIResponse {
-  bus_type: BusType
+  bus_type: BusType;
   next_bus: {
-    remain_time: number
-    bus_number?: number
-  } | null
+    remain_time: number;
+    bus_number?: number;
+  } | null;
   now_bus: {
-    remain_time: number
-    bus_number?: number
-  } | null
+    remain_time: number;
+    bus_number?: number;
+  } | null;
 }
 
 export type BusTimetableResponse = Array<BusRouteInfo>;
@@ -27,7 +27,7 @@ export type BusTimetableResponse = Array<BusRouteInfo>;
 interface BusRouteInfo {
   route_name: string;
   arrival_info: {
-    arrival_time: string
-    node_name: string
-  }[]
+    arrival_time: string;
+    node_name: string;
+  }[];
 }

--- a/src/api/bus/entity.ts
+++ b/src/api/bus/entity.ts
@@ -14,9 +14,11 @@ export interface BusResponse extends APIResponse {
   bus_type: BusType
   next_bus: {
     remain_time: number
+    bus_number?: number
   } | null
   now_bus: {
     remain_time: number
+    bus_number?: number
   } | null
 }
 
@@ -25,7 +27,7 @@ export type BusTimetableResponse = Array<BusRouteInfo>;
 interface BusRouteInfo {
   route_name: string;
   arrival_info: {
-    arrival_time: string;
-    node_name: string;
+    arrival_time: string
+    node_name: string
   }[]
 }

--- a/src/api/bus/index.ts
+++ b/src/api/bus/index.ts
@@ -1,0 +1,8 @@
+import { APIClient } from 'utils/ts/apiClient';
+import { BusInfo, BusTimetableInfo, CourseList } from './APIDetail';
+
+export const getCourseList = APIClient.of(CourseList);
+
+export const getBusInfo = APIClient.of(BusInfo);
+
+export const getBusTimetableInfo = APIClient.of(BusTimetableInfo);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
 export * as auth from './auth';
 export * as store from './store';
 export * as dept from './dept';
+export * as bus from './bus';

--- a/src/index.scss
+++ b/src/index.scss
@@ -30,6 +30,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
 
   /* https://css-tricks.com/snippets/css/system-font-stack/ */
   font-family:

--- a/src/pages/BusPage/BusLookUp/BusLookUp.module.scss
+++ b/src/pages/BusPage/BusLookUp/BusLookUp.module.scss
@@ -1,8 +1,6 @@
 .lookup {
-  &__container {
-    margin: 63px auto 0;
-    width: 1131px;
-  }
+  margin: 63px auto 0;
+  width: 1131px;
 
   &__title {
     font-family: NanumSquare, sans-serif;
@@ -14,7 +12,7 @@
 
   &__description {
     margin-top: 30px;
-    margin-bottom: 20px;
+    margin-bottom: 22px;
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
@@ -30,9 +28,71 @@
   }
 
   &__select {
+    cursor: pointer;
     border: 0;
+    margin: 0 10px 0 4px;
     font-size: 24px;
-    margin: 0 4px;
     font-weight: bold;
+  }
+}
+
+.cards {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: repeat(3, 370px);
+  grid-template-rows: 162px 85px;
+  gap: 5px 9px;
+  color: white;
+
+  &__top-card {
+    padding: 26px 23px 0;
+  }
+
+  &__bottom-card {
+    padding: 23px 23px 0;
+  }
+
+  &__card {
+    &--shuttle {
+      background-color: rgb(247 148 30);
+    }
+
+    &--express {
+      background-color: rgb(124 159 174);
+    }
+
+    &--city {
+      background-color: rgb(77 178 151);
+    }
+  }
+
+  &__content {
+    display: flex;
+    justify-content: space-between;
+
+    &--description {
+      margin-top: 26px;
+    }
+  }
+
+  &__direction {
+    font-size: 24px;
+    letter-spacing: -1.2px;
+    display: flex;
+    align-items: center;
+    margin-bottom: 11px;
+  }
+
+  &__badge {
+    width: 39px;
+    height: 19px;
+    border: 1px solid white;
+    border-radius: 14px;
+    font-size: 11px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 1px;
+    margin-right: 13px;
   }
 }

--- a/src/pages/BusPage/BusLookUp/BusLookUp.module.scss
+++ b/src/pages/BusPage/BusLookUp/BusLookUp.module.scss
@@ -95,4 +95,39 @@
     padding-top: 1px;
     margin-right: 13px;
   }
+
+  &__time {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: -0.9px;
+  }
+
+  &__detail {
+    font-size: 12px;
+    font-weight: 400;
+    letter-spacing: -0.6px;
+    margin-left: 10px;
+  }
+
+  &__bus-number {
+    font-size: 14px;
+    letter-spacing: -0.7px;
+  }
+
+  &__bus-icon {
+    position: relative;
+    height: 15px;
+    width: auto;
+    right: 8px;
+    top: 2px;
+  }
+
+  &__bus-type {
+    font-size: 14px;
+  }
+
+  &__title--bottom {
+    height: 20px;
+    font-size: 12px;
+  }
 }

--- a/src/pages/BusPage/BusLookUp/BusLookUp.module.scss
+++ b/src/pages/BusPage/BusLookUp/BusLookUp.module.scss
@@ -1,0 +1,38 @@
+.lookup {
+  &__container {
+    margin: 63px auto 0;
+    width: 1131px;
+  }
+
+  &__title {
+    font-family: NanumSquare, sans-serif;
+    letter-spacing: -1.5px;
+    font-size: 30px;
+    font-weight: 800;
+    color: #175c8e;
+  }
+
+  &__description {
+    margin-top: 30px;
+    margin-bottom: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    font-size: 24px;
+  }
+
+  &__subtitle {
+    font-family: NanumBarunGothic, sans-serif;
+    font-size: 24px;
+    letter-spacing: -1.2px;
+    font-weight: 300;
+    line-height: 28px;
+  }
+
+  &__select {
+    border: 0;
+    font-size: 24px;
+    margin: 0 4px;
+    font-weight: bold;
+  }
+}

--- a/src/pages/BusPage/BusLookUp/index.tsx
+++ b/src/pages/BusPage/BusLookUp/index.tsx
@@ -1,10 +1,21 @@
+import { Fragment, Suspense } from 'react';
+import cn from 'utils/ts/classnames';
 import useBusDirection from 'pages/BusPage/hooks/useBusDirection';
+import useBusLeftTIme from 'pages/BusPage/hooks/useBusLeftTime';
+import { getLeftTimeString } from 'pages/BusPage/ts/busTimeModules';
 import styles from './BusLookUp.module.scss';
+
+const BUS_TYPE = ['shuttle', 'express', 'city'];
 
 function BusLookUp() {
   const { depart, arrival } = useBusDirection(['한기대', '야우리', '천안역']);
+  const { data: busData } = useBusLeftTIme({
+    departList: [depart.value, depart.value, depart.value],
+    arrivalList: [arrival.value, arrival.value, arrival.value],
+  });
+
   return (
-    <div className={styles.lookup__container}>
+    <div className={styles.lookup}>
       <h1 className={styles.lookup__title}>버스 / 교통 운행정보</h1>
       <div className={styles.lookup__description}>
         <h2 className={styles.lookup__subtitle}>
@@ -35,6 +46,40 @@ function BusLookUp() {
           갑니다
         </div>
       </div>
+      <Suspense fallback={<div />}>
+        <div className={styles.cards}>
+          {BUS_TYPE.map((type, idx) => (
+            <Fragment key={type}>
+              <div className={cn({ [styles['cards__top-card']]: true, [styles[`cards__card--${type}`]]: true })}>
+                <div className={styles.cards__content}>
+                  <div>
+                    <div className={styles.cards__direction}>
+                      <span className={styles.cards__badge}>
+                        출발
+                      </span>
+                      {depart.options[0]}
+                    </div>
+                    <div className={styles.cards__direction}>
+                      <span className={styles.cards__badge}>
+                        도착
+                      </span>
+                      {arrival.options[0]}
+                    </div>
+                  </div>
+                  <span>400번 버스</span>
+                </div>
+                <div className={styles['cards__content--description']}>
+                  <span>{getLeftTimeString(busData[idx].data?.now_bus?.remain_time)}</span>
+                  <span>시내버스</span>
+                </div>
+              </div>
+              <div className={cn({ [styles['cards__bottom-card']]: true, [styles[`cards__card--${type}`]]: true })}>
+                하단
+              </div>
+            </Fragment>
+          ))}
+        </div>
+      </Suspense>
     </div>
   );
 }

--- a/src/pages/BusPage/BusLookUp/index.tsx
+++ b/src/pages/BusPage/BusLookUp/index.tsx
@@ -87,7 +87,12 @@ function BusLookUp() {
               </div>
             </div>
             <div className={cn({ [styles['cards__bottom-card']]: true, [styles[`cards__card--${type}`]]: true })}>
-              <div className={styles['cards__title--bottom']}>다음버스</div>
+              <div className={styles.cards__content}>
+                <span className={styles['cards__title--bottom']}>다음버스</span>
+                {typeof busData[idx]?.now_bus?.remain_time === 'number' && (
+                  <span className={styles['cards__bus-number']}>{`${busData[idx]?.next_bus?.bus_number}번 버스`}</span>
+                )}
+              </div>
               <div className={styles.cards__content}>
                 <div>
                   <span className={styles.cards__time}>

--- a/src/pages/BusPage/BusLookUp/index.tsx
+++ b/src/pages/BusPage/BusLookUp/index.tsx
@@ -88,7 +88,7 @@ function BusLookUp() {
             <div className={cn({ [styles['cards__bottom-card']]: true, [styles[`cards__card--${type}`]]: true })}>
               <div className={styles.cards__content}>
                 <span className={styles['cards__title--bottom']}>다음버스</span>
-                {typeof busData[idx]?.now_bus?.remain_time === 'number' && (
+                {busData[idx]?.next_bus?.bus_number && (
                   <span className={styles['cards__bus-number']}>{`${busData[idx]?.next_bus?.bus_number}번 버스`}</span>
                 )}
               </div>

--- a/src/pages/BusPage/BusLookUp/index.tsx
+++ b/src/pages/BusPage/BusLookUp/index.tsx
@@ -3,12 +3,11 @@ import cn from 'utils/ts/classnames';
 import useBusDirection from 'pages/BusPage/hooks/useBusDirection';
 import useBusLeftTIme from 'pages/BusPage/hooks/useBusLeftTime';
 import { getBusName, getLeftTimeString, getStartTimeString } from 'pages/BusPage/ts/busModules';
+import { BUS_DIRECTIONS, BUS_TYPES } from 'static/bus';
 import styles from './BusLookUp.module.scss';
 
-const BUS_TYPE = ['shuttle', 'express', 'city'];
-
 function BusLookUp() {
-  const { depart, arrival } = useBusDirection(['한기대', '야우리', '천안역']);
+  const { depart, arrival } = useBusDirection(BUS_DIRECTIONS);
   const { data: busData } = useBusLeftTIme({
     departList: [depart.value, depart.value, depart.value],
     arrivalList: [arrival.value, arrival.value, arrival.value],
@@ -47,7 +46,7 @@ function BusLookUp() {
         </div>
       </div>
       <div className={styles.cards}>
-        {BUS_TYPE.map((type, idx) => (
+        {BUS_TYPES.map((type, idx) => (
           <React.Fragment key={type}>
             <div className={cn({ [styles['cards__top-card']]: true, [styles[`cards__card--${type}`]]: true })}>
               <div className={styles.cards__content}>

--- a/src/pages/BusPage/BusLookUp/index.tsx
+++ b/src/pages/BusPage/BusLookUp/index.tsx
@@ -1,0 +1,42 @@
+import useBusDirection from 'pages/BusPage/hooks/useBusDirection';
+import styles from './BusLookUp.module.scss';
+
+function BusLookUp() {
+  const { depart, arrival } = useBusDirection(['한기대', '야우리', '천안역']);
+  return (
+    <div className={styles.lookup__container}>
+      <h1 className={styles.lookup__title}>버스 / 교통 운행정보</h1>
+      <div className={styles.lookup__description}>
+        <h2 className={styles.lookup__subtitle}>
+          어디를 가시나요?
+          <br />
+          운행수단별로 간단히 비교해드립니다.
+        </h2>
+        <div>
+          <select
+            className={styles.lookup__select}
+            onChange={depart.handleChange}
+            value={depart.value}
+          >
+            {depart.options.map((option) => (
+              <option key={option}>{option}</option>
+            ))}
+          </select>
+          에서
+          <select
+            className={styles.lookup__select}
+            onChange={arrival.handleChange}
+            value={arrival.value}
+          >
+            {arrival.options.map((option) => (
+              <option key={option}>{option}</option>
+            ))}
+          </select>
+          갑니다
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default BusLookUp;

--- a/src/pages/BusPage/BusLookUp/index.tsx
+++ b/src/pages/BusPage/BusLookUp/index.tsx
@@ -1,8 +1,8 @@
-import { Fragment, Suspense } from 'react';
+import React from 'react';
 import cn from 'utils/ts/classnames';
 import useBusDirection from 'pages/BusPage/hooks/useBusDirection';
 import useBusLeftTIme from 'pages/BusPage/hooks/useBusLeftTime';
-import { getLeftTimeString } from 'pages/BusPage/ts/busTimeModules';
+import { getBusName, getLeftTimeString, getStartTimeString } from 'pages/BusPage/ts/busModules';
 import styles from './BusLookUp.module.scss';
 
 const BUS_TYPE = ['shuttle', 'express', 'city'];
@@ -46,40 +46,68 @@ function BusLookUp() {
           갑니다
         </div>
       </div>
-      <Suspense fallback={<div />}>
-        <div className={styles.cards}>
-          {BUS_TYPE.map((type, idx) => (
-            <Fragment key={type}>
-              <div className={cn({ [styles['cards__top-card']]: true, [styles[`cards__card--${type}`]]: true })}>
-                <div className={styles.cards__content}>
-                  <div>
-                    <div className={styles.cards__direction}>
-                      <span className={styles.cards__badge}>
-                        출발
-                      </span>
-                      {depart.options[0]}
-                    </div>
-                    <div className={styles.cards__direction}>
-                      <span className={styles.cards__badge}>
-                        도착
-                      </span>
-                      {arrival.options[0]}
-                    </div>
+      <div className={styles.cards}>
+        {BUS_TYPE.map((type, idx) => (
+          <React.Fragment key={type}>
+            <div className={cn({ [styles['cards__top-card']]: true, [styles[`cards__card--${type}`]]: true })}>
+              <div className={styles.cards__content}>
+                <div>
+                  <div className={styles.cards__direction}>
+                    <span className={styles.cards__badge}>
+                      출발
+                    </span>
+                    {depart.options[0]}
                   </div>
-                  <span>400번 버스</span>
+                  <div className={styles.cards__direction}>
+                    <span className={styles.cards__badge}>
+                      도착
+                    </span>
+                    {arrival.options[0]}
+                  </div>
                 </div>
-                <div className={styles['cards__content--description']}>
-                  <span>{getLeftTimeString(busData[idx].data?.now_bus?.remain_time)}</span>
-                  <span>시내버스</span>
+                {busData[idx]?.now_bus?.bus_number && (
+                  <span className={styles['cards__bus-number']}>{`${busData[idx]?.now_bus?.bus_number}번 버스`}</span>
+                )}
+              </div>
+              <div className={cn({ [styles['cards__content--description']]: true, [styles.cards__content]: true })}>
+                <div>
+                  <span className={styles.cards__time}>
+                    {getLeftTimeString(busData[idx]?.now_bus?.remain_time)}
+                  </span>
+                  {typeof busData[idx]?.now_bus?.remain_time === 'number' && (
+                  <span className={styles.cards__detail}>
+                    {`(${getStartTimeString(busData[idx]?.now_bus?.remain_time)} 출발)`}
+                  </span>
+                  )}
+                </div>
+                <div>
+                  <img className={styles['cards__bus-icon']} src="https://static.koreatech.in/assets/img/bus_icon-white.png" alt="" />
+                  <span className={styles['cards__bus-type']}>{getBusName(type)}</span>
                 </div>
               </div>
-              <div className={cn({ [styles['cards__bottom-card']]: true, [styles[`cards__card--${type}`]]: true })}>
-                하단
+            </div>
+            <div className={cn({ [styles['cards__bottom-card']]: true, [styles[`cards__card--${type}`]]: true })}>
+              <div className={styles['cards__title--bottom']}>다음버스</div>
+              <div className={styles.cards__content}>
+                <div>
+                  <span className={styles.cards__time}>
+                    {getLeftTimeString(busData[idx]?.next_bus?.remain_time)}
+                  </span>
+                  {typeof busData[idx]?.next_bus?.remain_time === 'number' && (
+                  <span className={styles.cards__detail}>
+                    {`(${getStartTimeString(busData[idx]?.next_bus?.remain_time)} 출발)`}
+                  </span>
+                  )}
+                </div>
+                <div>
+                  <img className={styles['cards__bus-icon']} src="https://static.koreatech.in/assets/img/bus_icon-white.png" alt="" />
+                  <span className={styles['cards__bus-type']}>{getBusName(type)}</span>
+                </div>
               </div>
-            </Fragment>
-          ))}
-        </div>
-      </Suspense>
+            </div>
+          </React.Fragment>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/BusPage/BusTimetable/index.tsx
+++ b/src/pages/BusPage/BusTimetable/index.tsx
@@ -1,0 +1,9 @@
+function BusTimetable() {
+  return (
+    <div>
+      시간표
+    </div>
+  );
+}
+
+export default BusTimetable;

--- a/src/pages/BusPage/hooks/useBusDirection.ts
+++ b/src/pages/BusPage/hooks/useBusDirection.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent, useState } from 'react';
-import { directionToEnglish } from 'pages/BusPage/ts/busTimeModules';
+import { directionToEnglish } from 'pages/BusPage/ts/busModules';
 
 const useBusDirection = (directionList: string[]) => {
   const [depart, setDepart] = useState(directionList[0]);

--- a/src/pages/BusPage/hooks/useBusDirection.ts
+++ b/src/pages/BusPage/hooks/useBusDirection.ts
@@ -1,4 +1,5 @@
 import { ChangeEvent, useState } from 'react';
+import { directionToEnglish } from 'pages/BusPage/ts/busTimeModules';
 
 const useBusDirection = (directionList: string[]) => {
   const [depart, setDepart] = useState(directionList[0]);
@@ -16,12 +17,12 @@ const useBusDirection = (directionList: string[]) => {
 
   return {
     depart: {
-      value: depart,
+      value: directionToEnglish(depart),
       options: [depart].concat(directionList.filter((name) => name !== depart)),
       handleChange: changeDepart,
     },
     arrival: {
-      value: arrival,
+      value: directionToEnglish(arrival),
       options: [arrival].concat(directionList.filter((name) => name !== arrival)),
       handleChange: changeArrival,
     },

--- a/src/pages/BusPage/hooks/useBusDirection.ts
+++ b/src/pages/BusPage/hooks/useBusDirection.ts
@@ -1,0 +1,31 @@
+import { ChangeEvent, useState } from 'react';
+
+const useBusDirection = (directionList: string[]) => {
+  const [depart, setDepart] = useState(directionList[0]);
+  const [arrival, setArrival] = useState(directionList[1]);
+
+  const changeDepart = (e: ChangeEvent<HTMLSelectElement>) => {
+    setDepart(e.target.value);
+    if (e.target.value === arrival) setArrival(depart);
+  };
+
+  const changeArrival = (e: ChangeEvent<HTMLSelectElement>) => {
+    setArrival(e.target.value);
+    if (e.target.value === depart) setDepart(arrival);
+  };
+
+  return {
+    depart: {
+      value: depart,
+      options: [depart].concat(directionList.filter((name) => name !== depart)),
+      handleChange: changeDepart,
+    },
+    arrival: {
+      value: arrival,
+      options: [arrival].concat(directionList.filter((name) => name !== arrival)),
+      handleChange: changeArrival,
+    },
+  };
+};
+
+export default useBusDirection;

--- a/src/pages/BusPage/hooks/useBusLeftTime.ts
+++ b/src/pages/BusPage/hooks/useBusLeftTime.ts
@@ -1,8 +1,8 @@
 import { getBusInfo } from 'api/bus';
 import { useQueries } from 'react-query';
+import { BUS_TYPES } from 'static/bus';
 
 const BUS_KEY = 'bus_info';
-const BUS_TYPES = ['shuttle', 'express', 'city'];
 
 interface Props {
   departList: string[];

--- a/src/pages/BusPage/hooks/useBusLeftTime.ts
+++ b/src/pages/BusPage/hooks/useBusLeftTime.ts
@@ -1,5 +1,7 @@
 import { getBusInfo } from 'api/bus';
-import { useQueries } from 'react-query';
+import { BusResponse } from 'api/bus/entity';
+import { AxiosError } from 'axios';
+import { QueryOptions, useQueries } from 'react-query';
 import { BUS_TYPES } from 'static/bus';
 
 const BUS_KEY = 'bus_info';
@@ -21,14 +23,16 @@ const emptyRouteData = {
 } as const;
 
 const useBusLeftTIme = ({ departList, arrivalList }: Props) => {
-  const queries = BUS_TYPES.map((type, idx) => ({
-    queryKey: [BUS_KEY, type, departList[idx], arrivalList[idx]],
-    queryFn: () => getBusInfo(type, departList[idx], arrivalList[idx]),
-    refetchInterval: 60000,
-    staleTime: 60000,
-    suspense: true,
-    keepPreviousData: true,
-  }));
+  const queries = BUS_TYPES.map<QueryOptions<BusResponse, AxiosError, BusResponse, string[]>>(
+    (type, idx) => ({
+      queryKey: [BUS_KEY, type, departList[idx], arrivalList[idx]],
+      queryFn: ({ queryKey: [, busType, depart, arrival] }) => getBusInfo(busType, depart, arrival),
+      refetchInterval: 60000,
+      staleTime: 60000,
+      suspense: true,
+      keepPreviousData: true,
+    }),
+  );
 
   const results = useQueries(queries);
 

--- a/src/pages/BusPage/hooks/useBusLeftTime.ts
+++ b/src/pages/BusPage/hooks/useBusLeftTime.ts
@@ -1,0 +1,26 @@
+import { getBusInfo } from 'api/bus';
+import { useQueries } from 'react-query';
+
+const BUS_KEY = 'bus_info';
+const BUS_TYPES = ['shuttle', 'express', 'city'];
+
+interface Props {
+  departList: string[];
+  arrivalList: string[];
+}
+
+const useBusLeftTIme = ({ departList, arrivalList }: Props) => {
+  const queries = BUS_TYPES.map((type, idx) => ({
+    queryKey: [BUS_KEY, type, departList[idx], arrivalList[idx]],
+    queryFn: () => getBusInfo(type, departList[idx], arrivalList[idx]),
+    refetchInterval: 60000,
+    staleTime: 60000,
+    suspense: true,
+  }));
+
+  const results = useQueries(queries);
+
+  return { data: results };
+};
+
+export default useBusLeftTIme;

--- a/src/pages/BusPage/hooks/useBusLeftTime.ts
+++ b/src/pages/BusPage/hooks/useBusLeftTime.ts
@@ -9,6 +9,17 @@ interface Props {
   arrivalList: string[];
 }
 
+const emptyRouteData = {
+  now_bus: {
+    remain_time: '미운행',
+    bus_number: null,
+  },
+  next_bus: {
+    remain_time: '미운행',
+    bus_number: null,
+  },
+} as const;
+
 const useBusLeftTIme = ({ departList, arrivalList }: Props) => {
   const queries = BUS_TYPES.map((type, idx) => ({
     queryKey: [BUS_KEY, type, departList[idx], arrivalList[idx]],
@@ -16,11 +27,17 @@ const useBusLeftTIme = ({ departList, arrivalList }: Props) => {
     refetchInterval: 60000,
     staleTime: 60000,
     suspense: true,
+    keepPreviousData: true,
   }));
 
   const results = useQueries(queries);
 
-  return { data: results };
+  return {
+    data: results.map((result) => {
+      if (result.isError) return emptyRouteData;
+      return result.data;
+    }),
+  };
 };
 
 export default useBusLeftTIme;

--- a/src/pages/BusPage/index.tsx
+++ b/src/pages/BusPage/index.tsx
@@ -1,0 +1,13 @@
+import BusLookUp from './BusLookUp';
+import BusTimetable from './BusTimetable';
+
+function BusPage() {
+  return (
+    <main>
+      <BusLookUp />
+      <BusTimetable />
+    </main>
+  );
+}
+
+export default BusPage;

--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -15,7 +15,10 @@ export const getLeftTimeString = (second: number | '미운행' | undefined) => {
   } return `${getHour(second)}시간 ${getMinute(second)}분 전`;
 };
 
-export const getStartTimeString = (second: number) => {
+export const getStartTimeString = (second: number | '미운행' | undefined, isMain:boolean = false) => {
+  if (!second) return '';
+  if (second === '미운행') return '';
+
   const hour = getHour(second);
   const minute = getMinute(second);
 
@@ -26,8 +29,10 @@ export const getStartTimeString = (second: number) => {
 
   startHour %= 24;
   startMinute %= 60;
+  const timeString = [String(startHour).padStart(2, '0'), String(startMinute).padStart(2, '0')];
 
-  return `${String(startHour).padStart(2, '0')}시 ${String(startMinute).padStart(2, '0')}분`;
+  if (isMain) return `${timeString[0]}시 ${timeString[1]}분`;
+  return `${timeString[0]}:${timeString[1]}`;
 };
 
 // eslint-disable-next-line consistent-return
@@ -35,5 +40,12 @@ export const directionToEnglish = (direction: string) => {
   if (direction === '한기대') return 'koreatech';
   if (direction === '야우리') return 'terminal';
   if (direction === '천안역') return 'station';
+  return '';
+};
+
+export const getBusName = (busType: string) => {
+  if (busType === 'shuttle') return '셔틀버스';
+  if (busType === 'express') return '대성고속';
+  if (busType === 'city') return '시내버스';
   return '';
 };

--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -44,7 +44,7 @@ export const directionToEnglish = (direction: string) => {
 };
 
 export const getBusName = (busType: string) => {
-  if (busType === 'shuttle') return '셔틀버스';
+  if (busType === 'shuttle') return '학교셔틀';
   if (busType === 'express') return '대성고속';
   if (busType === 'city') return '시내버스';
   return '';

--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -35,7 +35,6 @@ export const getStartTimeString = (second: number | '미운행' | undefined, isM
   return `${timeString[0]}:${timeString[1]}`;
 };
 
-// eslint-disable-next-line consistent-return
 export const directionToEnglish = (direction: string) => {
   if (direction === '한기대') return 'koreatech';
   if (direction === '야우리') return 'terminal';

--- a/src/pages/BusPage/ts/busTimeModules.ts
+++ b/src/pages/BusPage/ts/busTimeModules.ts
@@ -1,0 +1,39 @@
+// 시간 반환 함수
+const getHour = (second: number) => Math.floor(second / 60 / 60);
+
+const getMinute = (second: number) => Math.ceil(second / 60) % 60;
+
+export const getLeftTimeString = (second: number | '미운행' | undefined) => {
+  if (!second) {
+    return '운행정보없음';
+  } if (second === '미운행') {
+    return '미운행';
+  } if (getHour(second) === 0 && getMinute(second) === 0) {
+    return '곧 도착';
+  } if (getHour(second) === 0) {
+    return `${getMinute(second)}분 전`;
+  } return `${getHour(second)}시간 ${getMinute(second)}분 전`;
+};
+
+export const getStartTimeString = (second: number) => {
+  const hour = getHour(second);
+  const minute = getMinute(second);
+
+  const today = new Date();
+
+  let startHour = today.getHours() + hour;
+  let startMinute = today.getMinutes() + minute;
+
+  startHour %= 24;
+  startMinute %= 60;
+
+  return `${String(startHour).padStart(2, '0')}시 ${String(startMinute).padStart(2, '0')}분`;
+};
+
+// eslint-disable-next-line consistent-return
+export const directionToEnglish = (direction: string) => {
+  if (direction === '한기대') return 'koreatech';
+  if (direction === '야우리') return 'terminal';
+  if (direction === '천안역') return 'station';
+  return '';
+};

--- a/src/static/bus.ts
+++ b/src/static/bus.ts
@@ -1,0 +1,3 @@
+export const BUS_TYPES = ['shuttle', 'express', 'city'];
+
+export const BUS_DIRECTIONS = ['한기대', '야우리', '천안역'];


### PR DESCRIPTION
## [#23] request

버스페이지 상단 카드 영역을 추가했습니다.
- 메인페이지 영역에서 경로 별 버스 정보를 조회할 것을 대비해 **`[셔틀, 대성, 마을]`** 순으로 출발지(`departList`)와 목적지(`arrivalList`)를 받습니다.
- 최소 1분에 한번씩은 조회하도록 `staleTime`과 `refetchInterval`을 설정했습니다.
- 미운행인 구간에 대해서는 API가 에러를 반환하는데(천안역 -> 야우리 등), 해당 부분은 `remain_time`에 `'미운행'`을 담고 있는 `emptyRouteData`를 반환하도록 만들었습니다. UI를 작성하는 부분에 있어서 편의를 위해 이렇게 작성했는데, 더 나은 방안이 생각난다면 추천 부탁드립니다.

추가로, 글꼴이 정확히 나오지 않고 있는 문제가 있어 `-webkit-font-smoothing: antialiased;`를 전역으로 추가했습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes

### Screenshot

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/50780281/206854306-29af1a58-b7ef-45ad-8a6f-0e5c7842f179.png">
