### PR TITLE
build: 빌드과정에서 CI=true로 변경되는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI=false && react-scripts build",
     "test": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "lint": "yarn lint:eslint && yarn lint:stylelint",

--- a/src/pages/Timetable/TimetablePage/DefaultPage/DefaultPage.module.scss
+++ b/src/pages/Timetable/TimetablePage/DefaultPage/DefaultPage.module.scss
@@ -33,7 +33,7 @@
 
   &__filter {
     display: flex;
-    justify-content: flex-end;
+    justify-content: end;
     gap: 16px;
     margin-bottom: 14px;
   }


### PR DESCRIPTION
젠킨스 빌드과정에서 autoprefixer의 warning을 에러로 치는문제를 수정합니다.
관련 쓰레드 https://bcsdlab.slack.com/archives/C06PLQTRZDE/p1716044609812629