### PR TITLE
feat: 시간표 강의 정보 api 연결

### DIFF
--- a/src/api/timetable/APIDetail.ts
+++ b/src/api/timetable/APIDetail.ts
@@ -14,6 +14,10 @@ import {
   TimetableFrameListResponse,
   AddTimetableFrameResponse,
   DeleteTimetableFrameResponse,
+  TimetableLectureInfoV2Response,
+  AddTimetableLectureV2Request,
+  UpdateTimetableLectureV2Request,
+  DeleteTimetableLectureV2Request,
 } from './entity';
 
 export class LectureList<R extends LectureInfoResponse> implements APIRequest<R> {
@@ -188,5 +192,71 @@ export class DeleteTimetableFrame<R extends DeleteTimetableFrameResponse> implem
     this.params = {
       id,
     };
+  }
+}
+export class TimetableLectureInfoV2
+  <R extends TimetableLectureInfoV2Response> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path = '/v2/timetables/lecture';
+
+  response!: R;
+
+  auth = true;
+
+  params: {
+    [index: string]: number;
+  };
+
+  constructor(public authorization: string, timeTableFrameId: number) {
+    this.params = {
+      timetable_frame_id: timeTableFrameId,
+    };
+  }
+}
+
+export class AddTimetableLectureV2
+  <R extends TimetableLectureInfoV2Response> implements APIRequest<R> {
+  method = HTTP_METHOD.POST;
+
+  path = '/v2/timetables/lecture';
+
+  response!: R;
+
+  auth = true;
+
+  constructor(public data: AddTimetableLectureV2Request, public authorization: string) {}
+}
+
+export class UpdateTimetableLectureV2
+  <R extends TimetableLectureInfoV2Response> implements APIRequest<R> {
+  method = HTTP_METHOD.PUT;
+
+  path = '/v2/timetables/lecture';
+
+  response!: R;
+
+  auth = true;
+
+  constructor(public data: UpdateTimetableLectureV2Request, public authorization: string) {}
+}
+
+export class DeleteTimetableLectureV2
+  <R extends TimetableLectureInfoV2Response> implements APIRequest<R> {
+  method = HTTP_METHOD.DELETE;
+
+  path = '/v2/timetables/lecture/:id';
+
+  response!: R;
+
+  auth = true;
+
+  constructor(
+    public authorization: string,
+    public id: number,
+    public data: DeleteTimetableLectureV2Request,
+  ) {
+    this.path = `/v2/timetables/frame/${id}`;
+    this.data = data;
   }
 }

--- a/src/api/timetable/entity.ts
+++ b/src/api/timetable/entity.ts
@@ -71,3 +71,57 @@ export interface UpdateTimetableFrameRequest {
 }
 
 export interface DeleteTimetableFrameResponse extends APIResponse { }
+
+export interface TimetableLectureInfoV2Response extends APIResponse {
+  '시간표프레임 id': number;
+  '시간표 상세정보': TimetableDetailInfo[];
+  '해당 학기 학점': number;
+  '전체 학기 학점': number;
+}
+
+export interface TimetableDetailInfo {
+  '시간표 id': number;
+  '수강 정원': string;
+  '과목 코드': string;
+  design_score: string;
+  class_time: number[];
+  class_place: string;
+  memo: string;
+  '학점': string;
+  '강의(커스텀) 이름': string;
+  '분반': string;
+  '대상': string;
+  '강의 교수': string;
+  '학부': string;
+}
+
+export interface AddTimetableLectureV2Request {
+  timetable_frame_id: number;
+  timetable_lecture: [{
+    class_title: string;
+    class_time: number[];
+    class_place: string;
+    professor: string;
+    grades: string;
+    memo: string;
+    lecture_id: number;
+  }];
+}
+
+export interface UpdateTimetableLectureV2Request {
+  timetable_frame_id: number;
+  timetable_lecture: [{
+    id: number;
+    lecture_id: number;
+    class_title: string;
+    class_time: number[];
+    class_place: string;
+    '강의 교수': string;
+    grades: string;
+    memo: string;
+  }];
+}
+
+export interface DeleteTimetableLectureV2Request {
+  id: number;
+}

--- a/src/api/timetable/index.ts
+++ b/src/api/timetable/index.ts
@@ -11,6 +11,7 @@ import {
   AddTimetableFrame,
   UpdateTimetableFrame,
   DeleteTimetableFrame,
+  TimetableLectureInfoV2,
 } from './APIDetail';
 
 export const getLectureList = APIClient.of(LectureList);
@@ -34,3 +35,5 @@ export const addTimetableFrame = APIClient.of(AddTimetableFrame);
 export const updateTimetableFrame = APIClient.of(UpdateTimetableFrame);
 
 export const deleteTimetableFrame = APIClient.of(DeleteTimetableFrame);
+
+export const getTimetableLectureInfoV2 = APIClient.of(TimetableLectureInfoV2);

