### PR TITLE
[식단 페이지] 모바일 환경에서 식단 더보기 이벤트 추가

### DIFF
--- a/src/pages/IndexPage/components/IndexCafeteria/index.tsx
+++ b/src/pages/IndexPage/components/IndexCafeteria/index.tsx
@@ -7,9 +7,11 @@ import cn from 'utils/ts/classnames';
 import useCafeteriaList from 'pages/Cafeteria/CafeteriaPage/hooks/useCafeteriaList';
 import useLogger from 'utils/hooks/useLogger';
 import { convertDateToSimpleString } from 'utils/ts/cafeteria';
+import useMediaQuery from 'utils/hooks/useMediaQuery';
 import styles from './IndexCafeteria.module.scss';
 
 function IndexCafeteria() {
+  const isMobile = useMediaQuery();
   const getType = () => {
     const hour = new Date().getHours();
     if (hour < 9) {
@@ -74,7 +76,16 @@ function IndexCafeteria() {
         <div className={styles.type}>
           {getType()[0]}
         </div>
-        <div className={styles.menuContainer} onClick={(e) => handleMoreClick(e)} role="button" tabIndex={0}>
+        <div
+          className={styles.menuContainer}
+          onClick={(e) => {
+            if (isMobile) {
+              handleMoreClick(e);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+        >
           {선택된_식단 ? 선택된_식단.menu.slice(0, 10).map((menu) => (
             <div className={styles.menu} key={menu}>
               {menu}

--- a/src/pages/IndexPage/components/IndexCafeteria/index.tsx
+++ b/src/pages/IndexPage/components/IndexCafeteria/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useNavigate } from 'react-router-dom';
 import { CAFETERIA_CATEGORY } from 'static/cafeteria';
 import { useState } from 'react';
@@ -73,7 +74,7 @@ function IndexCafeteria() {
         <div className={styles.type}>
           {getType()[0]}
         </div>
-        <div className={styles.menuContainer}>
+        <div className={styles.menuContainer} onClick={(e) => handleMoreClick(e)} role="button" tabIndex={0}>
           {선택된_식단 ? 선택된_식단.menu.slice(0, 10).map((menu) => (
             <div className={styles.menu} key={menu}>
               {menu}


### PR DESCRIPTION
## [#76 ] request

모바일환경에서 더보기 이벤트가 없어 다른 날, 다른 시간 식단표를 확인 할 수 없는 문제를 수정했습니다.


## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot

https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/51395707/200039fd-a0b7-4a00-bdf9-9dfa3be6c30e

- Close #76
