### PR TITLE
[정보 수정] 아이폰 사파리 폰트 색상 대응

### DIFF
--- a/src/components/TimetablePage/Listbox/Listbox.module.scss
+++ b/src/components/TimetablePage/Listbox/Listbox.module.scss
@@ -16,6 +16,7 @@
     padding: 0 15px;
     box-sizing: border-box;
     background-color: #fff;
+    color: #000;
     font-size: 15px;
     font-weight: 400;
     line-height: 1.2;

--- a/src/components/common/Header/Header.module.scss
+++ b/src/components/common/Header/Header.module.scss
@@ -262,6 +262,7 @@
     background-color: transparent;
     border: 0;
     padding: 0;
+    color: #000;
     cursor: pointer;
   }
 

--- a/src/pages/Auth/ModifyInfoPage/ModifyInfoPage.module.scss
+++ b/src/pages/Auth/ModifyInfoPage/ModifyInfoPage.module.scss
@@ -77,6 +77,7 @@
     padding: 0 15px;
     box-sizing: border-box;
     background-color: #fff;
+    color: #000;
     font-size: 15px;
     font-weight: 400;
     line-height: 1.2;

--- a/src/pages/Auth/ModifyInfoPage/ModifyInfoPage.module.scss
+++ b/src/pages/Auth/ModifyInfoPage/ModifyInfoPage.module.scss
@@ -202,6 +202,7 @@
       @include media.media-breakpoint(mobile) {
         width: 75px;
         height: 36px;
+        font-size: 11px;
       }
     }
 


### PR DESCRIPTION
- Close #265

## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 아이폰 사파리 폰트 색상 대응
- issue : #265

## Changes 📝
- 아이폰 사파리 폰트가 파란색으로 나오는 것들을 검은색으로 변경했습니다.
- 닉네임 `중복확인` 버튼 내 폰트 사이즈를 작게 수정했습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![IMG_2951](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74540646/5160d712-98df-4d7f-a718-4c5296228dee)
![IMG_2950](https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74540646/5a7f8e6f-5999-4738-a694-c250f6d230a1)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes
