### PR TITLE
[hotfix] 에러 상태 코드 수정

### DIFF
--- a/src/components/common/Header/hooks/useCheckPassword.ts
+++ b/src/components/common/Header/hooks/useCheckPassword.ts
@@ -16,7 +16,7 @@ const useCheckPassword = () => {
     },
     onError: (err) => {
       if (isKoinError(err)) {
-        if (err.status === 401) {
+        if (err.status === 400) {
           setErrorMessage('비밀번호가 일치하지 않습니다.');
           return;
         }


### PR DESCRIPTION
## Changes 📝
비밀번호 확인 시 api따라 반환 에러 코드를 401로 받던 것을 400으로 수정했습니다.
<!-- 이번 PR에서의 변경점 -->

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
