### PR TITLE
[공통] 클라이언트 에러 처리

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,6 +7,6 @@ declare module '*.scss' {
 
 declare module '@tanstack/react-query' {
   interface Register {
-    defaultError: unknwon;
+    defaultError: unknown;
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,3 +4,9 @@ declare module '*.scss' {
   const content: { [className: string]: string };
   export = content;
 }
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    defaultError: unknwon;
+  }
+}

--- a/src/pages/Auth/LoginPage/index.tsx
+++ b/src/pages/Auth/LoginPage/index.tsx
@@ -9,7 +9,8 @@ import useBooleanState from 'utils/hooks/useBooleanState';
 import { auth } from 'api';
 import sha256 from 'utils/ts/SHA-256';
 import showToast from 'utils/ts/showToast';
-import { AxiosError } from 'axios';
+import { isKoinError } from 'utils/ts/isKoinError';
+import { sendClientError } from 'utils/ts/sendClientError';
 import styles from './LoginPage.module.scss';
 
 interface IClassUser {
@@ -42,8 +43,13 @@ const useLogin = (state: IsAutoLogin) => {
       setToken(data.token);
       navigate('/');
     },
-    onError: (error: AxiosError<{ message: string }>) => {
-      showToast('error', error.response?.data?.message || '로그인에 실패했습니다.');
+    onError: (error: unknown) => {
+      if (isKoinError(error)) {
+        // 추후에 코드별 에러 분기처리 진행
+        showToast('error', error.message || '로그인에 실패했습니다.');
+      } else {
+        sendClientError(error);
+      }
     },
   });
 

--- a/src/pages/Auth/LoginPage/index.tsx
+++ b/src/pages/Auth/LoginPage/index.tsx
@@ -34,7 +34,6 @@ const useLogin = (state: IsAutoLogin) => {
   const navigate = useNavigate();
   const postLogin = useMutation(auth.login, {
     onSuccess: (data: LoginResponse) => {
-      throw new Error('로그인 클라이언트 에러가 발생했다');
       if (state.isAutoLoginFlag) {
         localStorage.setItem('AUTH_REFRESH_TOKEN_KEY', data.refresh_token);
         setCookie('AUTH_TOKEN_KEY', data.token, 3);

--- a/src/pages/Auth/LoginPage/index.tsx
+++ b/src/pages/Auth/LoginPage/index.tsx
@@ -50,6 +50,7 @@ const useLogin = (state: IsAutoLogin) => {
         showToast('error', error.message || '로그인에 실패했습니다.');
       } else {
         sendClientError(error);
+        showToast('error', '로그인에 실패했습니다.');
       }
     },
   });

--- a/src/pages/Auth/LoginPage/index.tsx
+++ b/src/pages/Auth/LoginPage/index.tsx
@@ -34,6 +34,7 @@ const useLogin = (state: IsAutoLogin) => {
   const navigate = useNavigate();
   const postLogin = useMutation(auth.login, {
     onSuccess: (data: LoginResponse) => {
+      throw new Error('로그인 클라이언트 에러가 발생했다');
       if (state.isAutoLoginFlag) {
         localStorage.setItem('AUTH_REFRESH_TOKEN_KEY', data.refresh_token);
         setCookie('AUTH_TOKEN_KEY', data.token, 3);
@@ -43,7 +44,7 @@ const useLogin = (state: IsAutoLogin) => {
       setToken(data.token);
       navigate('/');
     },
-    onError: (error: unknown) => {
+    onError: (error) => {
       if (isKoinError(error)) {
         // 추후에 코드별 에러 분기처리 진행
         showToast('error', error.message || '로그인에 실패했습니다.');

--- a/src/utils/ts/sendClientError.ts
+++ b/src/utils/ts/sendClientError.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+export const sendClientError = (error: unknown) => {
+  const url = window.location.href;
+
+  const serializedError = JSON.stringify(
+    error,
+    Object.getOwnPropertyNames(error),
+  );
+
+  const deserializedError = Object.assign(
+    new Error(),
+    JSON.parse(serializedError),
+  );
+
+  axios.post('https://api-slack.internal.bcsdlab.com/api/error-notice/frontend', {
+    url,
+    error: deserializedError,
+  });
+};


### PR DESCRIPTION
- Close #151 

## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 클라이언트 에러 처리 추가
- issue : #151 

## Changes 📝

- 클라이언트 에러 처리를 추가했습니다.
- `sendClientError()` 유틸 함수를 추가했습니다.
- usage 예시는 로그인쪽에 추가해두었습니다. 
- 에러는 삐봇 클라이언트 에러 api 로 post 됩니다.

- 전역 에러 타입 추론을  'unknwon`  기본값으로 지정했습니다.

## ScreenShot 📷

삐봇 알림 예시)
<img width="870" alt="image" src="https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/101982606/64aef488-61b3-4a69-9f4e-46575bcd8e08">


## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes
