### PR TITLE
[식단] 모바일 상세페이지 뒤로가기 오류 수정

### DIFF
--- a/src/pages/IndexPage/components/IndexCafeteria/index.tsx
+++ b/src/pages/IndexPage/components/IndexCafeteria/index.tsx
@@ -7,7 +7,6 @@ import { cn } from '@bcsdlab/utils';
 import useCafeteriaList from 'pages/Cafeteria/hooks/useCafeteriaList';
 import useLogger from 'utils/hooks/useLogger';
 import { convertDateToSimpleString } from 'utils/ts/cafeteria';
-import useMediaQuery from 'utils/hooks/useMediaQuery';
 import styles from './IndexCafeteria.module.scss';
 
 type CafeteriaType = {
@@ -17,7 +16,6 @@ type CafeteriaType = {
 };
 
 function IndexCafeteria() {
-  const isMobile = useMediaQuery();
   const getType = () => {
     const hour = new Date().getHours();
     if (hour < 9) {
@@ -39,8 +37,9 @@ function IndexCafeteria() {
 
   const handleMoreClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
-    logger.actionEventClick({ actionTitle: 'CAMPUS', title: 'main_menu_moveDetailView', value: '식단' });
+
     navigate('/cafeteria');
+    logger.actionEventClick({ actionTitle: 'CAMPUS', title: 'main_menu_moveDetailView', value: '식단' });
   };
 
   const onClickCafeteriaCorner = (e: React.MouseEvent<HTMLDivElement>, category: CafeteriaType) => {
@@ -57,7 +56,9 @@ function IndexCafeteria() {
     <section className={styles.template}>
       <h2 className={styles.title}>
         <div
-          onClick={(e) => handleMoreClick(e)}
+          onClick={(e) => {
+            handleMoreClick(e);
+          }}
           role="button"
           tabIndex={0}
         >
@@ -65,7 +66,9 @@ function IndexCafeteria() {
         </div>
         <div
           className={styles.moreLink}
-          onClick={(e) => handleMoreClick(e)}
+          onClick={(e) => {
+            handleMoreClick(e);
+          }}
           role="button"
           tabIndex={0}
         >
@@ -95,7 +98,9 @@ function IndexCafeteria() {
         </div>
         <div
           className={styles.menuBox}
-          onClick={(e) => handleMoreClick(e)}
+          onClick={(e) => {
+            handleMoreClick(e);
+          }}
           role="button"
           tabIndex={0}
         >
@@ -111,13 +116,6 @@ function IndexCafeteria() {
           </div>
           <div
             className={styles.menuContainer}
-            onClick={(e) => {
-              if (isMobile) {
-                handleMoreClick(e);
-              }
-            }}
-            role="button"
-            tabIndex={0}
           >
             {선택된_식단 ? 선택된_식단.menu.slice(0, 10).map((menu) => (
               <div className={styles.menu} key={menu}>


### PR DESCRIPTION
- Close #274 

## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->
- 기능 : 모바일 기준으로 navigate동작이 중복으로 처리되는 부분을 해결
- issue : 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--  
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->
- [ ] 모바일에서 식단상세보기를 눌러 상세보기를 조회한 뒤 뒤로가기하면 홈으로 한번에 이동하는가?
## Precaution

<!-- 유의 사항 -->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes
