### PR TITLE
[버스] 버스 남은 분 계산 로직 수정

### DIFF
--- a/src/pages/BusPage/ts/busModules.ts
+++ b/src/pages/BusPage/ts/busModules.ts
@@ -3,18 +3,26 @@ import { Course } from 'api/bus/entity';
 // 시간 반환 함수
 const getHour = (second: number) => Math.floor(second / 60 / 60) % 24;
 
-const getMinute = (second: number) => Math.round(second / 60) % 60;
+const getMinute = (second: number) => Math.floor(second / 60) % 60;
 
 export const getLeftTimeString = (second: number | '미운행' | undefined) => {
-  if (!second) {
+  if (second === undefined) {
     return '운행정보없음';
-  } if (second === '미운행') {
+  }
+
+  if (second === '미운행') {
     return '미운행';
-  } if (getHour(second) === 0 && getMinute(second) === 0) {
+  }
+
+  if (getHour(second) === 0 && getMinute(second) === 0) {
     return '곧 도착';
-  } if (getHour(second) === 0) {
+  }
+
+  if (getHour(second) === 0) {
     return `${getMinute(second)}분 전`;
-  } return `${getHour(second)}시간 ${getMinute(second)}분 전`;
+  }
+
+  return `${getHour(second)}시간 ${getMinute(second)}분 전`;
 };
 
 export const getStartTimeString = (second: number | '미운행' | undefined, isMain: boolean = false) => {


### PR DESCRIPTION
- Close #114 

## What is this PR? 🔍

- 기능 : 버스 남은시간 계산하는 로직을 정상화시킵니다.
- issue : #114

## Changes 📝


## ScreenShot 📷

<img width="790" alt="스크린샷 2024-03-30 오후 8 32 09" src="https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/50780281/cc363b71-5bbd-49f0-ab55-3d03b14e061a">


## Test CheckList ✅
 - [x] 3599초, 3600초, 3601초 남았을 때 각각 확인

## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes
