### PR TITLE
[시간표] 강의 검색 시 학부 필터링 미작동하는 학부 수정

### DIFF
--- a/src/components/TimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/DefaultPage/index.tsx
@@ -132,15 +132,15 @@ function CurrentSemesterLectureList({
         list={
           (lectureList as unknown as Array<LectureInfo>)
             .filter((lecture) => {
-              const searchFilter = filter.search;
+              const searchFilter = filter.search.toUpperCase();
               const departmentFilter = filter.department;
 
               if (searchFilter !== '' && departmentFilter !== '전체') {
-                return lecture.name.includes(searchFilter)
+                return lecture.name.toUpperCase().includes(searchFilter)
                   && lecture.department === departmentFilter;
               }
               if (searchFilter !== '') {
-                return lecture.name.includes(searchFilter);
+                return lecture.name.toUpperCase().includes(searchFilter);
               }
               if (departmentFilter !== '전체') {
                 return lecture.department === departmentFilter;

--- a/src/components/TimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/DefaultPage/index.tsx
@@ -49,21 +49,18 @@ const useSearch = () => {
   };
 };
 
-const defaultOptionList = [
+const deptOptionList = [
   { label: '전체', value: '전체' },
-];
+  { label: '디자인ㆍ건축공학부', value: '디자인ㆍ건축공학부' },
+  { label: '고용서비스정책학과', value: '고용서비스정책학과' },
+  { label: '기계공학부', value: '기계공학부' },
+  { label: '메카트로닉스공학부', value: '메카트로닉스공학부' },
+  { label: '산업경영학부', value: '산업경영학부' },
+  { label: '전기ㆍ전자ㆍ통신공학부', value: '전기ㆍ전자ㆍ통신공학부' },
+  { label: '컴퓨터공학부', value: '컴퓨터공학부' },
+  { label: '에너지신소재화학공학부', value: '에너지신소재화학공학부' },
+  { label: '교양학부', value: '교양학부' }];
 
-const useDeptOptionList = () => {
-  const { data: deptList } = useDeptList();
-  // 구조가 Array<Dept>인데 Array로 인식이 안됨.
-  const deptOptionList = defaultOptionList.concat(
-    (deptList as unknown as Array<IDept> | undefined ?? []).map(
-      (dept) => ({ label: dept.name, value: dept.name }),
-    ) ?? [],
-  );
-
-  return deptOptionList;
-};
 const useSemesterOptionList = () => {
   const { data: semesterList } = useSemester();
   // 구조가 Array<SemesterInfo>인데 Array로 인식이 안됨.
@@ -80,7 +77,6 @@ const useSemesterOptionList = () => {
 type DecidedListboxProps = Omit<ListboxProps, 'list'>;
 
 function DeptListbox({ value, onChange }: DecidedListboxProps) {
-  const deptOptionList = useDeptOptionList();
   React.useEffect(() => {
     if (deptOptionList.length !== 0) {
       onChange({ target: { value: deptOptionList[0].value } });


### PR DESCRIPTION
- Close #143

## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 
- issue : #143 

## Changes 📝
- 학부 선택 메뉴의 학부명을 개설학부에 있는 학부명과 일치하도록 했습니다.
- 추가로, 교과목 검색 시 영어 대소문자를 구분하지 않도록 했습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74342515/70b873fe-1793-4678-a2bb-bff93aa36618)
![image](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74342515/f9440737-a199-4647-871d-94a0bdcdbb49)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes
