### PR TITLE
[주변상점] 동일키 참조 문제 해결

### DIFF
--- a/src/api/store/entity.ts
+++ b/src/api/store/entity.ts
@@ -100,6 +100,7 @@ export interface StoreEvent {
 export interface AllStoreEventResponse extends APIResponse {
   events: {
     shop_id: number,
+    event_id: number,
     shop_name: string,
     title: string,
     content: string,

--- a/src/pages/Store/StorePage/components/EventCarousel/index.tsx
+++ b/src/pages/Store/StorePage/components/EventCarousel/index.tsx
@@ -25,7 +25,7 @@ export default function EventCarousel() {
             {carouselList.map((item) => (
               <Link
                 to={`${item.shop_id}`}
-                key={item.shop_id}
+                key={item.event_id}
                 className={styles['swipe-item']}
                 onClick={() => eventLogging(item.shop_name)}
               >


### PR DESCRIPTION
- Close #289 
  
## What is this PR? 🔍

- 기능 : 주변상점 동일키 참조 문제 해결
- issue : #289

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
AllStoreEventResponse 인터페이스에 event_id 속성을 추가하고
주변상점 map 함수의 키를 event_id로 변경하였습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="981" alt="image" src="https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/96577250/8123bfda-a883-4ae6-a5db-655c8d148e29">
에서
<img width="831" alt="image" src="https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/96577250/8f0b2477-5933-431d-8c9d-9f503a6ceb5c">


## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
