### PR TITLE
자동로그인 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import {
   Route,
   Navigate,
 } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 import AuthPage from 'pages/Auth/AuthPage';
 import LoginPage from 'pages/Auth/LoginPage';
 import BoardPage from 'pages/BoardPage';
@@ -20,9 +19,7 @@ import IndexPage from 'pages/IndexPage';
 import RoomPage from 'pages/Room/RoomPage';
 import RoomDetailPage from 'pages/Room/RoomDetailPage';
 import TimetablePage from 'pages/TimetablePage';
-import { tokenState } from 'utils/recoil';
-
-const useTokenState = () => useRecoilValue(tokenState);
+import useTokenState from 'utils/hooks/useTokenState';
 
 function App() {
   const token = useTokenState();

--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -3,6 +3,8 @@ import {
   LoginRequest,
   LoginResponse,
   NicknameDuplicateCheckResponse,
+  RefreshRequest,
+  RefreshResponse,
   SignupResponse,
 } from './entity';
 
@@ -43,4 +45,16 @@ export class Signup<R extends SignupResponse> implements APIRequest<R> {
   auth = false;
 
   constructor(public data: LoginRequest) {}
+}
+
+export class Refresh<R extends RefreshResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.POST;
+
+  path = '/user/refresh';
+
+  response!: R;
+
+  auth = false;
+
+  constructor(public data: RefreshRequest) {}
 }

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -37,4 +37,5 @@ export interface RefreshRequest {
 
 export interface RefreshResponse extends APIResponse {
   token: string;
+  refresh_token: string;
 }

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -1,48 +1,40 @@
 import { APIResponse } from 'interfaces/APIResponse';
 
 export type LoginRequest = {
-  email: string
-  password: string
+  email: string;
+  password: string;
 };
 
 export interface LoginResponse extends APIResponse {
-  token: string
-  ttl: number
-  user:{
-    accountNonExpired : boolean
-    accountNonLocked: boolean
-    anonymous_nickname: string
-    credentialsNonExpired: boolean
-    enabled: boolean
-    gender: number
-    id: number
-    identity: number
-    is_graduated: false
-    major: string
-    name: string
-    nickname: string
-    email: string
-    student_number: string
-    username: string
-  }
+  token: string;
+  refresh_token: string;
+  userType: 'STUDENT';
 }
 
 export interface NicknameDuplicateCheckResponse extends APIResponse {
-  'success': string;
+  success: string;
 }
 
 export interface SignupRequest {
-  email: string,
-  password: string,
+  email: string;
+  password: string;
   // options
-  name?: string,
-  nickname?: string,
-  gender?: string,
-  major?: string,
-  student_number?: string,
-  phone_number?: string,
-  identity?: number,
-  is_graduated?: boolean,
+  name?: string;
+  nickname?: string;
+  gender?: string;
+  major?: string;
+  student_number?: string;
+  phone_number?: string;
+  identity?: number;
+  is_graduated?: boolean;
 }
 
 export interface SignupResponse extends APIResponse { }
+
+export interface RefreshRequest {
+  refresh_token: string;
+}
+
+export interface RefreshResponse extends APIResponse {
+  token: string;
+}

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,8 +1,12 @@
 import APIClient from 'utils/ts/apiClient';
-import { Login, NicknameDuplicateCheck, Signup } from './APIDetail';
+import {
+  Login, NicknameDuplicateCheck, Refresh, Signup,
+} from './APIDetail';
 
 export const login = APIClient.of(Login);
 
 export const nicknameDuplicateCheck = APIClient.of(NicknameDuplicateCheck);
 
 export const signup = APIClient.of(Signup);
+
+export const refresh = APIClient.of(Refresh);

--- a/src/components/TimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/DefaultPage/index.tsx
@@ -16,7 +16,7 @@ import showToast from 'utils/ts/showToast';
 import Timetable, { TIMETABLE_ID } from 'components/TimetablePage/Timetable';
 import ErrorBoundary from 'components/common/ErrorBoundary';
 import useTimetableDayList from 'utils/hooks/useTimetableDayList';
-import { tokenState } from 'utils/recoil';
+import useTokenState from 'utils/hooks/useTokenState';
 import useDeptList from './hooks/useDeptList';
 import styles from './DefaultPage.module.scss';
 import useSemester from './hooks/useSemester';
@@ -115,7 +115,7 @@ function CurrentSemesterLectureList({ semesterKey }: CurrentSemesterLectureListP
   const myLecturesFromLocalStorageValue = useRecoilValue(myLecturesAtom);
   const addLectureToLocalStorage = useSetRecoilState(myLectureAddLectureSelector);
 
-  const token = useRecoilValue(tokenState);
+  const token = useTokenState();
   const { data: myLecturesFromServer } = useTimetableInfoList(selectedSemester, token);
   const { mutate: mutateAddWithServer } = useAddTimetableLecture(token);
   const isLoaded = status === 'success' && (myLecturesFromLocalStorageValue !== null || myLecturesFromServer !== undefined);
@@ -173,7 +173,7 @@ function CurrentMyLectureList() {
   const removeLectureFromLocalStorage = useSetRecoilState(myLectureRemoveLectureSelector);
 
   const selectedSemester = useRecoilValue(selectedSemesterAtom);
-  const token = useRecoilValue(tokenState);
+  const token = useTokenState();
   const { data: myLecturesFromServer } = useTimetableInfoList(selectedSemester, token);
   const { mutate: removeLectureFromServer } = useDeleteTimetableLecture(selectedSemester, token);
 
@@ -211,7 +211,7 @@ function CurrentSemesterTimetable(): JSX.Element {
   const selectedSemesterValue = useRecoilValue(selectedSemesterAtom);
   const myLecturesFromLocalStorageValue = useRecoilValue(myLecturesAtom);
 
-  const token = useRecoilValue(tokenState);
+  const token = useTokenState();
   const selectedSemester = useRecoilValue(selectedSemesterAtom);
   const { data: myLecturesFromServer } = useTimetableInfoList(selectedSemester, token);
   const myLectureDayValue = useTimetableDayList(

--- a/src/components/common/Header/Header.module.scss
+++ b/src/components/common/Header/Header.module.scss
@@ -230,6 +230,8 @@
       margin-right: 4px;
       content: "";
       background: url("http://static.koreatech.in/assets/img/ic-bottom_myinfo.png") center/24px 24px;
+      position: relative;
+      top: 6px;
     }
 
     & > a {

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -5,6 +5,7 @@ import CATEGORY, { Category, SubMenu } from 'static/category';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import cn from 'utils/ts/classnames';
+import useTokenState from 'utils/hooks/useTokenState';
 import styles from './Header.module.scss';
 
 const ID: { [key: string]: string; } = {
@@ -80,8 +81,7 @@ function Header() {
     expandSidebar,
     hideSidebar,
   } = useMobileSidebar(pathname, isMobile);
-  // TODO: Auth 모듈이 만들어지면 그 때 변경
-  const [token] = useState(false);
+  const token = useTokenState();
   const isLoggedin = !!token;
   const [userInfo] = useState<{ nickname: string; } | null>(null);
 
@@ -164,41 +164,27 @@ function Header() {
                     <ul className={styles['mobileheader__auth-menu']}>
                       {isLoggedin ? (
                         <>
-                          <li
-                            className={styles['mobileheader__my-info']}
-                          >
-                            <Link
-                              to="/modifyinfo"
-                            >
+                          <li className={styles['mobileheader__my-info']}>
+                            <Link to="/modifyinfo">
                               내 정보
                             </Link>
                           </li>
                           <li className={styles.mobileheader__link}>
-                            <button
-                              type="button"
-                            >
+                            <button type="button">
                               로그아웃
                             </button>
                           </li>
                         </>
                       ) : (
                         <>
-                          <li
-                            className={styles.mobileheader__link}
-                          >
-                            <Link
-                              to="/auth/signup"
-                            >
+                          <li className={styles.mobileheader__link}>
+                            <Link to="/auth/signup">
                               회원가입
                             </Link>
                           </li>
                           |
-                          <li
-                            className={styles.mobileheader__link}
-                          >
-                            <Link
-                              to="/auth"
-                            >
+                          <li className={styles.mobileheader__link}>
+                            <Link to="/auth">
                               로그인
                             </Link>
                           </li>

--- a/src/pages/Auth/LoginPage/index.tsx
+++ b/src/pages/Auth/LoginPage/index.tsx
@@ -3,7 +3,7 @@ import { LoginResponse } from 'api/auth/entity';
 import { tokenState } from 'utils/recoil';
 import { Link, useNavigate } from 'react-router-dom';
 import { useMutation } from 'react-query';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { setCookie } from 'utils/ts/cookie';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import { auth } from 'api';
@@ -28,11 +28,12 @@ interface UserInfo {
 const emailLocalPartRegex = /^[a-z_0-9]{1,12}$/;
 
 const useLogin = (state: IsAutoLogin) => {
-  const [, setToken] = useRecoilState(tokenState);
+  const setToken = useSetRecoilState(tokenState);
   const navigate = useNavigate();
   const postLogin = useMutation(auth.login, {
     onSuccess: (data: LoginResponse) => {
       if (state.isAutoLoginFlag) {
+        localStorage.setItem('AUTH_REFRESH_TOKEN_KEY', data.refresh_token);
         setCookie('AUTH_TOKEN_KEY', data.token, 3);
       } else {
         setCookie('AUTH_TOKEN_KEY', data.token, 0);
@@ -42,7 +43,7 @@ const useLogin = (state: IsAutoLogin) => {
     },
   });
 
-  const useSubmit = async (userInfo: UserInfo) => {
+  const login = async (userInfo: UserInfo) => {
     if (userInfo.userId === null) {
       showToast('error', '계정을 입력해주세요');
       return;
@@ -66,7 +67,7 @@ const useLogin = (state: IsAutoLogin) => {
       password: hashedPassword,
     });
   };
-  return useSubmit;
+  return login;
 };
 
 function LoginPage() {

--- a/src/utils/hooks/useTokenState.ts
+++ b/src/utils/hooks/useTokenState.ts
@@ -1,11 +1,9 @@
 import { useRecoilValueLoadable } from 'recoil';
-import { tokenStateQuery } from 'utils/recoil';
-import { setCookie } from 'utils/ts/cookie';
+import { tokenState } from 'utils/recoil';
 
 const useTokenState = () => {
-  const token = useRecoilValueLoadable(tokenStateQuery);
+  const token = useRecoilValueLoadable(tokenState);
   if (token.state === 'hasValue' && token.contents) {
-    setCookie('AUTH_TOKEN_KEY', token.contents, 3);
     return token.contents;
   }
   return '';

--- a/src/utils/hooks/useTokenState.ts
+++ b/src/utils/hooks/useTokenState.ts
@@ -1,0 +1,14 @@
+import { useRecoilValueLoadable } from 'recoil';
+import { tokenStateQuery } from 'utils/recoil';
+import { setCookie } from 'utils/ts/cookie';
+
+const useTokenState = () => {
+  const token = useRecoilValueLoadable(tokenStateQuery);
+  if (token.state === 'hasValue' && token.contents) {
+    setCookie('AUTH_TOKEN_KEY', token.contents, 3);
+    return token.contents;
+  }
+  return '';
+};
+
+export default useTokenState;

--- a/src/utils/recoil/index.ts
+++ b/src/utils/recoil/index.ts
@@ -1,12 +1,29 @@
-import { atom } from 'recoil';
+import { auth } from 'api';
+import { atom, selector } from 'recoil';
 import { getCookie } from 'utils/ts/cookie';
 
-export interface ITokenType {
-  token: string;
-}
+// string | null 로 바꿔야 할 듯
+// 다만 시간표 쪽 로직에 정의된 타입이 String 고정이라 어느 관심사에서 처리할지 고민해봐야 함
+export type TokenState = string;
 
 // token을 유지하는 atom
-export const tokenState = atom<string>({
+export const tokenState = atom<TokenState>({
   key: 'tokenState',
   default: getCookie('AUTH_TOKEN_KEY'),
+});
+
+export const tokenStateQuery = selector<TokenState>({
+  key: 'tokenStateQuery',
+  get: async ({ get }) => {
+    const token = get(tokenState);
+    if (token) {
+      return token;
+    }
+    const refreshToken = localStorage.getItem('AUTH_REFRESH_TOKEN_KEY');
+    if (refreshToken) {
+      const { token: accessToken } = await auth.refresh({ refresh_token: refreshToken });
+      return accessToken;
+    }
+    return '';
+  },
 });

--- a/src/utils/recoil/index.ts
+++ b/src/utils/recoil/index.ts
@@ -1,6 +1,6 @@
 import { auth } from 'api';
 import { atom, selector } from 'recoil';
-import { getCookie } from 'utils/ts/cookie';
+import { getCookie, setCookie } from 'utils/ts/cookie';
 
 // string | null 로 바꿔야 할 듯
 // 다만 시간표 쪽 로직에 정의된 타입이 String 고정이라 어느 관심사에서 처리할지 고민해봐야 함
@@ -9,21 +9,23 @@ export type TokenState = string;
 // token을 유지하는 atom
 export const tokenState = atom<TokenState>({
   key: 'tokenState',
-  default: getCookie('AUTH_TOKEN_KEY'),
-});
+  default: selector({
+    key: 'tokenState/Default',
+    get: async () => {
+      const token = getCookie('AUTH_TOKEN_KEY');
+      if (token) {
+        return token;
+      }
 
-export const tokenStateQuery = selector<TokenState>({
-  key: 'tokenStateQuery',
-  get: async ({ get }) => {
-    const token = get(tokenState);
-    if (token) {
-      return token;
-    }
-    const refreshToken = localStorage.getItem('AUTH_REFRESH_TOKEN_KEY');
-    if (refreshToken) {
-      const { token: accessToken } = await auth.refresh({ refresh_token: refreshToken });
-      return accessToken;
-    }
-    return '';
-  },
+      const refreshToken = localStorage.getItem('AUTH_REFRESH_TOKEN_KEY');
+      if (refreshToken) {
+        const result = await auth.refresh({ refresh_token: refreshToken });
+        const { token: newAccessToken, refresh_token: newRefreshToken } = result;
+        setCookie('AUTH_TOKEN_KEY', newAccessToken, 3);
+        localStorage.setItem('AUTH_REFRESH_TOKEN_KEY', newRefreshToken);
+        return newAccessToken;
+      }
+      return '';
+    },
+  }),
 });


### PR DESCRIPTION
## [#48] request

- `login` API의 Response entity가 변경된 것을 적용했습니다.
- `refresh` API가 추가되어, 클래스를 정의했습니다.
- refreshToken을 localStorage에 저장하게끔 수정했습니다.
- 기존에 사용하던 `tokenState` 대신, 해당 데이터를 불러와 없을 경우 refresh를 거쳐 토큰을 반환하는 selector(`tokenStateQuery`) 를 추가했습니다.
  - 해당 selector는 refresh요청 이후에 데이터를 반환해야 하므로, `useRecoilValueLoadable` 을 활용한 훅(`useTokenState`)으로 감싸 데이터를 반환하게 만들었습니다.
  - `useRecoilValueLoadable` 은, suspense를 지원해 해당 데이터의 로딩까지 Suspense를 동작시켜 화면 깜빡임 등이 발생하지 않습니다.
  - token set 동작은 기존처럼 `useSetRecoilValue(tokenState)`를 가져다 활용하셔도 `useTokenState`의 selector가 해당 아톰을 읽어 반환하기에 문제없습니다.

고민해볼 점은,
- `useTokenState`의 반환이 `string` 타입으로 고정된 상태라 훅의 의도와 맞추려면 `null | string` 으로 바꿔야 할 것 같은데, 해당 토큰을 사용하고 있는 로직들의 타입이 string 고정이라, 고려하지 못한 상태입니다.
- 해당 API들의 타입을 바꿔야 하는지, 토큰을 string 고정으로 바꾸며 로그인이 필요한 라우팅을 고정해야하는지 등을 고민해보면 좋을 것 같네요.
- **로그인 여부**를 토큰으로 판단하는 것이 옳지 않다고 생각합니다. 해당 토큰으로 인가 요청을 보내는 Auth 모듈이 필요해 보이네요.
  - 이러한 관리를 `tokenState`에 의존적으로 만들어야 하는지를 정하지 못했습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes
