### PR TITLE
[시간표] 메인 페이지의 시간표에서 같은 강의 시간 표시 삭제

### DIFF
--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import ErrorBoundary from 'components/common/ErrorBoundary';
 import { useRecoilValue } from 'recoil';
 import useTokenState from 'utils/hooks/useTokenState';
-import { myLecturesAtom, selectedSemesterAtom, selectedTempLectureSelector } from 'utils/recoil/semester';
+import { myLecturesAtom, selectedSemesterAtom } from 'utils/recoil/semester';
 import useTimetableInfoList from 'components/TimetablePage/DefaultPage/hooks/useTimetableInfoList';
 import useTimetableDayList from 'utils/hooks/useTimetableDayList';
-import useLectureList from 'components/TimetablePage/DefaultPage/hooks/useLectureList';
-import { LectureInfo } from 'interfaces/Lecture';
 import Timetable from 'components/TimetablePage/Timetable';
 import { useSelectRecoil } from 'components/TimetablePage/DefaultPage/hooks/useSelect';
 import { useSemesterOptionList } from 'components/TimetablePage/DefaultPage';
@@ -27,20 +25,9 @@ function CurrentSemesterTimetable(): JSX.Element {
       : (myLecturesFromLocalStorageValue ?? []),
   );
 
-  const selectedLecture = useRecoilValue(selectedTempLectureSelector);
-  const { data: lectureList, status } = useLectureList(selectedSemester);
-  const similarSelectedLecture = (lectureList as unknown as Array<LectureInfo>)
-    ?.filter((lecture) => lecture.code === selectedLecture?.code)
-    ?? [];
-  const similarSelectedLectureDayList = useTimetableDayList(similarSelectedLecture);
-  const selectedLectureIndex = similarSelectedLecture
-    .findIndex(({ lecture_class }) => lecture_class === selectedLecture?.lecture_class);
-
-  return selectedSemesterValue && status === 'success' ? (
+  return selectedSemesterValue ? (
     <Timetable
       lectures={myLectureDayValue}
-      similarSelectedLecture={similarSelectedLectureDayList}
-      selectedLectureIndex={selectedLectureIndex}
       colWidth={40}
       firstColWidth={42}
       rowHeight={16}


### PR DESCRIPTION
## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #116 
-->

- 기능 : 메인 페이지의 시간표에서 같은 강의 시간이 표시되는 것을 삭제
- issue : #116 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74342515/96d174e6-0234-439f-8091-5d3a4bc4f5f1)
![image](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74342515/c4ee74c9-9783-49fc-afb9-6d29aab2a014)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes
