### PR TITLE
[유저] 회원가입 시 이메일 전체를 적는 경우 에러 분기 처리

### DIFF
--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -48,7 +48,7 @@ export interface ISubmitForm {
 const isRefICustomFormInput = (
   elementRef: HTMLInputElement | ICustomFormInput | null,
 ): elementRef is ICustomFormInput => (elementRef !== null
-&& Object.prototype.hasOwnProperty.call(elementRef, 'valid'));
+  && Object.prototype.hasOwnProperty.call(elementRef, 'valid'));
 
 const useLightweightForm = (submitForm: ISubmitForm) => {
   const refCollection = React.useRef<IFormType>({});
@@ -481,7 +481,9 @@ function SignupDefaultPage() {
               if (value.indexOf('@koreatech.ac.kr') !== -1) {
                 return '계정명은 @koreatech.ac.kr을 빼고 입력해주세요.';
               }
-
+              if (value.indexOf('@') !== -1) {
+                return '이메일의 아이디 부분만 입력해주세요.';
+              }
               return true;
             },
           })}


### PR DESCRIPTION
  ## What is this PR? 🔍

- 기능 : 회원가입 시 이메일 전체를 적는 경우 에러 분기 처리 

## Changes 📝
- `bcsd1234@gmail.com` 처럼 뒤에 이메일 형식이 붙는 경우 `이메일의 아이디 부분만 입력해주세요` 라는 에러 메시지 추가하였습니다.
- 이메일 형식은 `@`로 구분하였습니다.
<!-- 이번 PR에서의 변경점 -->


## ScreenShot 📷
<img width="1480" alt="image" src="https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74540646/c5bdc5c4-7641-4f0b-b355-d76b9e90fb4e">
<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
