### PR TITLE
[Auth] 회원가입 API 변경사항 대응

### DIFF
--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -38,7 +38,7 @@ implements APIRequest<R> {
 export class Signup<R extends SignupResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
 
-  path = '/user/register';
+  path = '/user/student/register';
 
   response!: R;
 

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -21,7 +21,7 @@ export interface SignupRequest {
   // options
   name?: string;
   nickname?: string;
-  gender?: string;
+  gender?: number;
   major?: string;
   student_number?: string;
   phone_number?: string;

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -25,7 +25,6 @@ export interface SignupRequest {
   major?: string;
   student_number?: string;
   phone_number?: string;
-  identity?: number;
   is_graduated?: boolean;
 }
 

--- a/src/pages/Auth/SignupPage/hooks/useSignup.ts
+++ b/src/pages/Auth/SignupPage/hooks/useSignup.ts
@@ -1,4 +1,5 @@
 import { auth } from 'api';
+import { AxiosError } from 'axios';
 import { useMutation } from 'react-query';
 import showToast from 'utils/ts/showToast';
 
@@ -13,8 +14,10 @@ const useSignup = (options: ISignupOption) => {
       options.onSuccess?.();
       showToast('success', '아우누리 이메일로 인증 메일을 발송했습니다. 확인 부탁드립니다.');
     },
-    onError: () => {
-      showToast('error', '서버에 오류가 발생했습니다.');
+    onError: (error: AxiosError<{ message?: string }>) => {
+      if (error?.response?.data) {
+        showToast('error', error.response.data.message || '에러가 발생했습니다.');
+      }
     },
   });
 

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -330,7 +330,7 @@ const GenderListbox = React.forwardRef<ICustomFormInput, ICustomFormInputProps>(
           [styles['select__trigger--active']]: currentValue !== null,
         })}
       >
-        {currentValue !== null ? GENDER_TYPE[currentValue].value : '성별'}
+        {currentValue !== null ? GENDER_TYPE[currentValue].label : '성별'}
       </button>
       {isOpenedPopup && (
         <ul className={styles.select__content} role="listbox">
@@ -447,7 +447,7 @@ const useSignupForm = () => {
   const submitForm: ISubmitForm = (formValue) => {
     const payload = {
       // 필수정보
-      email: formValue.id?.trim(),
+      email: `${formValue.id?.trim()}@koreatech.ac.kr`,
       password: formValue.password,
       // 옵션
       name: formValue.name || undefined,
@@ -456,7 +456,6 @@ const useSignupForm = () => {
       major: formValue['student-number'].major || undefined,
       student_number: formValue['student-number'].studentNumber || undefined,
       phone_number: formValue['phone-number'] || undefined,
-      identity: 0,
       is_graduated: false,
     };
     mutate(payload);


### PR DESCRIPTION
## [#70] 회원가입 API 변경사항 대응

### 대응 상세 내용
- 회원가입 POST 기존 path `user/register` => `user/student/register`
- `identity` 프로퍼티 삭제
- gender request type `number`로 변경
- 성별 선택시 0과 1로 나타나는 오류 수정
- 에러별로 핸들링 할 수 있도록 변경

예) 이메일 중복일시 에러 메시지 변경
![image](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/101982606/2571ae79-4072-4b0d-9155-7f42dbe4dfde)


딱히 테스트할만한 koreatech 아이디가 없어서, 이메일 인증 로직까지는 체크하지 못했습니다.
이부분에 대한 테스트는 QA시점으로 넘기거나, 계정을 삭제하고 다시 인증해야할것같습니다.


## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot
