### PR TITLE
[유저] 유저팀 로깅 수정, 공통 로그 수정

### DIFF
--- a/src/components/TimetablePage/Listbox/index.tsx
+++ b/src/components/TimetablePage/Listbox/index.tsx
@@ -31,11 +31,11 @@ function Listbox({
   const logger = useLogger();
   const handleLogClick = (optionValue: string) => {
     if (logTitle === 'select_dept') {
-      logger.actionEventClick({ actionTitle: 'USER', title: 'timetable', value: `click_${optionValue}` });
+      logger.actionEventClick({ actionTitle: 'USER', title: 'timetable', value: `click_curriculum_${optionValue}` });
       return;
     }
     if (logTitle === 'select_semester') {
-      logger.actionEventClick({ actionTitle: 'USER', title: 'timetable', value: `click_${optionValue}` });
+      logger.actionEventClick({ actionTitle: 'USER', title: 'timetable', value: `click_semester_${optionValue}` });
     }
   };
 

--- a/src/components/common/Header/MobileHeader/Panel/index.tsx
+++ b/src/components/common/Header/MobileHeader/Panel/index.tsx
@@ -35,8 +35,17 @@ export default function Panel({ openModal }: PanelProps) {
   };
 
   // 기존 페이지에서 햄버거를 통해 다른 페이지로 이동할 때의 로그입니다.
-  const logExitExistingPage = () => {
-    if (pathname === '/timetable') logger.actionEventClick({ actionTitle: 'USER', title: 'timetable_back', value: '햄버거' });
+  const logExitExistingPage = (title: string) => {
+    if (pathname === '/timetable') {
+      logger.actionEventClick({
+        actionTitle: 'USER',
+        title: 'timetable_back',
+        value: '햄버거',
+        previous_page: '시간표',
+        current_page: title,
+        duration_time: (new Date().getTime() - Number(sessionStorage.getItem('enterTimetablePage'))) / 1000,
+      });
+    }
   };
 
   const handleMyInfoClick = () => {
@@ -55,7 +64,7 @@ export default function Panel({ openModal }: PanelProps) {
 
   const handleSubmenuClick = (submenu: Submenu) => {
     logShortcut(submenu.title);
-    logExitExistingPage();
+    logExitExistingPage(submenu.title);
     closeSidebar();
     if (submenu.openInNewTab) {
       window.open(submenu.link, '_blank');

--- a/src/components/common/Header/MobileHeader/Panel/index.tsx
+++ b/src/components/common/Header/MobileHeader/Panel/index.tsx
@@ -44,7 +44,7 @@ export default function Panel({ openModal }: PanelProps) {
       logger.actionEventClick({
         actionTitle: 'USER',
         title: 'hamburger',
-        value: '정보수정',
+        value: '내정보',
       });
       closeSidebar();
       openModal();

--- a/src/components/common/Header/MobileHeader/index.tsx
+++ b/src/components/common/Header/MobileHeader/index.tsx
@@ -36,6 +36,16 @@ export default function MobileHeader({ openModal }: MobileHeaderProps) {
         actionTitle: 'BUSINESS', title: 'shop_detail_view_back', value: response.name, event_category: 'click',
       }); // 상점 내 뒤로가기 버튼 로깅
     }
+    if (pathname === '/timetable') {
+      logger.actionEventClick({
+        actionTitle: 'USER',
+        title: 'timetable_back',
+        value: '뒤로가기버튼',
+        previous_page: '시간표',
+        current_page: '메인',
+        duration_time: (new Date().getTime() - Number(sessionStorage.getItem('enterTimetablePage'))) / 1000,
+      });
+    }
   };
 
   const handleHamburgerClick = () => {

--- a/src/pages/TimetablePage/DefaultPage/index.tsx
+++ b/src/pages/TimetablePage/DefaultPage/index.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable no-restricted-globals */
 /* eslint-disable no-restricted-imports */
 import LoadingSpinner from 'components/common/LoadingSpinner';
 import React, { Suspense } from 'react';
+import useLogger from 'utils/hooks/analytics/useLogger';
 import Curriculum from '../components/Curriculum';
 import LectureList from '../components/LectureList';
 import MyLectureList from '../components/MyLectureList';
@@ -8,6 +10,37 @@ import MyLectureTimetable from '../components/MyLectureTimetable';
 import styles from './DefaultPage.module.scss';
 
 export default function DefaultPage() {
+  const logger = useLogger();
+  const isClickedFirst = React.useRef(false);
+  const handlePopState = React.useCallback(() => {
+    history.back();
+    sessionStorage.removeItem('timetableVisited');
+    logger.actionEventClick({
+      actionTitle: 'USER',
+      title: 'timetable_back',
+      value: '뒤로가기버튼',
+      previous_page: '시간표',
+      current_page: '메인',
+      duration_time: (new Date().getTime() - Number(sessionStorage.getItem('enterTimetablePage'))) / 1000,
+    });
+  }, [logger]);
+
+  React.useEffect(() => {
+    const hasVisited = sessionStorage.getItem('timetableVisited');
+    if (!hasVisited) {
+      history.pushState({ state: 'timetable' }, '');
+      sessionStorage.setItem('timetableVisited', 'true');
+      isClickedFirst.current = true;
+    }
+  }, []);
+
+  React.useEffect(() => {
+    window.addEventListener('popstate', handlePopState);
+    return (() => {
+      window.removeEventListener('popstate', handlePopState);
+    });
+  }, [handlePopState]);
+
   return (
     <>
       <h1 className={styles.page__title}>시간표</h1>

--- a/src/pages/TimetablePage/DefaultPage/index.tsx
+++ b/src/pages/TimetablePage/DefaultPage/index.tsx
@@ -13,7 +13,19 @@ export default function DefaultPage() {
   const logger = useLogger();
   const handlePopState = React.useCallback(() => {
     history.back();
-    sessionStorage.removeItem('timetableVisited');
+    // swipe로 뒤로가기 시
+    if (sessionStorage.getItem('swipeToBack') === 'true') {
+      logger.actionEventSwipe({
+        actionTitle: 'USER',
+        title: 'timetable_back',
+        value: 'OS스와이프',
+        previous_page: '시간표',
+        current_page: '메인',
+        duration_time: (new Date().getTime() - Number(sessionStorage.getItem('enterTimetablePage'))) / 1000,
+      });
+      return;
+    }
+    // 브라우저의 뒤로가기 버튼 클릭 시 / 마우스 사이드 버튼 누를 시
     logger.actionEventClick({
       actionTitle: 'USER',
       title: 'timetable_back',
@@ -36,6 +48,20 @@ export default function DefaultPage() {
       window.removeEventListener('popstate', handlePopState);
     });
   }, [handlePopState]);
+
+  React.useEffect(() => {
+    sessionStorage.setItem('swipeToBack', 'false');
+    const handleWheel = (e: WheelEvent) => {
+      // 한 번에 최소 100px만큼 스크롤(드래그) 시 swipe했다고 간주
+      if (e.deltaX < -100) {
+        sessionStorage.setItem('swipeToBack', 'true');
+      }
+    };
+    window.addEventListener('wheel', handleWheel);
+    return () => {
+      window.removeEventListener('wheel', handleWheel);
+    };
+  }, []);
 
   return (
     <>

--- a/src/pages/TimetablePage/DefaultPage/index.tsx
+++ b/src/pages/TimetablePage/DefaultPage/index.tsx
@@ -11,7 +11,6 @@ import styles from './DefaultPage.module.scss';
 
 export default function DefaultPage() {
   const logger = useLogger();
-  const isClickedFirst = React.useRef(false);
   const handlePopState = React.useCallback(() => {
     history.back();
     sessionStorage.removeItem('timetableVisited');
@@ -26,11 +25,8 @@ export default function DefaultPage() {
   }, [logger]);
 
   React.useEffect(() => {
-    const hasVisited = sessionStorage.getItem('timetableVisited');
-    if (!hasVisited) {
+    if (history.state.state !== 'timetable') {
       history.pushState({ state: 'timetable' }, '');
-      sessionStorage.setItem('timetableVisited', 'true');
-      isClickedFirst.current = true;
     }
   }, []);
 

--- a/src/pages/TimetablePage/MobilePage/index.tsx
+++ b/src/pages/TimetablePage/MobilePage/index.tsx
@@ -24,6 +24,7 @@ function MobilePage() {
       actionTitle: 'USER',
       title: 'timetable',
       value: '이미지저장',
+      duration_time: (new Date().getTime() - Number(sessionStorage.getItem('enterTimetablePage'))) / 1000,
     });
     onTimetableImageDownload('my-timetable');
   };

--- a/src/pages/TimetablePage/components/Curriculum.tsx
+++ b/src/pages/TimetablePage/components/Curriculum.tsx
@@ -20,11 +20,12 @@ function Curriculum() {
                 <a
                   className={styles.page__curriculum}
                   href={dept.curriculum_link}
+                  target="_blank"
                   onClick={() => {
                     logger.actionEventClick({
                       actionTitle: 'USER',
                       title: 'timetable',
-                      value: `click_${dept.name}`,
+                      value: `click_curriculum_${dept.name}`,
                     });
                   }}
                   rel="noreferrer"
@@ -37,11 +38,12 @@ function Curriculum() {
               <a
                 className={styles.page__curriculum}
                 href="https://www.koreatech.ac.kr/board.es?mid=a10103010000&bid=0002"
+                target="_blank"
                 onClick={() => {
                   logger.actionEventClick({
                     actionTitle: 'USER',
                     title: 'timetable',
-                    value: 'click_대학요람',
+                    value: 'click_curriculum_대학요람',
                   });
                 }}
                 rel="noreferrer"

--- a/src/pages/TimetablePage/components/MyLectureTimetable/index.tsx
+++ b/src/pages/TimetablePage/components/MyLectureTimetable/index.tsx
@@ -44,6 +44,7 @@ export default function MyLectureTimetable() {
               actionTitle: 'USER',
               title: 'timetable',
               value: '이미지저장',
+              duration_time: (new Date().getTime() - Number(sessionStorage.getItem('enterTimetablePage'))) / 1000,
             });
           }}
         >

--- a/src/pages/TimetablePage/index.tsx
+++ b/src/pages/TimetablePage/index.tsx
@@ -9,6 +9,7 @@ import DefaultPage from './DefaultPage';
 function TimetablePage() {
   const isMobile = useMediaQuery();
   useScrollToTop();
+  sessionStorage.setItem('enterTimetablePage', new Date().getTime().toString());
 
   return (
     <div className={styles.page}>

--- a/src/utils/hooks/analytics/useLogger.ts
+++ b/src/utils/hooks/analytics/useLogger.ts
@@ -10,7 +10,7 @@ type ScrollLoggerProps = {
   title: string,
 };
 
-type ActionClickLoggerProps = {
+type ActionLoggerProps = {
   actionTitle: string,
   title: string,
   value: string,
@@ -84,9 +84,22 @@ const useLogger = () => {
     duration_time,
     previous_page,
     current_page,
-  }: ActionClickLoggerProps) => {
+  }: ActionLoggerProps) => {
     logEvent({
-      action: actionTitle, category: 'button', label: title, value, duration_time, previous_page, current_page,
+      action: actionTitle, category: 'click', label: title, value, duration_time, previous_page, current_page,
+    });
+  };
+
+  const actionEventSwipe = ({
+    actionTitle,
+    title,
+    value,
+    duration_time,
+    previous_page,
+    current_page,
+  }: ActionLoggerProps) => {
+    logEvent({
+      action: actionTitle, category: 'swipe', label: title, value, duration_time, previous_page, current_page,
     });
   };
 
@@ -94,6 +107,7 @@ const useLogger = () => {
     click,
     scroll,
     actionEventClick,
+    actionEventSwipe,
   };
 };
 


### PR DESCRIPTION
- Close #424 
  
## What is this PR? 🔍

- 기능 : 로깅 관련 수정 사항 수정하고, 뒤로가기 로그 추가했습니다.
 추가로 `actionEventClick`의 `category`가 `button`인 부분을 `click`으로 수정했습니다.
- issue : #424 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 브라우저 내장 뒤로가기 버튼 클릭 시 로그 추가
- 웹에서 스와이프를 통한 뒤로가기 시 로그 추가


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
- 뒤로가기 클릭 시

https://github.com/user-attachments/assets/3b7fae1e-d829-4181-8881-ad4989470662

- 스와이프로 뒤로가기 시

https://github.com/user-attachments/assets/219baeb7-fd34-4d39-af65-7842f1d5adf7



<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] `pushState`나 `popstate` 때문인 것 같은데 `앞으로가기`나 `뒤로가기`로 시간표 페이지 이동 후에 다시 뒤로 가면 코인 페이지에 로드 되기 전 페이지로 이동함. stage에서도 그러는지 확인해봐야 함. 
 페이지 이동 후 페이지 아무 곳 클릭하면 정상 작동함.
- 비정상 작동 화면

https://github.com/user-attachments/assets/e18097ad-1ae3-4a02-930f-cb9f76c7eb19



- 정상 작동 화면(페이지 한 번 클릭 후 뒤로가기)

https://github.com/user-attachments/assets/935fce23-07d3-43d4-ac58-88f8794e0231




## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