--- a/src/pages/Timetable/ModifyTimetablePage/DefaultPage/index.tsx
+++ b/src/pages/Timetable/ModifyTimetablePage/DefaultPage/index.tsx
@@ -69,8 +69,8 @@ export default function DefaultPage() {
             {isRegularCourseSelected ? (
               <LectureList />
             ) : (
-              <CustomLecture />
-              // <div>직접 추가 UI</div>
+            // V2 데이터로 변경 및 fraomId 넣어줘야합니다.
+              <CustomLecture frameId={2058} />
             )}
           </div>
           <div className={styles.page__timetable}>

--- a/src/pages/Timetable/components/CustomLecture/index.tsx
+++ b/src/pages/Timetable/components/CustomLecture/index.tsx
@@ -1,16 +1,23 @@
 import { ReactComponent as AddIcon } from 'assets/svg/add-icon.svg';
+import useTokenState from 'utils/hooks/useTokenState';
+import useTimetableV2InfoList from 'pages/Timetable/hooks/useTimetableV2InfoList';
 import styles from './CustomLecture.module.scss';
 import CustomLectureDefaultInput from './CustomLectureDefaultInput';
 import CustomLectureLocationTimeSetting from './CustomLectureLocationTimeSetting';
 
-function CustomLecture() {
-  const handleAddLecture = () => {
-
+function CustomLecture({ frameId }: { frameId: number }) {
+  const handleAddLecture = (e: any) => {
+    e.preventDefault();
   };
+
+  const token = useTokenState();
+  const { data: timetableInfoList } = useTimetableV2InfoList(frameId, token);
+
+  console.log('dlddld', timetableInfoList);
 
   // 해당 파트의 api 명세가 어떻게 나오느냐에 따라 html 구조의 변동이 있을 수 있을 것 같습니다.
   return (
-    <form onSubmit={handleAddLecture} className={styles['form-container']}>
+    <form onSubmit={(e) => handleAddLecture(e)} className={styles['form-container']}>
       <CustomLectureDefaultInput title="수업명" placeholder="수업명을 입력하세요." require />
       <CustomLectureDefaultInput title="교수명" placeholder="교수명을 입력하세요." require={false} />
       <CustomLectureLocationTimeSetting />
@@ -18,6 +25,7 @@ function CustomLecture() {
         <span>시간 및 장소 추가</span>
         <AddIcon />
       </button>
+      <button type="submit" className={styles['submit-button']}>일정 저장</button>
     </form>
   );
 }

--- a/src/pages/Timetable/components/CustomLecture/index.tsx
+++ b/src/pages/Timetable/components/CustomLecture/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ReactComponent as AddIcon } from 'assets/svg/add-icon.svg';
 import useTokenState from 'utils/hooks/useTokenState';
 import useTimetableV2InfoList from 'pages/Timetable/hooks/useTimetableV2InfoList';

--- a/src/pages/Timetable/components/CustomLecture/index.tsx
+++ b/src/pages/Timetable/components/CustomLecture/index.tsx
@@ -7,7 +7,7 @@ import CustomLectureDefaultInput from './CustomLectureDefaultInput';
 import CustomLectureLocationTimeSetting from './CustomLectureLocationTimeSetting';
 
 function CustomLecture({ frameId }: { frameId: number }) {
-  const handleAddLecture = (e: any) => {
+  const handleAddLecture = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
   };
 

--- a/src/pages/Timetable/hooks/useTimetableV2InfoList.ts
+++ b/src/pages/Timetable/hooks/useTimetableV2InfoList.ts
@@ -1,0 +1,26 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getTimetableLectureInfoV2 } from 'api/timetable';
+import { TimetableLectureInfoV2Response } from 'api/timetable/entity';
+import { KoinError } from 'interfaces/APIError';
+// import { TimetableLectureInfo } from 'interfaces/Lecture';
+
+export const TIMETABLE_INFO_V2_LIST = 'TIMETABLE_INFO_V2_LIST';
+
+function useTimetableV2InfoList(
+  timetableFrameId: number,
+  authorization: string,
+) {
+  const { data: timetableV2InfoList } = useSuspenseQuery<
+  TimetableLectureInfoV2Response | null,
+  KoinError
+  >(
+    {
+      queryKey: [TIMETABLE_INFO_V2_LIST, timetableFrameId + authorization],
+      queryFn: () => (authorization && timetableFrameId
+        ? getTimetableLectureInfoV2(authorization, timetableFrameId) : null),
+    },
+  );
+  return { data: timetableV2InfoList };
+}
+
+export default useTimetableV2InfoList;


### PR DESCRIPTION
- Close #373
  
## What is this PR? 🔍

- 기능 : 시간표 강의 정보관련 api 연결
- issue : #373 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

시간표 강의 정보 관련 api를 추가했습니다. 

api 및 시간표 직접 수정 기능까지 이번 PR에서 다루려고 했으나, 
기능상으로 시간표의 프레임에 따른 시간표 UI 변경 기능을 먼저 수정해야 할 것 같아 api 만 추가 하였습니다. 
위의 기능 개발 후에 새로운 feature 로 이어 작업하도록 하겠습니다. 



## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] api 연결

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
