### PR TITLE
[편의] 병합 시 삐봇 서버에 요청 추가

### DIFF
--- a/.github/workflows/CHECK_PR_MERGED.yml
+++ b/.github/workflows/CHECK_PR_MERGED.yml
@@ -1,0 +1,35 @@
+name: "Check PR Merged"
+
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  check_pr_merged:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check PR Merged
+        id: check_pr_merged
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prUrl = context.payload.pull_request.html_url;
+            core.setOutput('pullRequestLink', JSON.stringify(prUrl));
+
+      - name: test valiable
+        uses: actions/github-script@v7
+        with: 
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: console.log(${{ steps.check_pr_merged.outputs.pullRequestLink }})
+
+      - name: Send Slack Trigger
+        run: |
+          curl -X POST https://api-slack.internal.bcsdlab.com/api/pr-merged/frontend \
+          -H 'Content-Type: application/json' \
+          -d '{
+                "pullRequestLink": ${{ steps.pick_random_reviewer.outputs.pullRequestLink }}
+              }'

--- a/.github/workflows/PICK_REVIEWER.yml
+++ b/.github/workflows/PICK_REVIEWER.yml
@@ -51,12 +51,6 @@ jobs:
               core.setOutput('reviewer2GithubName', reviewer2.githubName);
             }
 
-      - name: test valiable
-        uses: actions/github-script@v7
-        with: 
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: console.log(${{ steps.pick_random_reviewer.outputs.reviewer1Name }})
-
       - name: Add Reviewers
         uses: madrapps/add-reviewers@v1
         with:


### PR DESCRIPTION
- Close #118

## What is this PR? 🔍
PR이 병합될 때 삐봇서버로 PR링크를 보냅니다.
아직은 인터널에서 대응되지 않아 서버 동작이 없지만, 추후 해당 링크를 읽어서

PR이 만들어지는 순간에 인터널 서버에 저장해둔 PR링크를 토대로,
병합된 PR의 경우엔 `#frontend_github` 채널에서 해당 메시지를 다르게 보일 수 있도록 수정할 예정입니다.

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes
