### PR TITLE
[메인 페이지] 주변식당 카테고리, 버스 컴포넌트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Toast from 'components/common/Toast';
 import SignupPage from 'pages/Auth/SignupPage';
 import StoreDetailPage from 'pages/BoardPage/Store/StoreDetailPage';
 import BusPage from 'pages/BusPage';
+import IndexPage from 'pages/IndexPage';
 
 const useTokenState = () => {
   const [token, setToken] = useRecoilState(tokenState);
@@ -34,6 +35,7 @@ function App() {
     <>
       <Routes>
         <Route path="/" element={<BoardPage />}>
+          <Route path="/" element={<IndexPage />} />
           <Route path="/store" element={<StorePage />} />
           <Route path="/store/:id" element={<StoreDetailPage />} />
           <Route path="/bus" element={<BusPage />} />

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
-import CATEGORY, { ICategory, ISubMenu } from 'static/category';
+import CATEGORY, { Category, SubMenu } from 'static/category';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import cn from 'utils/ts/classnames';
@@ -13,8 +13,8 @@ const ID: { [key: string]: string; } = {
   LABEL2: 'megamenu-label-2',
 };
 
-const useMegaMenu = (category: ICategory[]) => {
-  const [panelMenuList, setPanelMenuList] = useState<ISubMenu[] | null>();
+const useMegaMenu = (category: Category[]) => {
+  const [panelMenuList, setPanelMenuList] = useState<SubMenu[] | null>();
   const [isExpanded, setIsExpanded] = useState(false);
 
   const createOnChangeMenu = (title: string) => () => {

--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -26,8 +26,8 @@ export const getStartTimeString = (second: number | '미운행' | undefined, isM
 
   const today = new Date();
 
-  let startHour = today.getHours() + hour;
   let startMinute = today.getMinutes() + minute;
+  let startHour = today.getHours() + hour + Math.ceil(startMinute / 60);
 
   startHour %= 24;
   startMinute %= 60;

--- a/src/pages/IndexPage/IndexPage.module.scss
+++ b/src/pages/IndexPage/IndexPage.module.scss
@@ -1,4 +1,4 @@
-@use "src/utils/scss/media";
+@use "src/utils/scss/media" as media;
 
 .template {
   width: 1132px;

--- a/src/pages/IndexPage/IndexPage.module.scss
+++ b/src/pages/IndexPage/IndexPage.module.scss
@@ -4,4 +4,8 @@
   width: 1132px;
   margin: 0 auto;
   padding: 40px 0;
+
+  @include media.media-breakpoint(mobile) {
+    width: 100%;
+  }
 }

--- a/src/pages/IndexPage/IndexPage.module.scss
+++ b/src/pages/IndexPage/IndexPage.module.scss
@@ -1,0 +1,7 @@
+@use "src/utils/scss/media";
+
+.template {
+  width: 1132px;
+  margin: 0 auto;
+  padding: 40px 0;
+}

--- a/src/pages/IndexPage/IndexPage.module.scss
+++ b/src/pages/IndexPage/IndexPage.module.scss
@@ -4,6 +4,9 @@
   width: 1132px;
   margin: 0 auto;
   padding: 40px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
 
   @include media.media-breakpoint(mobile) {
     width: 100%;

--- a/src/pages/IndexPage/components/IndexBus/IndexBus.module.scss
+++ b/src/pages/IndexPage/components/IndexBus/IndexBus.module.scss
@@ -6,6 +6,10 @@
   align-items: flex-start;
   gap: 18px;
 
+  @include media.media-breakpoint(mobile) {
+    order: 1;
+  }
+
   &__title {
     font-family: NanumSquare, serif;
     font-size: 17px;

--- a/src/pages/IndexPage/components/IndexBus/IndexBus.module.scss
+++ b/src/pages/IndexPage/components/IndexBus/IndexBus.module.scss
@@ -8,6 +8,7 @@
 
   @include media.media-breakpoint(mobile) {
     order: 1;
+    width: 100%;
   }
 
   &__title {
@@ -30,9 +31,31 @@
   display: flex;
   justify-content: space-between;
 
+  @include media.media-breakpoint(mobile) {
+    overflow-x: auto;
+    width: 100%;
+    white-space: nowrap;
+    display: block;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
   &__card {
     width: 272px;
     height: 202px;
+
+    @include media.media-breakpoint(mobile) {
+      display: inline-block;
+      height: auto;
+      width: 75%;
+      transition: 0.3s ease 0s;
+
+      &--sm {
+        transform: scale(0.9);
+      }
+    }
   }
 
   &__head {
@@ -57,13 +80,24 @@
     &--city {
       background-color: rgb(77 178 151);
     }
+
+    @include media.media-breakpoint(mobile) {
+      gap: 5px;
+      font-size: 12px;
+      height: 30px;
+    }
   }
 
   &__bus-icon {
     position: relative;
-    height: 20px;
     width: 20px;
+    height: 20px;
     top: -1px;
+
+    @include media.media-breakpoint(mobile) {
+      width: 16px;
+      height: 16px;
+    }
   }
 
   &__body {
@@ -73,10 +107,19 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+
+    @include media.media-breakpoint(mobile) {
+      height: 106px;
+    }
   }
 
   &__remain-time {
     margin-top: 41px;
+    font-weight: bold;
+
+    @include media.media-breakpoint(mobile) {
+      margin-top: 27px;
+    }
   }
 
   &__detail {
@@ -92,6 +135,11 @@
     align-items: center;
     font-size: 14px;
     gap: 26px;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 12px;
+      gap: 11px;
+    }
   }
 
   &__toggle {

--- a/src/pages/IndexPage/components/IndexBus/IndexBus.module.scss
+++ b/src/pages/IndexPage/components/IndexBus/IndexBus.module.scss
@@ -1,0 +1,107 @@
+@use "src/utils/scss/media" as media;
+
+.template {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 18px;
+
+  &__title {
+    font-family: NanumSquare, serif;
+    font-size: 17px;
+    font-weight: bold;
+    color: #175c8e;
+    text-decoration: none;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 15px;
+      padding-left: 3px;
+      margin-left: 16px;
+    }
+  }
+}
+
+.cards {
+  width: 848px;
+  display: flex;
+  justify-content: space-between;
+
+  &__card {
+    width: 272px;
+    height: 202px;
+  }
+
+  &__head {
+    height: 38px;
+    padding-top: 2px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    color: white;
+    font-size: 14px;
+    font-weight: bold;
+
+    &--shuttle {
+      background-color: rgb(247 148 30);
+    }
+
+    &--express {
+      background-color: rgb(124 159 174);
+    }
+
+    &--city {
+      background-color: rgb(77 178 151);
+    }
+  }
+
+  &__bus-icon {
+    position: relative;
+    height: 20px;
+    width: 20px;
+    top: -1px;
+  }
+
+  &__body {
+    height: 162px;
+    border: 1px solid;
+    border-color: rgb(228 228 228);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  &__remain-time {
+    margin-top: 41px;
+  }
+
+  &__detail {
+    margin-top: 5px;
+    font-size: 12px;
+    height: 12px;
+  }
+
+  &__directions {
+    margin-top: 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 14px;
+    gap: 26px;
+  }
+
+  &__toggle {
+    appearance: none;
+    border: none;
+    background: none;
+    cursor: pointer;
+    height: 16px;
+    width: 16px;
+    padding: 0;
+
+    &--image {
+      height: 16px;
+      width: 16px;
+    }
+  }
+}

--- a/src/pages/IndexPage/components/IndexBus/hooks/useIndexBusDirection.ts
+++ b/src/pages/IndexPage/components/IndexBus/hooks/useIndexBusDirection.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+const useIndexBusDirection = () => {
+  const [toSchoolList, setToSchoolList] = useState([false, false, false]);
+
+  const toggleDirection = (index: number) => {
+    const newList = [...toSchoolList];
+    newList[index] = !newList[index];
+    setToSchoolList(newList);
+  };
+
+  return { toSchoolList, toggleDirection };
+};
+
+export default useIndexBusDirection;

--- a/src/pages/IndexPage/components/IndexBus/hooks/useIndexBusDirection.ts
+++ b/src/pages/IndexPage/components/IndexBus/hooks/useIndexBusDirection.ts
@@ -4,9 +4,11 @@ const useIndexBusDirection = () => {
   const [toSchoolList, setToSchoolList] = useState([false, false, false]);
 
   const toggleDirection = (index: number) => {
-    const newList = [...toSchoolList];
-    newList[index] = !newList[index];
-    setToSchoolList(newList);
+    setToSchoolList((value) => {
+      const newValue = [...value];
+      newValue[index] = !value[index];
+      return newValue;
+    });
   };
 
   return { toSchoolList, toggleDirection };

--- a/src/pages/IndexPage/components/IndexBus/hooks/useMobileBusCarousel.ts
+++ b/src/pages/IndexPage/components/IndexBus/hooks/useMobileBusCarousel.ts
@@ -7,8 +7,6 @@ const useMobileBusCarousel = () => {
   const [mobileBusTypes, setMobileBusTypes] = useState([2, 0, 1]);
 
   useEffect(() => {
-    const centerPoint = window.innerWidth * 0.625;
-
     let walk = 0;
     let startX = 0;
     let scrollValue = 0;
@@ -21,16 +19,13 @@ const useMobileBusCarousel = () => {
     };
 
     const stopSlide = () => {
-      if (sliderRef.current && walk) {
-        sliderRef.current.scrollLeft = centerPoint;
-        if (walk < 0) {
-          if (walk < -120) {
-            setMobileBusTypes((state) => [state[2]].concat(state.slice(0, 2)));
-          }
-        } else if (walk > 0) {
-          if (walk > 120) {
-            setMobileBusTypes((state) => state.slice(1, 3).concat(state[0]));
-          }
+      if (sliderRef.current) {
+        sliderRef.current.scrollLeft = window.innerWidth * 0.625;
+        if (walk < -120) {
+          setMobileBusTypes((state) => [state[2]].concat(state.slice(0, 2)));
+        }
+        if (walk > 120) {
+          setMobileBusTypes((state) => state.slice(1, 3).concat(state[0]));
         }
       }
       walk = 0;
@@ -45,7 +40,7 @@ const useMobileBusCarousel = () => {
     };
 
     if (sliderRef.current) {
-      sliderRef.current.scrollLeft = centerPoint;
+      sliderRef.current.scrollLeft = window.innerWidth * 0.625;
       sliderRef.current.addEventListener('touchstart', slideTouchStart);
       sliderRef.current.addEventListener('touchend', stopSlide);
       sliderRef.current.addEventListener('touchcancel', stopSlide);

--- a/src/pages/IndexPage/components/IndexBus/hooks/useMobileBusCarousel.ts
+++ b/src/pages/IndexPage/components/IndexBus/hooks/useMobileBusCarousel.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
+import useMediaQuery from 'utils/hooks/useMediaQuery';
+
+const useMobileBusCarousel = () => {
+  const isMobile = useMediaQuery();
+  const sliderRef = useRef<HTMLDivElement>(null);
+  const [mobileBusTypes, setMobileBusTypes] = useState([2, 0, 1]);
+
+  useEffect(() => {
+    const centerPoint = window.innerWidth * 0.625;
+
+    let walk = 0;
+    let startX = 0;
+    let scrollValue = 0;
+
+    const slideTouchStart = (e:TouchEvent) => {
+      if (sliderRef.current) {
+        startX = e.touches[0].pageX - sliderRef.current.offsetLeft;
+        scrollValue = sliderRef.current.scrollLeft;
+      }
+    };
+
+    const stopSlide = () => {
+      if (sliderRef.current && walk) {
+        sliderRef.current.scrollLeft = centerPoint;
+        if (walk < 0) {
+          if (walk < -120) {
+            setMobileBusTypes((state) => [state[2]].concat(state.slice(0, 2)));
+          }
+        } else if (walk > 0) {
+          if (walk > 120) {
+            setMobileBusTypes((state) => state.slice(1, 3).concat(state[0]));
+          }
+        }
+      }
+      walk = 0;
+    };
+
+    const slideTouchMove = (e:TouchEvent) => {
+      e.preventDefault();
+      if (sliderRef.current) {
+        walk = (e.touches[0].pageX - sliderRef.current.offsetLeft - startX) * 0.9;
+        sliderRef.current.scrollLeft = scrollValue - walk;
+      }
+    };
+
+    if (sliderRef.current) {
+      sliderRef.current.scrollLeft = centerPoint;
+      sliderRef.current.addEventListener('touchstart', slideTouchStart);
+      sliderRef.current.addEventListener('touchend', stopSlide);
+      sliderRef.current.addEventListener('touchcancel', stopSlide);
+      sliderRef.current.addEventListener('touchmove', slideTouchMove);
+    }
+  }, []);
+
+  const matchToMobileType = <T>(data: Array<T>) => {
+    if (isMobile) return mobileBusTypes.map((index) => data[index]);
+    return data;
+  };
+
+  return {
+    isMobile, sliderRef, mobileBusTypes, matchToMobileType,
+  };
+};
+
+export default useMobileBusCarousel;

--- a/src/pages/IndexPage/components/IndexBus/hooks/useMobileBusCarousel.ts
+++ b/src/pages/IndexPage/components/IndexBus/hooks/useMobileBusCarousel.ts
@@ -10,22 +10,23 @@ const useMobileBusCarousel = () => {
     let walk = 0;
     let startX = 0;
     let scrollValue = 0;
+    const slider = sliderRef.current;
 
     const slideTouchStart = (e:TouchEvent) => {
-      if (sliderRef.current) {
-        startX = e.touches[0].pageX - sliderRef.current.offsetLeft;
-        scrollValue = sliderRef.current.scrollLeft;
+      if (slider) {
+        startX = e.touches[0].pageX - slider.offsetLeft;
+        scrollValue = slider.scrollLeft;
       }
     };
 
     const stopSlide = () => {
-      if (sliderRef.current) {
-        sliderRef.current.scrollLeft = window.innerWidth * 0.625;
+      if (slider) {
+        slider.scrollLeft = window.innerWidth * 0.625;
         if (walk < -120) {
-          setMobileBusTypes((state) => [state[2]].concat(state.slice(0, 2)));
+          setMobileBusTypes((state) => state.slice(1, 3).concat(state[0]));
         }
         if (walk > 120) {
-          setMobileBusTypes((state) => state.slice(1, 3).concat(state[0]));
+          setMobileBusTypes((state) => [state[2]].concat(state.slice(0, 2)));
         }
       }
       walk = 0;
@@ -33,19 +34,28 @@ const useMobileBusCarousel = () => {
 
     const slideTouchMove = (e:TouchEvent) => {
       e.preventDefault();
-      if (sliderRef.current) {
-        walk = (e.touches[0].pageX - sliderRef.current.offsetLeft - startX) * 0.9;
-        sliderRef.current.scrollLeft = scrollValue - walk;
+      if (slider) {
+        walk = (e.touches[0].pageX - slider.offsetLeft - startX) * 0.9;
+        slider.scrollLeft = scrollValue - walk;
       }
     };
 
-    if (sliderRef.current) {
-      sliderRef.current.scrollLeft = window.innerWidth * 0.625;
-      sliderRef.current.addEventListener('touchstart', slideTouchStart);
-      sliderRef.current.addEventListener('touchend', stopSlide);
-      sliderRef.current.addEventListener('touchcancel', stopSlide);
-      sliderRef.current.addEventListener('touchmove', slideTouchMove);
+    if (slider) {
+      slider.scrollLeft = window.innerWidth * 0.625;
+      slider.addEventListener('touchstart', slideTouchStart);
+      slider.addEventListener('touchend', stopSlide);
+      slider.addEventListener('touchcancel', stopSlide);
+      slider.addEventListener('touchmove', slideTouchMove);
     }
+
+    return () => {
+      if (slider) {
+        slider.removeEventListener('touchstart', slideTouchStart);
+        slider.removeEventListener('touchend', stopSlide);
+        slider.removeEventListener('touchcancel', stopSlide);
+        slider.removeEventListener('touchmove', slideTouchMove);
+      }
+    };
   }, []);
 
   const matchToMobileType = <T>(data: Array<T>) => {

--- a/src/pages/IndexPage/components/IndexBus/index.tsx
+++ b/src/pages/IndexPage/components/IndexBus/index.tsx
@@ -1,7 +1,60 @@
+import { Link } from 'react-router-dom';
+import useBusLeftTIme from 'pages/BusPage/hooks/useBusLeftTime';
+import { BUS_DIRECTIONS, BUS_TYPES } from 'static/bus';
+import cn from 'utils/ts/classnames';
+import { useState } from 'react';
+import { getLeftTimeString, getStartTimeString, directionToEnglish } from 'pages/BusPage/ts/busModules';
+import styles from './IndexBus.module.scss';
+
+const useIndexBusDirection = () => {
+  const [toSchoolList, setToSchoolList] = useState([false, false, false]);
+
+  const toggleDirection = (index: number) => {
+    const newList = [...toSchoolList];
+    newList[index] = !newList[index];
+    setToSchoolList(newList);
+  };
+
+  return { toSchoolList, toggleDirection };
+};
+
 function IndexBus() {
+  const { toSchoolList, toggleDirection } = useIndexBusDirection();
+  const { data: busData } = useBusLeftTIme({
+    departList: toSchoolList.map((depart) => directionToEnglish(BUS_DIRECTIONS[Number(depart)])),
+    arrivalList: toSchoolList.map((depart) => directionToEnglish(BUS_DIRECTIONS[Number(!depart)])),
+  });
+
   return (
-    <section>
-      indexbus
+    <section className={styles.template}>
+      <Link to="/bus" className={styles.template__title}>버스/교통</Link>
+      <div className={styles.cards}>
+        {busData && BUS_TYPES.map(({ key: type, tabName }, idx) => (
+          <div key={type} className={styles.cards__card}>
+            <div className={cn({ [styles.cards__head]: true, [styles[`cards__head--${type}`]]: true })}>
+              <img className={styles['cards__bus-icon']} src="http://static.koreatech.in/assets/img/ic-bus.png" alt="" />
+              {tabName}
+            </div>
+            <div className={styles.cards__body}>
+              <span className={styles['cards__remain-time']}>
+                {getLeftTimeString(busData[idx]?.now_bus?.remain_time)}
+              </span>
+              <span className={styles.cards__detail}>
+                {typeof busData[idx]?.now_bus?.remain_time === 'number' && (
+                  `${getStartTimeString(busData[idx]?.now_bus?.remain_time, true)} 출발`
+                )}
+              </span>
+              <div className={styles.cards__directions}>
+                <span>{BUS_DIRECTIONS[Number(toSchoolList[idx])]}</span>
+                <button type="button" onClick={() => toggleDirection(idx)} className={styles.cards__toggle}>
+                  <img src="http://static.koreatech.in/assets/img/reverse_destination.png" alt="목적지 변경" className={styles['cards__toggle--image']} />
+                </button>
+                <span>{BUS_DIRECTIONS[Number(!toSchoolList[idx])]}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/pages/IndexPage/components/IndexBus/index.tsx
+++ b/src/pages/IndexPage/components/IndexBus/index.tsx
@@ -1,0 +1,9 @@
+function IndexBus() {
+  return (
+    <section>
+      indexbus
+    </section>
+  );
+}
+
+export default IndexBus;

--- a/src/pages/IndexPage/components/IndexBus/index.tsx
+++ b/src/pages/IndexPage/components/IndexBus/index.tsx
@@ -2,21 +2,10 @@ import { Link } from 'react-router-dom';
 import useBusLeftTIme from 'pages/BusPage/hooks/useBusLeftTime';
 import { BUS_DIRECTIONS, BUS_TYPES } from 'static/bus';
 import cn from 'utils/ts/classnames';
-import { useState } from 'react';
 import { getLeftTimeString, getStartTimeString, directionToEnglish } from 'pages/BusPage/ts/busModules';
 import styles from './IndexBus.module.scss';
-
-const useIndexBusDirection = () => {
-  const [toSchoolList, setToSchoolList] = useState([false, false, false]);
-
-  const toggleDirection = (index: number) => {
-    const newList = [...toSchoolList];
-    newList[index] = !newList[index];
-    setToSchoolList(newList);
-  };
-
-  return { toSchoolList, toggleDirection };
-};
+import useIndexBusDirection from './hooks/useIndexBusDirection';
+import useMobileBusCarousel from './hooks/useMobileBusCarousel';
 
 function IndexBus() {
   const { toSchoolList, toggleDirection } = useIndexBusDirection();
@@ -24,32 +13,44 @@ function IndexBus() {
     departList: toSchoolList.map((depart) => directionToEnglish(BUS_DIRECTIONS[Number(depart)])),
     arrivalList: toSchoolList.map((depart) => directionToEnglish(BUS_DIRECTIONS[Number(!depart)])),
   });
+  const {
+    isMobile, sliderRef, mobileBusTypes, matchToMobileType,
+  } = useMobileBusCarousel();
 
   return (
     <section className={styles.template}>
       <Link to="/bus" className={styles.template__title}>버스/교통</Link>
-      <div className={styles.cards}>
-        {busData && BUS_TYPES.map(({ key: type, tabName }, idx) => (
-          <div key={type} className={styles.cards__card}>
+      <div className={styles.cards} ref={sliderRef}>
+        {busData && matchToMobileType(BUS_TYPES).map(({ key: type, tabName }, idx) => (
+          <div
+            key={type}
+            className={cn({
+              [styles.cards__card]: true,
+              [styles['cards__card--sm']]: idx !== 1,
+            })}
+          >
             <div className={cn({ [styles.cards__head]: true, [styles[`cards__head--${type}`]]: true })}>
               <img className={styles['cards__bus-icon']} src="http://static.koreatech.in/assets/img/ic-bus.png" alt="" />
               {tabName}
             </div>
             <div className={styles.cards__body}>
               <span className={styles['cards__remain-time']}>
-                {getLeftTimeString(busData[idx]?.now_bus?.remain_time)}
+                {getLeftTimeString(matchToMobileType(busData)[idx]?.now_bus?.remain_time)}
               </span>
+              {!isMobile
+              && (
               <span className={styles.cards__detail}>
                 {typeof busData[idx]?.now_bus?.remain_time === 'number' && (
                   `${getStartTimeString(busData[idx]?.now_bus?.remain_time, true)} 출발`
                 )}
               </span>
+              )}
               <div className={styles.cards__directions}>
-                <span>{BUS_DIRECTIONS[Number(toSchoolList[idx])]}</span>
-                <button type="button" onClick={() => toggleDirection(idx)} className={styles.cards__toggle}>
+                <span>{BUS_DIRECTIONS[Number(matchToMobileType(toSchoolList)[idx])]}</span>
+                <button type="button" onClick={() => toggleDirection(isMobile ? mobileBusTypes[idx] : idx)} className={styles.cards__toggle}>
                   <img src="http://static.koreatech.in/assets/img/reverse_destination.png" alt="목적지 변경" className={styles['cards__toggle--image']} />
                 </button>
-                <span>{BUS_DIRECTIONS[Number(!toSchoolList[idx])]}</span>
+                <span>{BUS_DIRECTIONS[Number(!matchToMobileType(toSchoolList)[idx])]}</span>
               </div>
             </div>
           </div>

--- a/src/pages/IndexPage/components/IndexCafeteria/IndexCafeteria.module.scss
+++ b/src/pages/IndexPage/components/IndexCafeteria/IndexCafeteria.module.scss
@@ -1,0 +1,7 @@
+@use "src/utils/scss/media" as media;
+
+.template {
+  @include media.media-breakpoint(mobile) {
+    order: 3;
+  }
+}

--- a/src/pages/IndexPage/components/IndexCafeteria/index.tsx
+++ b/src/pages/IndexPage/components/IndexCafeteria/index.tsx
@@ -1,0 +1,9 @@
+function IndexCafeteria() {
+  return (
+    <section>
+      indexCafeteria
+    </section>
+  );
+}
+
+export default IndexCafeteria;

--- a/src/pages/IndexPage/components/IndexCafeteria/index.tsx
+++ b/src/pages/IndexPage/components/IndexCafeteria/index.tsx
@@ -1,6 +1,8 @@
+import styles from './IndexCafeteria.module.scss';
+
 function IndexCafeteria() {
   return (
-    <section>
+    <section className={styles.template}>
       indexCafeteria
     </section>
   );

--- a/src/pages/IndexPage/components/IndexNotice/IndexNotice.module.scss
+++ b/src/pages/IndexPage/components/IndexNotice/IndexNotice.module.scss
@@ -1,0 +1,7 @@
+@use "src/utils/scss/media" as media;
+
+.template {
+  @include media.media-breakpoint(mobile) {
+    display: none;
+  }
+}

--- a/src/pages/IndexPage/components/IndexNotice/index.tsx
+++ b/src/pages/IndexPage/components/IndexNotice/index.tsx
@@ -1,0 +1,9 @@
+function IndexNotice() {
+  return (
+    <section>
+      indexnotice
+    </section>
+  );
+}
+
+export default IndexNotice;

--- a/src/pages/IndexPage/components/IndexNotice/index.tsx
+++ b/src/pages/IndexPage/components/IndexNotice/index.tsx
@@ -1,6 +1,8 @@
+import styles from './IndexNotice.module.scss';
+
 function IndexNotice() {
   return (
-    <section>
+    <section className={styles.template}>
       indexnotice
     </section>
   );

--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -7,6 +7,8 @@
 
   @include media.media-breakpoint(mobile) {
     order: 2;
+    width: 100%;
+    overflow-x: auto;
   }
 
   &__title {

--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -14,10 +14,8 @@
 
     @include media.media-breakpoint(mobile) {
       font-size: 15px;
-      color: #175c8e;
       padding-left: 3px;
       margin-left: 16px;
-      width: 100px;
     }
   }
 }
@@ -29,6 +27,14 @@
     flex-wrap: wrap;
     padding: 18px 5px;
     gap: 23px;
+
+    @include media.media-breakpoint(mobile) {
+      width: 100%;
+      justify-content: flex-start;
+      flex-wrap: nowrap;
+      gap: 8px;
+      overflow-x: auto;
+    }
   }
 
   &__item {
@@ -42,6 +48,23 @@
 
     &:hover {
       color: #f7941e;
+    }
+
+    @include media.media-breakpoint(mobile) {
+      letter-spacing: -0.8px;
+      width: 40px;
+      padding-top: 11px;
+      margin-right: 8px;
+      font-size: 12px;
+      color: #252525;
+
+      &:first-child {
+        margin-left: 20px;
+      }
+
+      &:last-child {
+        padding-right: 20px;
+      }
     }
   }
 

--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -5,6 +5,10 @@
   flex-direction: column;
   align-items: flex-start;
 
+  @include media.media-breakpoint(mobile) {
+    order: 2;
+  }
+
   &__title {
     font-family: NanumSquare, serif;
     font-size: 17px;

--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -37,6 +37,7 @@
     @include media.media-breakpoint(mobile) {
       width: 100%;
       justify-content: flex-start;
+      box-sizing: border-box;
       flex-wrap: nowrap;
       gap: 8px;
       overflow-x: auto;

--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -1,0 +1,58 @@
+@use "src/utils/scss/media" as media;
+
+.template {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  &__title {
+    font-family: NanumSquare, serif;
+    font-size: 17px;
+    font-weight: bold;
+    color: #175c8e;
+    text-decoration: none;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 15px;
+      color: #175c8e;
+      padding-left: 3px;
+      margin-left: 16px;
+      width: 100px;
+    }
+  }
+}
+
+.category {
+  &__wrapper {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    padding: 18px 5px;
+    gap: 23px;
+  }
+
+  &__item {
+    width: 73px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 15px;
+    color: black;
+    text-decoration: none;
+
+    &:hover {
+      color: #f7941e;
+    }
+  }
+
+  &__image {
+    width: 56px;
+    height: 56px;
+    border-width: 50%;
+
+    @media (max-width: 576px) {
+      width: 40px;
+      height: 40px;
+    }
+  }
+}

--- a/src/pages/IndexPage/components/IndexStore/index.tsx
+++ b/src/pages/IndexPage/components/IndexStore/index.tsx
@@ -1,8 +1,11 @@
 import STORE_CATEGORY from 'static/storeCategory';
 import { Link } from 'react-router-dom';
+import useMediaQuery from 'utils/hooks/useMediaQuery';
 import styles from './IndexStore.module.scss';
 
 function IndexStore() {
+  const isMobile = useMediaQuery();
+
   return (
     <section className={styles.template}>
       <Link to="/store" className={styles.template__title}>주변상점</Link>
@@ -10,7 +13,7 @@ function IndexStore() {
         {STORE_CATEGORY.map((category) => (
           <Link to={`/store?category=${category.tag}`} key={category.title} className={styles.category__item}>
             <img src={category.image} alt={category.title} className={styles.category__image} />
-            {category.title.slice(0, 4)}
+            {isMobile ? category.title.slice(0, 4) : category.title}
           </Link>
         ))}
       </div>

--- a/src/pages/IndexPage/components/IndexStore/index.tsx
+++ b/src/pages/IndexPage/components/IndexStore/index.tsx
@@ -1,7 +1,19 @@
+import STORE_CATEGORY from 'static/storeCategory';
+import { Link } from 'react-router-dom';
+import styles from './IndexStore.module.scss';
+
 function IndexStore() {
   return (
-    <section>
-      indexstore
+    <section className={styles.template}>
+      <Link to="/store" className={styles.template__title}>주변상점</Link>
+      <div className={styles.category__wrapper}>
+        {STORE_CATEGORY.map((category) => (
+          <Link to={`/store?category=${category.tag}`} key={category.title} className={styles.category__item}>
+            <img src={category.image} alt={category.title} className={styles.category__image} />
+            {category.title}
+          </Link>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/pages/IndexPage/components/IndexStore/index.tsx
+++ b/src/pages/IndexPage/components/IndexStore/index.tsx
@@ -10,7 +10,7 @@ function IndexStore() {
         {STORE_CATEGORY.map((category) => (
           <Link to={`/store?category=${category.tag}`} key={category.title} className={styles.category__item}>
             <img src={category.image} alt={category.title} className={styles.category__image} />
-            {category.title}
+            {category.title.slice(0, 4)}
           </Link>
         ))}
       </div>

--- a/src/pages/IndexPage/components/IndexStore/index.tsx
+++ b/src/pages/IndexPage/components/IndexStore/index.tsx
@@ -1,0 +1,9 @@
+function IndexStore() {
+  return (
+    <section>
+      indexstore
+    </section>
+  );
+}
+
+export default IndexStore;

--- a/src/pages/IndexPage/components/IndexTimetable/IndexTimetable.module.scss
+++ b/src/pages/IndexPage/components/IndexTimetable/IndexTimetable.module.scss
@@ -1,0 +1,7 @@
+@use "src/utils/scss/media" as media;
+
+.template {
+  @include media.media-breakpoint(mobile) {
+    display: none;
+  }
+}

--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -1,6 +1,8 @@
+import styles from './IndexTimetable.module.scss';
+
 function IndexTimetable() {
   return (
-    <section>
+    <section className={styles.template}>
       indextimetable
     </section>
   );

--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -1,0 +1,9 @@
+function IndexTimetable() {
+  return (
+    <section>
+      indextimetable
+    </section>
+  );
+}
+
+export default IndexTimetable;

--- a/src/pages/IndexPage/index.tsx
+++ b/src/pages/IndexPage/index.tsx
@@ -9,10 +9,10 @@ function IndexPage() {
   return (
     <main className={styles.template}>
       <IndexStore />
-      <IndexCafeteria />
       <IndexTimetable />
       <IndexBus />
       <IndexNotice />
+      <IndexCafeteria />
     </main>
   );
 }

--- a/src/pages/IndexPage/index.tsx
+++ b/src/pages/IndexPage/index.tsx
@@ -1,9 +1,9 @@
-import styles from './IndexPage.module.scss';
 import IndexBus from './components/IndexBus';
 import IndexCafeteria from './components/IndexCafeteria';
 import IndexNotice from './components/IndexNotice';
 import IndexStore from './components/IndexStore';
 import IndexTimetable from './components/IndexTimetable';
+import styles from './IndexPage.module.scss';
 
 function IndexPage() {
   return (

--- a/src/pages/IndexPage/index.tsx
+++ b/src/pages/IndexPage/index.tsx
@@ -1,0 +1,20 @@
+import styles from './IndexPage.module.scss';
+import IndexBus from './components/IndexBus';
+import IndexCafeteria from './components/IndexCafeteria';
+import IndexNotice from './components/IndexNotice';
+import IndexStore from './components/IndexStore';
+import IndexTimetable from './components/IndexTimetable';
+
+function IndexPage() {
+  return (
+    <main className={styles.template}>
+      <IndexStore />
+      <IndexCafeteria />
+      <IndexTimetable />
+      <IndexBus />
+      <IndexNotice />
+    </main>
+  );
+}
+
+export default IndexPage;

--- a/src/static/category.ts
+++ b/src/static/category.ts
@@ -1,4 +1,4 @@
-export interface ISubMenu {
+export interface SubMenu {
   title: string;
   link: string;
   newFlag: boolean;
@@ -6,13 +6,13 @@ export interface ISubMenu {
   tag: number | null;
 }
 
-export interface ICategory {
+export interface Category {
   title: string;
   planFlag: boolean;
-  submenu: ISubMenu[]
+  submenu: SubMenu[]
 }
 
-const CATEGORY: ICategory[] = [
+const CATEGORY: Category[] = [
   {
     title: '서비스',
     planFlag: false,

--- a/src/static/storeCategory.ts
+++ b/src/static/storeCategory.ts
@@ -1,11 +1,11 @@
-export interface IStoreCategory {
+export interface StoreCategory {
   title: string;
   state: string;
   tag: string;
   image: string;
 }
 
-const STORE_CATEGORY:IStoreCategory[] = [
+const STORE_CATEGORY:StoreCategory[] = [
   {
     title: '전체보기',
     state: 'ALL',


### PR DESCRIPTION
## [#28] request

메인페이지에 필요한 주변식당 카테고리 목록과, 버스 컴포넌트를 추가했습니다.
메인페이지에 각 컴포넌트에 공간을 할당해두었으니, 추후에 시간표 / 식당 / 공지사항도 추가해주세요.
최대한 기존 페이지에 존재하는 훅과 static 데이터를 활용했고, 이 과정에서 몇가지 리팩토링을 진행했습니다.

- 카테고리에 존재하는 헝가리안 표기법 레거시를 제거했습니다
  - 전체가 추가되며 바뀐 카테고리에 맞추다보니 프로덕션과 카테고리 아이템 정보가 달라졌습니다.
- 버스 캐러셀 UI 조작 방식을 중복되는 부분만 제거하고 유지했습니다.
- 버스의 상태를 다루는 부분은 최적화를 진행했습니다.
  - 데이터는 `[셔틀, 대성, 시내]` 순서로 가지고있고, 모바일의 경우 UI 표시 순서를 `mobileBusTypes`로 가져 둘 간의 동기화를 위해 `matchToMobileType`함수를 사용합니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot
<img width="1095" alt="스크린샷 2023-01-23 오전 3 03 10" src="https://user-images.githubusercontent.com/50780281/213932616-a649a587-d000-40fd-8eb4-2a3dbc63ca25.png">

![recodeindex](https://user-images.githubusercontent.com/50780281/213932623-3926b78e-5fe6-4e8d-9648-a4ae9ce95262.gif)
