### PR TITLE
[비즈니스] 리뷰 필터버튼이 on 될때만 로깅되도록 수정

### DIFF
--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -190,12 +190,17 @@ function StorePage() {
         ...prevState,
         sorter: item,
       }));
-      logger.actionEventClick({
-        actionTitle: 'BUSINESS',
-        title: 'shop_can',
-        value: loggingCategoryToggleValue(item, categories?.shop_categories[selectedCategory].name),
-        event_category: 'click',
-      });
+      if (storeMobileFilterState.sorter !== item) {
+        logger.actionEventClick({
+          actionTitle: 'BUSINESS',
+          title: 'shop_can',
+          value: loggingCategoryToggleValue(
+            item,
+            categories?.shop_categories[selectedCategory]?.name,
+          ),
+          event_category: 'click',
+        });
+      }
     } else if (item === 'DELIVERY' || item === 'OPEN') {
       setStoreMobileFilterState((prevState) => {
         const newFilter = prevState.filter.includes(item)
@@ -206,14 +211,21 @@ function StorePage() {
           filter: newFilter,
         };
       });
-      logger.actionEventClick({
-        actionTitle: 'BUSINESS',
-        title: 'shop_can',
-        value: loggingCategoryToggleValue(item, categories?.shop_categories[selectedCategory].name),
-        event_category: 'click',
-      });
+      // 현재상태와 바뀔 상태를 비교해서 토글이 on 되는지 판단함
+      if (!storeMobileFilterState.filter.includes(item)) {
+        logger.actionEventClick({
+          actionTitle: 'BUSINESS',
+          title: 'shop_can',
+          value: loggingCategoryToggleValue(
+            item,
+            categories?.shop_categories[selectedCategory]?.name,
+          ),
+          event_category: 'click',
+        });
+      }
     }
   };
+
   useScrollToTop();
   const storeScrollLogging = () => {
     const currentCategoryId = searchParams.get('category') === undefined ? 0 : Number(searchParams.get('category')) - 1;

--- a/src/utils/hooks/analytics/useLogger.ts
+++ b/src/utils/hooks/analytics/useLogger.ts
@@ -45,19 +45,8 @@ const useLogger = () => {
     const event = {
       action, category, label, value, duration_time, previous_page, current_page,
     };
-    if (
-      !prevEvent.current
-      || prevEvent.current.action !== action
-      || prevEvent.current.category !== category
-      || prevEvent.current.label !== label
-      || prevEvent.current.value !== value
-      || prevEvent.current.duration_time !== duration_time
-      || prevEvent.current.previous_page !== previous_page
-      || prevEvent.current.current_page !== current_page
-    ) {
-      gtag.event(event);
-      prevEvent.current = event;
-    }
+    gtag.event(event);
+    prevEvent.current = event;
   };
 
   const click = ({


### PR DESCRIPTION

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
기존에는 필터, 정렬 버튼을 누를때마다 로깅되었는데, 토글 on될때마다 로깅되도록 수정했습니다 (da 요청사항)


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
