### PR TITLE
[시간표] 강의 검색 학부 필터링 적용

### DIFF
--- a/src/components/TimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/DefaultPage/index.tsx
@@ -139,11 +139,11 @@ function CurrentSemesterLectureList({
               const searchFilter = filter.search;
               const departmentFilter = filter.department;
 
-              if (searchFilter && departmentFilter !== '전체') {
+              if (searchFilter !== '' && departmentFilter !== '전체') {
                 return lecture.name.includes(searchFilter)
                   && lecture.department === departmentFilter;
               }
-              if (searchFilter) {
+              if (searchFilter !== '') {
                 return lecture.name.includes(searchFilter);
               }
               if (departmentFilter !== '전체') {

--- a/src/components/TimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/DefaultPage/index.tsx
@@ -138,16 +138,18 @@ function CurrentSemesterLectureList({
             .filter((lecture) => {
               const searchFilter = filter.search;
               const departmentFilter = filter.department;
-              if (searchFilter && departmentFilter === '전체') {
-                return lecture.name.includes(searchFilter);
-              }
-              if (!searchFilter && departmentFilter !== '전체') {
-                return lecture.department === departmentFilter;
-              }
+
               if (searchFilter && departmentFilter !== '전체') {
                 return lecture.name.includes(searchFilter)
                   && lecture.department === departmentFilter;
               }
+              if (searchFilter) {
+                return lecture.name.includes(searchFilter);
+              }
+              if (departmentFilter !== '전체') {
+                return lecture.department === departmentFilter;
+              }
+
               return true;
             })
         }

--- a/src/components/TimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/DefaultPage/index.tsx
@@ -109,7 +109,7 @@ interface CurrentSemesterLectureListProps {
   semesterKey: string | null;
   filter: {
     // 백엔드 수정하면 optional 제거
-    dept: string;
+    department: string;
     search: string;
   }
 }
@@ -137,15 +137,16 @@ function CurrentSemesterLectureList({
           (lectureList as unknown as Array<LectureInfo>)
             .filter((lecture) => {
               const searchFilter = filter.search;
-              const deptFilter = filter.dept;
-              if (searchFilter && deptFilter === '전체') {
+              const departmentFilter = filter.department;
+              if (searchFilter && departmentFilter === '전체') {
                 return lecture.name.includes(searchFilter);
               }
-              if (!searchFilter && deptFilter !== '전체') {
-                return lecture.department === deptFilter;
+              if (!searchFilter && departmentFilter !== '전체') {
+                return lecture.department === departmentFilter;
               }
-              if (searchFilter && deptFilter !== '전체') {
-                return lecture.name.includes(searchFilter) && lecture.department === deptFilter;
+              if (searchFilter && departmentFilter !== '전체') {
+                return lecture.name.includes(searchFilter)
+                  && lecture.department === departmentFilter;
               }
               return true;
             })
@@ -315,7 +316,7 @@ function DefaultPage() {
     value: searchValue,
   } = useSearch();
   const {
-    value: deptFilterValue,
+    value: departmentFilterValue,
     onChangeSelect: onChangeDeptSelect,
   } = useSelect();
   const {
@@ -347,7 +348,7 @@ function DefaultPage() {
             <div className={styles.page__depart}>
               <React.Suspense fallback={<LoadingSpinner className={styles['dropdown-loading-spinner']} />}>
                 <DeptListbox
-                  value={deptFilterValue}
+                  value={departmentFilterValue}
                   onChange={onChangeDeptSelect}
                 />
               </React.Suspense>
@@ -360,7 +361,7 @@ function DefaultPage() {
                 semesterKey={semesterFilterValue}
                 filter={{
                   // 백엔드 수정하면 제거
-                  dept: deptFilterValue ?? '전체',
+                  department: departmentFilterValue ?? '전체',
                   search: searchValue ?? '',
                 }}
               />


### PR DESCRIPTION
- Close #100 

## What is this PR? 🔍

- 기능 : 시간표 강의 검색 학부 필터링 적용
- issue : #100 

## Changes 📝

- 시간표 강의 검색 과 필터링 기능을 추가했습니다.
- 키워드 검색 필터와 학부 필터 검색을 동시에 진행하기 위해 조건부에 따라 필터링을 다르게 설정했습니다.

1. 검색어만 입력한 경우: 검색어를 기반으로 필터링됩니다.
2. 학부만 선택한 경우: 해당 학부에 따라 필터링됩니다.
3. 검색어와 학부를 모두 선택한 경우: 검색어와 학부를 동시에 고려하여 필터링됩니다.

## ScreenShot 📷

https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/101982606/226077cc-ad91-496b-9853-a4c510c07be4


## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->
- [x] 검색어 필터 테스트
- [x] 학부 필터 테스트
- [x] 둘다 입력했을 경우 테스트

## Precaution

x

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes
