### PR TITLE
API 변경 대응

### DIFF
--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -1,7 +1,7 @@
 import { APIResponse } from 'interfaces/APIResponse';
 
 export type LoginRequest = {
-  portal_account: string
+  email: string
   password: string
 };
 
@@ -21,7 +21,7 @@ export interface LoginResponse extends APIResponse {
     major: string
     name: string
     nickname: string
-    portal_account: string
+    email: string
     student_number: string
     username: string
   }
@@ -32,7 +32,7 @@ export interface NicknameDuplicateCheckResponse extends APIResponse {
 }
 
 export interface SignupRequest {
-  portal_account: string,
+  email: string,
   password: string,
   // options
   name?: string,

--- a/src/api/store/entity.ts
+++ b/src/api/store/entity.ts
@@ -1,12 +1,18 @@
 import { APIResponse } from 'interfaces/APIResponse';
 
+interface Open {
+  open_time: string,
+  close_time: string,
+  closed: boolean,
+  day_of_week: 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY',
+}
+
 export interface StoreDetailResponse extends APIResponse {
   weekend_open_time: string | null,
   created_at: string,
   description: string,
   image_urls: string[],
   address: string,
-  open_time: string,
   weekend_close_time: string | null,
   pay_bank: boolean,
   hit: number,
@@ -32,7 +38,7 @@ export interface StoreDetailResponse extends APIResponse {
   phone: string,
   delivery: boolean,
   delivery_price: number,
-  close_time: string,
+  open: Open[],
 }
 
 export interface StoreListResponse extends APIResponse {
@@ -41,7 +47,7 @@ export interface StoreListResponse extends APIResponse {
     created_at : string,
     description : string,
     image_urls: string[],
-    open_time: string,
+    open: Open[],
     // weekend_close_time: null,
     pay_bank: boolean,
     hit: number,
@@ -53,7 +59,6 @@ export interface StoreListResponse extends APIResponse {
     delivery: boolean,
     address: string,
     pay_card: boolean,
-    close_time: string,
     is_event: boolean,
     event_articles: {}[],
     phone: string,

--- a/src/pages/Auth/LoginPage/index.tsx
+++ b/src/pages/Auth/LoginPage/index.tsx
@@ -62,7 +62,7 @@ const useLogin = (state: IsAutoLogin) => {
     const hashedPassword = await sha256(userInfo.password);
 
     postLogin.mutate({
-      portal_account: userInfo.userId,
+      email: `${userInfo.userId}@koreatech.ac.kr`,
       password: hashedPassword,
     });
   };

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -447,7 +447,7 @@ const useSignupForm = () => {
   const submitForm: ISubmitForm = (formValue) => {
     const payload = {
       // 필수정보
-      portal_account: formValue.id?.trim(),
+      email: formValue.id?.trim(),
       password: formValue.password,
       // 옵션
       name: formValue.name || undefined,

--- a/src/pages/Store/StoreDetailPage/hooks/useStoreDetail.ts
+++ b/src/pages/Store/StoreDetailPage/hooks/useStoreDetail.ts
@@ -5,7 +5,15 @@ const useStoreDetail = (params: string | undefined) => {
   const { data: storeDetail } = useQuery(
     ['storeDetail', params],
     ({ queryKey }) => api.store.getStoreDetailInfo(queryKey[1]),
-    { retry: 0 },
+    {
+      retry: 0,
+      // 임시 처리, 추후 요일별 시간 디자인이 나온 경우 필요 없어짐
+      select: (response) => ({
+        ...response,
+        open_time: response.open[0].open_time,
+        close_time: response.open[0].close_time,
+      }),
+    },
   );
   const storeDescription = storeDetail?.description ? storeDetail?.description.replace(/(?:\/)/g, '\n') : '-';
 

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -46,7 +46,19 @@ const useStore = (params: any) => {
   const { data: storeList } = useQuery(
     'storeList',
     api.store.getStoreList,
-    { retry: 0 },
+    {
+      retry: 0,
+      // 임시 처리, 추후 요일별 시간 디자인이 나온 경우 필요 없어짐
+      select: (response) => ({
+        shops: response.shops.map((shop) => (
+          {
+            ...shop,
+            open_time: shop.open[0].open_time,
+            close_time: shop.open[0].close_time,
+          }
+        )),
+      }),
+    },
   );
   return storeList?.shops.filter(
     (store) => ((params.category === undefined || params.category === 'ALL') || store.category === params.category)
@@ -178,7 +190,7 @@ function StorePage() {
       <div className={styles['store-list']}>
         {
           storeList?.map((store) => (
-            <Link to={`/store/${store.permalink}`} className={styles['store-list__item']} key={store.id}>
+            <Link to={`/store/${store.id}`} className={styles['store-list__item']} key={store.id}>
               {isStoreOpen(store.open_time, store.close_time) && <div className={styles['store-none-open']} />}
               <div className={styles['store-list__title']}>{store.name}</div>
               <div className={styles['store-list__phone']}>


### PR DESCRIPTION
## [#42 ] request
변경된 API Request body, Response를 적용했습니다.
- 로그인
  - 파라미터 key값을 `account`를 `email`로 변경했습니다.
  - 해당 값에 `@koreatech.ac.kr`을 붙여주었습니다.
- 주변상점
  - 목록 페이지에 필요한 `open_time`과 `close_time`의 값을 `open`객체의 첫번째 값을 통해 받아오도록 했습니다.
    - 임시 처리이며, 0번째 데이터는 "월요일"을 의미하고, 이후 상세페이지를 수정하며 각 요일별로 바꿀 예정입니다.
  - 상세페이지 이동 시 기존 링크로 사용되던 `permalink`에서, `id`로 변경했습니다.
  - 상세페이지는 [API Response와 디자인에 맞게 전부 수정](https://bcsdlab.slack.com/archives/CE3MQCQNA/p1680676629780729)해야해서 추가 Issue로 남겨놓겠습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes

### Screenshot
