### PR TITLE
[시간표] 시간표 렌더링 및 시간표 수정시 강의 목록 렌더링 이슈 해결 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,8 +57,8 @@ function App() {
         <Route path="/" element={<BoardPage />}>
           <Route path="/" element={<HelmetWrapper title="코인 - 한기대 커뮤니티" element={<IndexPage />} />} />
           <Route path="timetable" element={<HelmetWrapper title="코인 - 시간표" element={<TimetablePage />} />} />
-          <Route path="timetable/modify/regular" element={<HelmetWrapper title="코인 - 시간표 수정" element={<ModifyTimetablePage />} />} />
-          <Route path="timetable/modify/direct" element={<HelmetWrapper title="코인 - 시간표 수정" element={<ModifyTimetablePage />} />} />
+          <Route path="timetable/modify/regular/:semester" element={<HelmetWrapper title="코인 - 시간표 수정" element={<ModifyTimetablePage />} />} />
+          <Route path="timetable/modify/direct/:semester" element={<HelmetWrapper title="코인 - 시간표 수정" element={<ModifyTimetablePage />} />} />
           <Route path="/store" element={<HelmetWrapper title="코인 - 상점" element={<StorePage />} />} />
           <Route path="/store/:id" element={<HelmetWrapper title="코인 - 상점 상세" element={<StoreDetailPage />} />} />
           <Route path="/bus" element={<HelmetWrapper title="코인 - 버스" element={<BusPage />} />} />

--- a/src/pages/Timetable/ModifyTimetablePage/DefaultPage/index.tsx
+++ b/src/pages/Timetable/ModifyTimetablePage/DefaultPage/index.tsx
@@ -37,7 +37,7 @@ export default function DefaultPage() {
   const handleCourseClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const { value: courseType } = e.currentTarget;
     setSelectedCourseType(courseType);
-    navigate(`/timetable/modify/${courseType}`);
+    navigate(`/timetable/modify/${courseType}/${semester}`);
   };
   return (
     <div className={styles.page}>

--- a/src/pages/Timetable/components/LectureList/index.tsx
+++ b/src/pages/Timetable/components/LectureList/index.tsx
@@ -3,7 +3,7 @@ import LoadingSpinner from 'components/common/LoadingSpinner';
 import { LectureInfo, TimetableLectureInfo } from 'interfaces/Lecture';
 import React from 'react';
 import useTimetableMutation from 'pages/Timetable/hooks/useTimetableMutation';
-import { useSemester } from 'utils/zustand/semester';
+import { useSemester, useSemesterAction } from 'utils/zustand/semester';
 import { useTempLecture, useTempLectureAction } from 'utils/zustand/myTempLecture';
 import useSelect from 'pages/Timetable/hooks/useSelect';
 import showToast from 'utils/ts/showToast';
@@ -12,6 +12,7 @@ import useSearch from 'pages/Timetable/hooks/useSearch';
 import useMyLectures from 'pages/Timetable/hooks/useMyLectures';
 import LectureTable from 'components/TimetablePage/LectureTable';
 import { useUser } from 'utils/hooks/useUser';
+import { useParams } from 'react-router-dom';
 import DeptListbox from './DeptListbox';
 import LastUpdatedDate from './LastUpdatedDate';
 import styles from './LectureList.module.scss';
@@ -95,6 +96,8 @@ function CurrentSemesterLectureList({
 }
 
 function LectureList() {
+  const semesterParams = useParams().semester;
+
   const {
     value: departmentFilterValue,
     onChangeSelect: onChangeDeptSelect,
@@ -103,6 +106,10 @@ function LectureList() {
     onClickSearchButton, onKeyDownSearchInput, value: searchValue, searchInputRef,
   } = useSearch();
   const semester = useSemester();
+  const { updateSemester } = useSemesterAction();
+  updateSemester(semesterParams || '20241');
+  // ur에서 학기 정보를 가져오고 그것으로 store저장 만약 params가 없을 때, 가장 최근의 학기로 설정
+
   const { myLectures } = useMyLectures();
 
   return (

--- a/src/pages/Timetable/components/MyLectureTimetable/index.tsx
+++ b/src/pages/Timetable/components/MyLectureTimetable/index.tsx
@@ -52,7 +52,7 @@ export default function MainTimetable() {
         <button
           type="button"
           className={styles.page__button}
-          onClick={() => navigate('/timetable/modify/regular')}
+          onClick={() => navigate(`/timetable/modify/regular/${semester}`)}
         >
           <EditIcon />
           시간표 수정

--- a/src/pages/Timetable/hooks/useTimetableInfoList.ts
+++ b/src/pages/Timetable/hooks/useTimetableInfoList.ts
@@ -17,7 +17,7 @@ function useTimetableInfoList(
   [string, string]
   >(
     {
-      queryKey: [TIMETABLE_INFO_LIST, semester],
+      queryKey: [TIMETABLE_INFO_LIST, semester + authorization],
       queryFn: () => (authorization && semester ? getTimetableInfo(authorization, semester) : null),
       select: (data) => (data ? data.timetable : undefined),
     },


### PR DESCRIPTION
- Close #331 
  
## What is this PR? 🔍

- 기능 : 
- issue : #331 

## Changes 📝

* 최초 로그인시 시간표 api를 불러오지 않아, 시간표가 보이지 않음

  => api를 부르는 쿼리키에 현재 semester만 요소를 가지고 있었음. semester의 경우 로그인을 하지 않아도 가지고 있던 속성으로 쿼리키가 동일하기에 호출하지 않던 것으로 파악
**`[해결]`**: 쿼리키 인자로 semester + authorization로 설정하여 로그인을 하여 인증 토큰이 생겼을 경우 timetable api를 다시 호출하게 함.

* 시간표 편집 페이지 새로고침 시 강의 목록 사라짐

   => semester를 zustand를 사용해 전역적으로 사용하는 중, 시간표 메인 페이지 -> 편집 페이지로 이동할 때는 semester가 정상적을 store(저장)되지만 편지 상황에서 새로고침을 하면 semester 전역상태가 빈 문자열로 새로고침 되어 api 호출이 정상적으로 작동하지 않음
**`[해결]`**: url에 semester라는 params를 추가하여 store에 set하는 방식을 사용. 
<!-- 이번 PR에서의 변경점 -->



## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution
`시간표 편집 페이지 새로고침 시 강의 목록 사라짐`를 해결하는 과정에서 url에 semester를 달아 해당 값으로 전역 상태 관리 set을 하는 방식을 사용했는데 더 괜찮은 방법이 있다면 코드리뷰 남겨주시면 감사하겠습니다. 현재로는 url방법 뿐이 생각이 나지 않았네요,,

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
