### PR TITLE
[시간표] 시간표 공통 토스트

### DIFF
--- a/src/components/common/Toast/TimetableToast/TimetableToast.module.scss
+++ b/src/components/common/Toast/TimetableToast/TimetableToast.module.scss
@@ -1,0 +1,65 @@
+@keyframes slide-up {
+  0% {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-down {
+  0% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+}
+
+.toast {
+  position: absolute;
+  left: calc(50vw - 446.5px);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 845px;
+  height: 30px;
+  padding: 18px 24px;
+  border-radius: 5px;
+  background-color: #041a44cc;
+  z-index: 5;
+  animation: slide-up 500ms;
+
+  &:hover {
+    button {
+      color: #fff;
+      background-color: #0000004d;
+      border-radius: 5px;
+    }
+  }
+
+  &__close {
+    animation: slide-down 400ms;
+  }
+
+  &__message {
+    color: #fff;
+    font-size: 16px;
+    line-height: 25.6px;
+  }
+
+  &__button {
+    font-size: 16px;
+    color: #f7941e;
+    padding: 4px 16px;
+    border: none;
+    font-weight: 500;
+    line-height: 25.6px;
+  }
+}

--- a/src/components/common/Toast/TimetableToast/index.tsx
+++ b/src/components/common/Toast/TimetableToast/index.tsx
@@ -19,7 +19,7 @@ export default function TimetableToast({
   const [isClicked, setIsClicked] = useState(false);
   const toastRef = useRef<HTMLDivElement | null>(null);
 
-  const [toastProps, isVisible, setIsVisible] = useToastTimer({
+  const [toastProps, isVisible, closeToast] = useToastTimer({
     autoCloseTime: duration,
     onClose,
   });
@@ -36,11 +36,6 @@ export default function TimetableToast({
   const handleRecoverClick = () => {
     setIsClicked(true);
     onRecover();
-  };
-
-  const handleConfirmClick = () => {
-    setIsVisible(false);
-    setTimeout(onClose, 300);
   };
 
   useEffect(() => {
@@ -69,7 +64,7 @@ export default function TimetableToast({
       ) : (
         <>
           <div className={styles.toast__message}>{recoverMessage}</div>
-          <button className={styles.toast__button} type="button" onClick={handleConfirmClick}>확인</button>
+          <button className={styles.toast__button} type="button" onClick={closeToast}>확인</button>
         </>
       )}
     </div>

--- a/src/components/common/Toast/TimetableToast/index.tsx
+++ b/src/components/common/Toast/TimetableToast/index.tsx
@@ -1,0 +1,81 @@
+import { cn } from '@bcsdlab/utils';
+import {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+import useToastTimer from 'utils/hooks/useToastTimer';
+import styles from './TimetableToast.module.scss';
+
+export interface Toast {
+  message: string;
+  recoverMessage: string;
+  onClose: () => void;
+  onRecover: () => void;
+  duration?: number;
+}
+
+export default function TimetableToast({
+  message, recoverMessage, onClose, onRecover, duration = 5000,
+}: Toast) {
+  const [isClicked, setIsClicked] = useState(false);
+  const toastRef = useRef<HTMLDivElement | null>(null);
+
+  const [toastProps, isVisible, setIsVisible] = useToastTimer({
+    autoCloseTime: duration,
+    onClose,
+  });
+
+  const updateToastPosition = useCallback(() => {
+    const toast = toastRef.current;
+    const distanceFromBottom = 32;
+    const scrollPosition = window.scrollY || document.documentElement.scrollTop;
+    if (toast) {
+      toast.style.bottom = `${distanceFromBottom - scrollPosition}px`;
+    }
+  }, []);
+
+  const handleRecoverClick = () => {
+    setIsClicked(true);
+    onRecover();
+  };
+
+  const handleConfirmClick = () => {
+    setIsVisible(false);
+    setTimeout(onClose, 300);
+  };
+
+  useEffect(() => {
+    updateToastPosition();
+    window.addEventListener('scroll', updateToastPosition);
+    return () => {
+      window.removeEventListener('scroll', updateToastPosition);
+    };
+  }, [updateToastPosition]);
+
+  return (
+    <div
+      className={cn({
+        [styles.toast]: true,
+        [styles.toast__close]: !isVisible,
+      })}
+      ref={toastRef}
+      onMouseEnter={toastProps.onMouseEnter}
+      onMouseLeave={toastProps.onMouseLeave}
+    >
+      {!isClicked ? (
+        <>
+          <div className={styles.toast__message}>{message}</div>
+          <button className={styles.toast__button} type="button" onClick={handleRecoverClick}>되돌리기</button>
+        </>
+      ) : (
+        <>
+          <div className={styles.toast__message}>{recoverMessage}</div>
+          <button className={styles.toast__button} type="button" onClick={handleConfirmClick}>확인</button>
+        </>
+      )}
+    </div>
+  );
+}
+
+TimetableToast.defaultProps = {
+  duration: 5000,
+};

--- a/src/components/common/Toast/useToast.tsx
+++ b/src/components/common/Toast/useToast.tsx
@@ -1,0 +1,21 @@
+import useModalPortal from 'utils/hooks/useModalPortal';
+import { Portal } from 'components/common/Modal/PortalProvider';
+import TimetableToast, { Toast } from 'components/common/Toast/TimetableToast';
+
+export default function useToast() {
+  const portalManager = useModalPortal();
+  const open = ({
+    message, recoverMessage, onRecover, duration = 3000,
+  }: Omit<Toast, 'onClose'>) => {
+    portalManager.open((portalOption: Portal) => (
+      <TimetableToast
+        message={message}
+        recoverMessage={recoverMessage}
+        onRecover={onRecover}
+        duration={duration}
+        onClose={portalOption.close}
+      />
+    ));
+  };
+  return { open };
+}

--- a/src/pages/Timetable/ModifyTimetablePage/DefaultPage/index.tsx
+++ b/src/pages/Timetable/ModifyTimetablePage/DefaultPage/index.tsx
@@ -11,6 +11,7 @@ import { ReactComponent as PenIcon } from 'assets/svg/pen-icon.svg';
 import LectureList from 'pages/Timetable/components/LectureList';
 import TotalGrades from 'pages/Timetable/components/TotalGrades';
 import CustomLecture from 'pages/Timetable/components/CustomLecture';
+import useToast from 'components/common/Toast/useToast';
 import { useSemester } from 'utils/zustand/semester';
 import styles from './DefaultPage.module.scss';
 
@@ -28,6 +29,7 @@ export default function DefaultPage() {
     setSelectedCourseType(courseType);
     navigate(`/timetable/modify/${courseType}/${semester}`);
   };
+  const toast = useToast();
   return (
     <div className={styles.page}>
       <TimetableHeader />
@@ -78,7 +80,7 @@ export default function DefaultPage() {
               <div className={styles['page__total-grades']}>
                 <TotalGrades myLectureList={myLectures} />
               </div>
-              <button type="button" className={styles['page__save-button']} onClick={() => navigate('/timetable')}>
+              <button type="button" className={styles['page__save-button']} onClick={() => toast.open({ message: '시간표 저장~', recoverMessage: '시간표 저장되었어요~', onRecover: () => console.log('언두') })}>
                 <PenIcon className={styles['page__pen-icon']} />
                 시간표 저장
               </button>

--- a/src/utils/hooks/useToastTimer.ts
+++ b/src/utils/hooks/useToastTimer.ts
@@ -1,0 +1,56 @@
+import {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+
+interface ToastTimerProps {
+  autoCloseTime: number;
+  onClose: () => void;
+}
+
+export default function useToastTimer({ autoCloseTime, onClose }: ToastTimerProps) {
+  const [isPaused, setIsPaused] = useState(false);
+  const [isVisible, setIsVisible] = useState(true);
+  const timerId = useRef<NodeJS.Timeout | null>(null);
+  const remainingTime = useRef<number>(autoCloseTime);
+  const startTime = useRef<number | null>(null);
+
+  const startTimer = useCallback(() => {
+    startTime.current = Date.now();
+    timerId.current = setTimeout(() => {
+      setIsVisible(false);
+      setTimeout(onClose, 300);
+    }, remainingTime.current);
+  }, [onClose]);
+
+  const pauseTimer = () => {
+    if (timerId.current) {
+      clearTimeout(timerId.current);
+    }
+    if (startTime.current) {
+      const elapsedTime = Date.now() - startTime.current;
+      remainingTime.current -= elapsedTime;
+    }
+    setIsPaused(true);
+  };
+
+  const resumeTimer = useCallback(() => {
+    setIsPaused(false);
+    startTimer();
+  }, [startTimer]);
+
+  const toastProps = {
+    onMouseEnter: pauseTimer,
+    onMouseLeave: resumeTimer,
+  };
+
+  useEffect(() => {
+    startTimer();
+    return () => {
+      if (timerId.current) {
+        clearTimeout(timerId.current);
+      }
+    };
+  }, [startTimer]);
+
+  return [toastProps, isVisible, setIsVisible, isPaused] as const;
+}

--- a/src/utils/hooks/useToastTimer.ts
+++ b/src/utils/hooks/useToastTimer.ts
@@ -43,6 +43,14 @@ export default function useToastTimer({ autoCloseTime, onClose }: ToastTimerProp
     onMouseLeave: resumeTimer,
   };
 
+  const closeToast = () => {
+    if (timerId.current) {
+      clearTimeout(timerId.current);
+    }
+    setIsVisible(false);
+    setTimeout(onClose, 300);
+  };
+
   useEffect(() => {
     startTimer();
     return () => {
@@ -52,5 +60,5 @@ export default function useToastTimer({ autoCloseTime, onClose }: ToastTimerProp
     };
   }, [startTimer]);
 
-  return [toastProps, isVisible, setIsVisible, isPaused] as const;
+  return [toastProps, isVisible, closeToast, isPaused] as const;
 }


### PR DESCRIPTION
- Close #330  
## What is this PR? 🔍

- 기능 : 시간표 공통 토스트
- issue : #330

## Changes 📝
- 시간표 공통 토스트를 만들었습니다.
- hover 시 시간이 멈추도록 했습니다.
- 되돌아가기 버튼에 대한 이벤트를 인자로 받도록 했습니다.
사용법은 다음과 같습니다.
``` ts
  const toast = useToast();
  toast.open({ message: '시간표 저장~', recoverMessage: '시간표 저장되었어요~', onRecover: () => console.log('언두') })
```
반드시 넣어야 하는 속성은 `message`, `recoverMessage`, `onRecover` 입니다.

<!-- 이번 PR에서의 변경점 -->



## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

https://github.com/BCSDLab/KOIN_WEB_RECODE/assets/74540646/057a78aa-0a3c-430d-b2c0-30fe423bf5d3



## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution
`시간표 저장` 버튼에 테스트로 넣어 놓았습니다! 머지할 때는 없앨 예정입니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
