### PR TITLE
Feature/#38

### DIFF
--- a/src/api/bus/entity.ts
+++ b/src/api/bus/entity.ts
@@ -26,10 +26,12 @@ export interface BusResponse extends APIResponse {
   bus_type: BusType;
   next_bus: {
     remain_time: number;
+    start_time: number; //
     bus_number?: number;
   } | null;
   now_bus: {
     remain_time: number;
+    start_time: number; //
     bus_number?: number;
   } | null;
 }

--- a/src/pages/BusPage/BusLookUp/index.tsx
+++ b/src/pages/BusPage/BusLookUp/index.tsx
@@ -75,7 +75,7 @@ function BusLookUp() {
                   </span>
                   {typeof busData[idx]?.now_bus?.remain_time === 'number' && (
                   <span className={styles.cards__detail}>
-                    {`(${getStartTimeString(busData[idx]?.now_bus?.remain_time)} 출발)`}
+                    {`(${getStartTimeString(busData[idx]?.now_bus?.start_time)} 출발)`}
                   </span>
                   )}
                 </div>
@@ -99,7 +99,7 @@ function BusLookUp() {
                   </span>
                   {typeof busData[idx]?.next_bus?.remain_time === 'number' && (
                   <span className={styles.cards__detail}>
-                    {`(${getStartTimeString(busData[idx]?.next_bus?.remain_time)} 출발)`}
+                    {`(${getStartTimeString(busData[idx]?.next_bus?.start_time)} 출발)`}
                   </span>
                   )}
                 </div>

--- a/src/pages/BusPage/hooks/useBusLeftTime.ts
+++ b/src/pages/BusPage/hooks/useBusLeftTime.ts
@@ -40,7 +40,21 @@ const useBusLeftTIme = ({ departList, arrivalList }: Props) => {
         );
         const nowRemainSecond = response.now_bus?.remain_time;
         const nextRemainSecond = response.next_bus?.remain_time;
-        if (nowRemainSecond !== undefined && nextRemainSecond !== undefined) {
+        if (nowRemainSecond !== undefined) {
+          if (nextRemainSecond !== undefined) {
+            return {
+              now_bus: {
+                remain_time: nowRemainSecond,
+                start_time: (nowSecond + nowRemainSecond),
+                bus_number: null,
+              },
+              next_bus: {
+                remain_time: nextRemainSecond,
+                start_time: (nowSecond + nextRemainSecond),
+                bus_number: null,
+              },
+            };
+          }
           return {
             now_bus: {
               remain_time: nowRemainSecond,
@@ -48,8 +62,8 @@ const useBusLeftTIme = ({ departList, arrivalList }: Props) => {
               bus_number: null,
             },
             next_bus: {
-              remain_time: nextRemainSecond,
-              start_time: (nowSecond + nextRemainSecond),
+              remain_time: '미운행',
+              start_time: '미운행',
               bus_number: null,
             },
           };

--- a/src/pages/BusPage/hooks/useBusLeftTime.ts
+++ b/src/pages/BusPage/hooks/useBusLeftTime.ts
@@ -14,10 +14,12 @@ interface Props {
 const emptyRouteData = {
   now_bus: {
     remain_time: '미운행',
+    start_time: '미운행', //
     bus_number: null,
   },
   next_bus: {
     remain_time: '미운행',
+    start_time: '미운행', //
     bus_number: null,
   },
 } as const;
@@ -31,6 +33,29 @@ const useBusLeftTIme = ({ departList, arrivalList }: Props) => {
       staleTime: 60000,
       suspense: true,
       keepPreviousData: true,
+      select: (response: BusResponse) => {
+        const today = new Date();
+        const nowSecond = (
+          today.getHours() * 3600 + today.getMinutes() * 60 + today.getSeconds()
+        );
+        const nowRemainSecond = response.now_bus?.remain_time;
+        const nextRemainSecond = response.next_bus?.remain_time;
+        if (nowRemainSecond !== undefined && nextRemainSecond !== undefined) {
+          return {
+            now_bus: {
+              remain_time: nowRemainSecond,
+              start_time: (nowSecond + nowRemainSecond),
+              bus_number: null,
+            },
+            next_bus: {
+              remain_time: nextRemainSecond,
+              start_time: (nowSecond + nextRemainSecond),
+              bus_number: null,
+            },
+          };
+        }
+        return { response };
+      },
     }),
   );
 

--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -20,19 +20,14 @@ export const getLeftTimeString = (second: number | '미운행' | undefined) => {
 export const getStartTimeString = (second: number | '미운행' | undefined, isMain:boolean = false) => {
   if (!second) return '';
   if (second === '미운행') return '';
-
   const hour = getHour(second);
   const minute = getMinute(second);
-
   const today = new Date();
-
   let startMinute = today.getMinutes() + minute;
-  let startHour = today.getHours() + hour + Math.ceil(startMinute / 60);
-
+  let startHour = today.getHours() + hour + Math.floor(startMinute / 60);
   startHour %= 24;
   startMinute %= 60;
   const timeString = [String(startHour).padStart(2, '0'), String(startMinute).padStart(2, '0')];
-
   if (isMain) return `${timeString[0]}시 ${timeString[1]}분`;
   return `${timeString[0]}:${timeString[1]}`;
 };

--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -22,9 +22,9 @@ export const getStartTimeString = (second: number | '미운행' | undefined, isM
   if (second === '미운행') return '';
   const hour = getHour(second);
   const minute = getMinute(second);
-  const today = new Date();
-  let startMinute = today.getMinutes() + minute;
-  let startHour = today.getHours() + hour + Math.floor(startMinute / 60);
+  let startMinute = minute;
+  let startHour = hour;
+  if (startMinute === 0) startHour += 1;
   startHour %= 24;
   startMinute %= 60;
   const timeString = [String(startHour).padStart(2, '0'), String(startMinute).padStart(2, '0')];

--- a/src/pages/IndexPage/components/IndexBus/index.tsx
+++ b/src/pages/IndexPage/components/IndexBus/index.tsx
@@ -41,7 +41,7 @@ function IndexBus() {
               && (
               <span className={styles.cards__detail}>
                 {typeof busData[idx]?.now_bus?.remain_time === 'number' && (
-                  `${getStartTimeString(busData[idx]?.now_bus?.remain_time, true)} 출발`
+                  `${getStartTimeString(busData[idx]?.now_bus?.start_time, true)} 출발`
                 )}
               </span>
               )}


### PR DESCRIPTION
## [#38] request

<!--
- Write here your development contents
- e.g.) Make a main page.
-->

* 59초에서 00초로 넘어갈 때 버스 출발시간이 1분씩 튀는 현상

  * **현재 시간에서 버스 출발까지 남은 시간을 초 단위**로 api를 통해 가져옴
  * 이를 시간 변환 함수 **getHour, getMinute**을 통해 **시, 분으로 변환**하고 여기에 **현재 시간을 받아와 더함**으로 출발 시간 구현.

    ### [예상 버그 발생 이유]

    => 그러나, **api로 값을 받아와 시, 분으로 변환하는데 걸리는 시간**보다 
**Date객체로 현재 시간을 받아오는 것**이 더 빠르기에 남은 시간을 줄지 않고, 현재 시간은 늘어 있어 두 값을 더했을때  01분씩 튀는 현상이 발생했다고 판단.
---

### [시도한 방법]
* 현재 시간에서 버스 출발까지 남은 시간을 가져올때 **useQuery의 select속성**을 사용하여  미리 현재 시간 값을 더함을 통해 가공하여 넘기는 방향으로 구현
---

### [현재 상황]
* 그러나 값이 튀는 현상을 해결할 순 없었음. 
* 새로고침을 하면 값이 튀지 않지만 페이지 이동후 시간이 지나면 흐른 시간만큼 출발시간이 증가해 있는 현상 지속
## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/86779590/230866696-4f8bde0a-d6ad-4b2b-af13-7e4897841185.png">

* 새로고침을 하면 아래 사진처럼 정상적으로 작동
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/86779590/230866747-30d702fb-9296-4932-ac7c-8244087c8cc5.png">

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/86779590/230866829-0f10c36f-5387-4507-b980-e46e1df4db1e.png">


