### PR TITLE
[버스 페이지] 시간 표시 오류 수정

### DIFF
--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -1,9 +1,9 @@
 import { Course } from 'api/bus/entity';
 
 // 시간 반환 함수
-const getHour = (second: number) => Math.floor(second / 60 / 60);
+const getHour = (second: number) => Math.floor(second / 60 / 60) % 24;
 
-const getMinute = (second: number) => Math.ceil(second / 60) % 60;
+const getMinute = (second: number) => Math.round(second / 60) % 60;
 
 export const getLeftTimeString = (second: number | '미운행' | undefined) => {
   if (!second) {
@@ -17,21 +17,17 @@ export const getLeftTimeString = (second: number | '미운행' | undefined) => {
   } return `${getHour(second)}시간 ${getMinute(second)}분 전`;
 };
 
-export const getStartTimeString = (second: number | '미운행' | undefined, isMain:boolean = false) => {
+export const getStartTimeString = (second: number | '미운행' | undefined, isMain: boolean = false) => {
   if (!second) return '';
   if (second === '미운행') return '';
 
-  const hour = getHour(second);
-  const minute = getMinute(second);
+  const today = (new Date().getTime() - new Date().getTimezoneOffset() * 60 * 1000);
+  const arrivalTimeSecond = (today / 1000) + second;
 
-  const today = new Date();
+  const hour = getHour(arrivalTimeSecond);
+  const minute = getMinute(arrivalTimeSecond);
 
-  let startMinute = today.getMinutes() + minute;
-  let startHour = today.getHours() + hour + Math.ceil(startMinute / 60);
-
-  startHour %= 24;
-  startMinute %= 60;
-  const timeString = [String(startHour).padStart(2, '0'), String(startMinute).padStart(2, '0')];
+  const timeString = [String(hour).padStart(2, '0'), String(minute).padStart(2, '0')];
 
   if (isMain) return `${timeString[0]}시 ${timeString[1]}분`;
   return `${timeString[0]}:${timeString[1]}`;


### PR DESCRIPTION
## [#38] request

현재 시간을 밀리초 단위로 더해 버스 도착 시간을 계산하도록 변경했습니다.
(기존 방식: 현재 시, 분만을 합산하여 계산하는 방식)

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes

### Screenshot

<img width="888" alt="image" src="https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/50780281/5f605f64-fac0-4300-941f-344e340cb312">
