### PR TITLE
[메인페이지] 공지사항 컴포넌트 추가

### DIFF
--- a/src/assets/svg/right-arrow.svg
+++ b/src/assets/svg/right-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.42773 17.1428L14.5706 12L9.42773 6.85712" stroke="#252525" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/IndexPage/components/IndexNotice/IndexNotice.module.scss
+++ b/src/pages/IndexPage/components/IndexNotice/IndexNotice.module.scss
@@ -1,7 +1,89 @@
 @use "src/utils/scss/media" as media;
 
 .template {
+  width: 848px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
   @include media.media-breakpoint(mobile) {
     display: none;
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__title {
+    font-family: NanumSquare, serif;
+    font-size: 17px;
+    font-weight: bold;
+    color: #175c8e;
+    text-decoration: none;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 15px;
+      padding-left: 3px;
+      margin-left: 16px;
+    }
+  }
+
+  &__title-link {
+    text-decoration: none;
+  }
+
+  &__link {
+    font-size: 12px;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    color: #252525;
+    position: relative;
+    left: 8px;
+
+    svg {
+      position: relative;
+      top: -1px;
+      right: 3px;
+    }
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    height: 18px;
+  }
+
+  &__item-link {
+    font-size: 14px;
+    color: #252525;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+  }
+
+  &__item-type {
+    font-weight: 600;
+    margin-right: 4px;
+  }
+
+  &__item-tag {
+    width: 14px;
+    height: 14px;
+    margin-left: 10px;
+  }
+
+  &__item-created {
+    color: #999;
+    text-align: right;
+    font-size: 12px;
   }
 }

--- a/src/pages/IndexPage/components/IndexNotice/index.tsx
+++ b/src/pages/IndexPage/components/IndexNotice/index.tsx
@@ -1,9 +1,75 @@
+import { Link } from 'react-router-dom';
+import { ReactComponent as RightArrow } from 'assets/svg/right-arrow.svg';
+import useArticleList from 'pages/Notice/NoticeListPage/hooks/useArticleList';
 import styles from './IndexNotice.module.scss';
 
+const getArticleType = (id: number) => {
+  switch (id) {
+    case 5:
+      return '[일반공지]';
+    case 6:
+      return '[장학공지]';
+    case 7:
+      return '[학사공지]';
+    case 8:
+      return '[취업공지]';
+    default:
+      return '[공지]';
+  }
+};
+
+const isNew = (createdAt: string) => {
+  const now = new Date();
+  const created = new Date(createdAt);
+
+  return (now.getTime() - created.getTime()) < 1000 * 60 * 60 * 24 * 1;
+};
+
 function IndexNotice() {
+  const articleList = useArticleList('1');
+
   return (
     <section className={styles.template}>
-      indexnotice
+      <div className={styles.template__header}>
+        <Link to="board/notice" className={styles['template__title-link']}>
+          <h1 className={styles.template__title}>공지사항</h1>
+        </Link>
+        <Link to="/board/notice" className={styles.template__link}>
+          더보기
+          <RightArrow aria-hidden />
+        </Link>
+      </div>
+
+      {articleList && (
+        <ul className={styles.list}>
+          {articleList.articles.slice(0, 7).map((article) => (
+            <li key={article.id} className={styles.list__item}>
+              <Link
+                to={`/board/notice/${article.id}`}
+                className={styles['list__item-link']}
+              >
+                <span className={styles['list__item-type']}>
+                  {getArticleType(article.board_id)}
+                </span>
+                <span>
+                  {article.title}
+                </span>
+                {isNew(article.created_at) && (
+                  <img
+                    className={styles['list__item-tag']}
+                    src="https://static.koreatech.in/upload/7f2af097aeeca368b0a491f9e00f80ca.png"
+                    alt="NEW"
+                    aria-hidden
+                  />
+                )}
+              </Link>
+              <span className={styles['list__item-created']}>
+                {article.created_at.slice(0, 10).replaceAll('-', '.')}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## [#28] request

`IndexPage` 컴포넌트 중 공지사항 컴포넌트를 추가했습니다.

- 공지사항 목록 페이지에서 사용한 `useArticleList()` 훅을 사용해 UI 맞게 길이만큼 잘라 그리게끔 만들었습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot
<img width="1836" alt="image" src="https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/50780281/d59d6014-d532-4ac9-91a4-7c2b1463c2e0">
