### PR TITLE
[시간표]시간표 이미지 하단 여백 제거

### DIFF
--- a/src/pages/TimetablePage/MobilePage/MobilePage.module.scss
+++ b/src/pages/TimetablePage/MobilePage/MobilePage.module.scss
@@ -54,6 +54,7 @@
   font-size: 15px;
   line-height: 1.6;
   color: rgb(23 92 142);
+  margin-top: 17px;
   cursor: pointer;
 }
 

--- a/src/pages/TimetablePage/MobilePage/index.tsx
+++ b/src/pages/TimetablePage/MobilePage/index.tsx
@@ -66,7 +66,7 @@ function MobilePage() {
                 columnWidth={55}
                 firstColumnWidth={52}
                 rowHeight={21}
-                totalHeight={456}
+                totalHeight={439}
               />
             </React.Suspense>
           </ErrorBoundary>

--- a/src/pages/TimetablePage/components/MyLectureTimetable/index.tsx
+++ b/src/pages/TimetablePage/components/MyLectureTimetable/index.tsx
@@ -53,7 +53,7 @@ export default function MyLectureTimetable() {
               columnWidth={55}
               firstColumnWidth={52}
               rowHeight={21}
-              totalHeight={456}
+              totalHeight={453}
             />
           </React.Suspense>
         </ErrorBoundary>


### PR DESCRIPTION
- Close #250 

## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 시간표 이미지 하단 여백 제거
- issue : #250 

## Changes 📝
- 시간표 이미지 저장 시 하단에 생기는 여백을 제거했습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
- 웹
![image](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74342515/576ca7ac-92fb-4644-82b7-2022f03cd4ec)
- 모바일
![image](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74342515/8365c4ea-3ac1-406c-a119-58ebc77186d5)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes
