### PR TITLE
[시간표] 시간표 늘리기

### DIFF
--- a/src/components/TimetablePage/Timetable/Timetable.module.scss
+++ b/src/components/TimetablePage/Timetable/Timetable.module.scss
@@ -120,6 +120,7 @@
     z-index: 3;
     font-family: NanumSquare, serif;
     box-sizing: border-box;
+    backdrop-filter: blur(10px);
 
     @include media.media-breakpoint(mobile) {
       width: calc((100% - 57px) / 5);

--- a/src/components/TimetablePage/Timetable/Timetable.module.scss
+++ b/src/components/TimetablePage/Timetable/Timetable.module.scss
@@ -120,7 +120,6 @@
     z-index: 3;
     font-family: NanumSquare, serif;
     box-sizing: border-box;
-    backdrop-filter: blur(10px);
 
     @include media.media-breakpoint(mobile) {
       width: calc((100% - 57px) / 5);

--- a/src/components/TimetablePage/Timetable/Timetable.module.scss
+++ b/src/components/TimetablePage/Timetable/Timetable.module.scss
@@ -49,10 +49,15 @@
 
   &__content {
     width: 100%;
-    overflow: hidden;
+    overflow: auto;
     display: inline-flex;
     flex: none;
     position: relative;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    ::-webkit-scrollbar {
+      display: none;
+    }
 
     &--time {
       display: flex;

--- a/src/components/TimetablePage/Timetable/Timetable.module.scss
+++ b/src/components/TimetablePage/Timetable/Timetable.module.scss
@@ -55,6 +55,7 @@
     position: relative;
     -ms-overflow-style: none;
     scrollbar-width: none;
+
     ::-webkit-scrollbar {
       display: none;
     }

--- a/src/components/TimetablePage/Timetable/index.tsx
+++ b/src/components/TimetablePage/Timetable/index.tsx
@@ -64,15 +64,14 @@ function Timetable({
   };
   const findMaxTime = (myTimetableLectures: TimetableDayLectureInfo[][] | undefined) => {
     let maxTime = 19;
-    DAYS_STRING.forEach((day, index) => {
-      if (myTimetableLectures !== undefined) {
-        myTimetableLectures[index].forEach((lecture) => {
-          if (lecture.end > maxTime) {
-            maxTime = lecture.end;
-          }
-        });
-      }
-    });
+    if (myTimetableLectures !== undefined) {
+      const flatedMyLectures = myTimetableLectures.flat();
+      flatedMyLectures.forEach((lecture) => {
+        if (lecture.end > maxTime) {
+          maxTime = lecture.end;
+        }
+      });
+    }
     return maxTime;
   };
   const updateTimeString = (maxTime: number) => {

--- a/src/components/TimetablePage/Timetable/index.tsx
+++ b/src/components/TimetablePage/Timetable/index.tsx
@@ -65,11 +65,13 @@ function Timetable({
   const findMaxTime = (myTimetableLectures: TimetableDayLectureInfo[][] | undefined) => {
     let maxTime = 19;
     DAYS_STRING.forEach((day, index) => {
-      myTimetableLectures![index].forEach((lecture) => {
-        if (lecture.end > maxTime) {
-          maxTime = lecture.end;
-        }
-      });
+      if (myTimetableLectures !== undefined) {
+        myTimetableLectures[index].forEach((lecture) => {
+          if (lecture.end > maxTime) {
+            maxTime = lecture.end;
+          }
+        });
+      }
     });
     return maxTime;
   };

--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -6,16 +6,30 @@ import { ReactComponent as LoadingSpinner } from 'assets/svg/loading-spinner.svg
 import useLogger from 'utils/hooks/useLogger';
 import ErrorBoundary from 'components/common/ErrorBoundary';
 import useMyLectures from 'pages/Timetable/hooks/useMyLectures';
-import { useSemesterAction } from 'utils/zustand/semester';
+import { useSemester, useSemesterAction } from 'utils/zustand/semester';
 import useSemesterOptionList from 'pages/Timetable/hooks/useSemesterOptionList';
+import useLectureList from 'pages/Timetable/hooks/useLectureList';
+import { useTempLecture } from 'utils/zustand/myTempLecture';
 import styles from './IndexTimetable.module.scss';
 
 function CurrentSemesterTimetable(): JSX.Element {
   const { myLectures } = useMyLectures();
   const myLectureDayValue = useTimetableDayList(myLectures);
+  const semester = useSemester();
+  const tempLecture = useTempLecture();
+  const { data: lectureList } = useLectureList(semester);
+  const similarSelectedLecture = lectureList
+    ?.filter((lecture) => lecture.code === tempLecture?.code)
+    ?? [];
+  const selectedLectureIndex = similarSelectedLecture
+    .findIndex(({ lecture_class }) => lecture_class === tempLecture?.lecture_class);
+
+  const similarSelectedLectureDayList = useTimetableDayList(similarSelectedLecture);
   return myLectureDayValue ? (
     <Timetable
       lectures={myLectureDayValue}
+      similarSelectedLecture={similarSelectedLectureDayList}
+      selectedLectureIndex={selectedLectureIndex}
       columnWidth={44}
       firstColumnWidth={29}
       rowHeight={17.3}

--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -6,30 +6,16 @@ import { ReactComponent as LoadingSpinner } from 'assets/svg/loading-spinner.svg
 import useLogger from 'utils/hooks/useLogger';
 import ErrorBoundary from 'components/common/ErrorBoundary';
 import useMyLectures from 'pages/Timetable/hooks/useMyLectures';
-import { useSemester, useSemesterAction } from 'utils/zustand/semester';
+import { useSemesterAction } from 'utils/zustand/semester';
 import useSemesterOptionList from 'pages/Timetable/hooks/useSemesterOptionList';
-import useLectureList from 'pages/Timetable/hooks/useLectureList';
-import { useTempLecture } from 'utils/zustand/myTempLecture';
 import styles from './IndexTimetable.module.scss';
 
 function CurrentSemesterTimetable(): JSX.Element {
   const { myLectures } = useMyLectures();
   const myLectureDayValue = useTimetableDayList(myLectures);
-  const semester = useSemester();
-  const tempLecture = useTempLecture();
-  const { data: lectureList } = useLectureList(semester);
-  const similarSelectedLecture = lectureList
-    ?.filter((lecture) => lecture.code === tempLecture?.code)
-    ?? [];
-  const selectedLectureIndex = similarSelectedLecture
-    .findIndex(({ lecture_class }) => lecture_class === tempLecture?.lecture_class);
-
-  const similarSelectedLectureDayList = useTimetableDayList(similarSelectedLecture);
   return myLectureDayValue ? (
     <Timetable
       lectures={myLectureDayValue}
-      similarSelectedLecture={similarSelectedLectureDayList}
-      selectedLectureIndex={selectedLectureIndex}
       columnWidth={44}
       firstColumnWidth={29}
       rowHeight={17.3}

--- a/src/static/timetable.ts
+++ b/src/static/timetable.ts
@@ -1,3 +1,2 @@
-export const TIME_STRING = ['9', '10', '11', '12', '13', '14', '15', '16', '17', '18'].flatMap((time) => [time, '']);
 export const DAYS_STRING = ['월', '화', '수', '목', '금'];
 export const BACKGROUND_COLOR = ['#ff9100', '#ff9e7d', '#d2691e', '#ff5675', '#ff46c5', '#3dff92', '#2c952c', '#80e12a', '#008c8c', '#00a5ff', '#6495ed', '#0078ff'];


### PR DESCRIPTION
- Close #316 
  
## What is this PR? 🔍

- 기능 : 18시 이후 강의도 볼 수 있습니다.
- issue : #316 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 18시까지만 보여주던 시간표를 18시 이후 강의도 보여질 수 있게 합니다.
- 강의를 추가하거나 강의 시간을 알기 위해 강의를 클릭할 시(검은색 테두리 표시) 강의 시간만큼 시간표가 늘어납니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74342515/11fde8cc-f32c-46fc-b5fb-dd69582a76d9


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
