### PR TITLE
[유저] 시간표 로깅 추가

### DIFF
--- a/src/components/TimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/DefaultPage/index.tsx
@@ -18,6 +18,7 @@ import ErrorBoundary from 'components/common/ErrorBoundary';
 import useTimetableDayList from 'utils/hooks/useTimetableDayList';
 import useTokenState from 'utils/hooks/useTokenState';
 import { ReactComponent as LoadingSpinner } from 'assets/svg/loading-spinner.svg';
+import useLogger from 'utils/hooks/useLogger';
 import useDeptList from './hooks/useDeptList';
 import styles from './DefaultPage.module.scss';
 import useSemester from './hooks/useSemester';
@@ -77,7 +78,7 @@ const useSemesterOptionList = () => {
   return semesterOptionList;
 };
 
-type DecidedListboxProps = Omit<ListboxProps, 'list'>;
+type DecidedListboxProps = Omit<ListboxProps, 'list' | 'logTitle'>;
 
 function DeptListbox({ value, onChange }: DecidedListboxProps) {
   const deptOptionList = useDeptOptionList();
@@ -89,7 +90,7 @@ function DeptListbox({ value, onChange }: DecidedListboxProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (
-    <Listbox list={deptOptionList} value={value} onChange={onChange} />
+    <Listbox list={deptOptionList} value={value} onChange={onChange} logTitle="select_dept" />
   );
 }
 
@@ -101,7 +102,7 @@ function SemesterListbox({ value, onChange }: DecidedListboxProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (
-    <Listbox list={semesterOptionList} value={value} onChange={onChange} />
+    <Listbox list={semesterOptionList} value={value} onChange={onChange} logTitle="select_semester" />
   );
 }
 
@@ -271,6 +272,11 @@ function CurrentSemesterTimetable(): JSX.Element {
 
 function Curriculum() {
   const { data: deptList } = useDeptList();
+  const logger = useLogger();
+
+  const handleLogClick = (deptName: string) => {
+    logger.actionEventClick({ actionTitle: 'USER', title: 'curriculum', value: deptName });
+  };
   return (
     <ul className={styles['page__curriculum-list']}>
       {(deptList as unknown as Array<IDept> | undefined ?? []).map((dept) => (
@@ -278,6 +284,7 @@ function Curriculum() {
           <a
             className={styles.page__curriculum}
             href={dept.curriculum_link}
+            onClick={() => handleLogClick(dept.name)}
           >
             {dept.name}
           </a>
@@ -325,6 +332,7 @@ function DefaultPage() {
     value: semesterFilterValue,
     onChangeSelect: onChangeSemesterSelect,
   } = useSelectRecoil(selectedSemesterAtom);
+  const logger = useLogger();
 
   return (
     <>
@@ -338,6 +346,7 @@ function DefaultPage() {
                 className={styles['search-input__input']}
                 placeholder="교과명을 입력하세요."
                 onKeyDown={onKeyDownSearchInput}
+                onClick={() => logger.actionEventClick({ actionTitle: 'USER', title: 'timetable_search', value: '시간표 검색' })}
               />
               <button
                 className={styles['search-input__button']}
@@ -398,6 +407,7 @@ function DefaultPage() {
                       link.click();
                     });
                 });
+                logger.actionEventClick({ actionTitle: 'USER', title: 'timetable_image', value: '시간표 이미지 저장' });
               }}
             >
               <img src="https://static.koreatech.in/assets/img/ic-image.png" alt="이미지" />

--- a/src/components/TimetablePage/Listbox/index.tsx
+++ b/src/components/TimetablePage/Listbox/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import cn from 'utils/ts/classnames';
 import useBooleanState from 'utils/hooks/useBooleanState';
+// import useLogger from 'utils/hooks/useLogger';
+import useLogger from 'utils/hooks/useLogger';
 import styles from './Listbox.module.scss';
 
 export interface ListboxRef {
@@ -16,19 +18,33 @@ export interface ListboxProps {
   list: ListItem[];
   value: string | null;
   onChange: (event: { target: ListboxRef }) => void;
+  logTitle?: string;
 }
 
 function Listbox({
   list,
   value,
   onChange,
+  logTitle = '',
 }: ListboxProps) {
   const [isOpenedPopup, , closePopup, triggerPopup] = useBooleanState(false);
   const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const logger = useLogger();
+  const handleLogClick = (optionValue: string) => {
+    if (logTitle === 'select_dept') {
+      logger.actionEventClick({ actionTitle: 'USER', title: 'select_dept', value: optionValue });
+      return;
+    }
+    if (logTitle === 'select_semester') {
+      logger.actionEventClick({ actionTitle: 'USER', title: 'select_semester', value: optionValue });
+    }
+  };
+
   const onClickOption = (event: React.MouseEvent<HTMLLIElement>) => {
     const { currentTarget } = event;
     const optionValue = currentTarget.getAttribute('data-value');
     onChange({ target: { value: optionValue ?? '' } });
+    handleLogClick(optionValue ?? '');
     closePopup();
   };
   const onKeyPressOption = (event: React.KeyboardEvent<HTMLLIElement>) => {
@@ -90,5 +106,9 @@ function Listbox({
     </div>
   );
 }
+
+Listbox.defaultProps = {
+  logTitle: '',
+};
 
 export default Listbox;

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -96,6 +96,7 @@ function Header() {
   const logger = useLogger();
   const loggingBusinessShortCut = (title: string) => {
     if (title === '주변상점') logger.actionEventClick({ actionTitle: 'BUSINESS', title: 'hamburger_shop', value: title });
+    if (title === '시간표') logger.actionEventClick({ actionTitle: 'USER', title: 'hamburger_timetable', value: title });
   };
 
   useEffect(() => {

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -96,7 +96,7 @@ function Header() {
   const logger = useLogger();
   const loggingBusinessShortCut = (title: string) => {
     if (title === '주변상점') logger.actionEventClick({ actionTitle: 'BUSINESS', title: 'hamburger_shop', value: title });
-    if (title === '시간표') logger.actionEventClick({ actionTitle: 'USER', title: 'hamburger_timetable', value: title });
+    if (title === '시간표') logger.actionEventClick({ actionTitle: 'USER', title: 'hamburger_timetable', value: `햄버거 ${title}` });
   };
 
   useEffect(() => {

--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -10,6 +10,7 @@ import { useSelectRecoil } from 'components/TimetablePage/DefaultPage/hooks/useS
 import { useSemesterOptionList } from 'components/TimetablePage/DefaultPage';
 import { Link } from 'react-router-dom';
 import { ReactComponent as LoadingSpinner } from 'assets/svg/loading-spinner.svg';
+import useLogger from 'utils/hooks/useLogger';
 import styles from './IndexTimetable.module.scss';
 
 function CurrentSemesterTimetable(): JSX.Element {
@@ -43,6 +44,8 @@ export default function IndexTimeTable() {
     onChangeSelect: onChangeSemesterSelect,
   } = useSelectRecoil(selectedSemesterAtom);
   const semesterOptionList = useSemesterOptionList();
+  const logger = useLogger();
+
   React.useEffect(() => {
     onChangeSemesterSelect({ target: { value: semesterOptionList[0].value } });
   // onChange와 deptOptionList가 렌더링될 때마다 선언되서 처음 한번만 해야 하는 onChange를 렌더링할 때마다 한다.
@@ -51,12 +54,31 @@ export default function IndexTimeTable() {
 
   return (
     <div className={styles.template}>
-      <Link to="/timetable" className={styles.title}>
+      <Link
+        to="/timetable"
+        className={styles.title}
+        onClick={() => {
+          logger.actionEventClick({
+            actionTitle: 'USER',
+            title: 'entry_text_timetable',
+            value: '시간표 텍스트 진입',
+          });
+        }}
+      >
         시간표
       </Link>
       <ErrorBoundary fallbackClassName="loading">
         <React.Suspense fallback={<LoadingSpinner className={styles['template__loading-spinner']} />}>
-          <Link to="/timetable">
+          <Link
+            to="/timetable"
+            onClick={() => {
+              logger.actionEventClick({
+                actionTitle: 'USER',
+                title: 'entry_table_timetable',
+                value: '시간표 테이블 진입',
+              });
+            }}
+          >
             <CurrentSemesterTimetable />
           </Link>
         </React.Suspense>


### PR DESCRIPTION
- Close #240 

## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 유저팀 시간표 로깅 추가
- issue : #240

## Changes 📝
유저팀 웹 시간표 로깅 추가했습니다. [유저팀 로그 시트](https://docs.google.com/spreadsheets/d/1gdM4oX3t6LTOfC1Dkrc5Bwnfm-0jTyAzmflnvGnnMss/edit#gid=607823791)
유저팀 로그 시트 중 **앱 로그** 는 main 브랜치에 기능이 추가되어 있지 않아 **앱 로그**는 배포 후 로그를 추가할 예정입니다.
(`(앱) 시간표_학기 드롭다운_전체 클릭` 과 `(앱) 시간표_이미지 저장_클릭`만 추후 추가하도록 하겠습니다.)

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution
공통으로 사용하는 ListBox에 새로운 속성인 `logTitle`이 추가되었습니다. 이 부분을 중점적으로 리뷰해주시면 감사하겠습니다!
<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes
