### PR TITLE
[비즈니스][상점 상세] 상점 상세 페이지 메뉴 사진 여러개 UI 에러 현상 수정

### DIFF
--- a/src/pages/Store/StoreDetailPage/MenuTable/MenuTable.module.scss
+++ b/src/pages/Store/StoreDetailPage/MenuTable/MenuTable.module.scss
@@ -67,7 +67,7 @@
 .menu-info {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  padding: 20px;
+  padding: 20px 0;
   border-bottom: 1px solid #eee;
   gap: 10px;
 
@@ -115,6 +115,7 @@
 
 .image {
   display: flex;
+  justify-content: center;
 
   &__button {
     border: none;
@@ -126,6 +127,31 @@
       border-radius: 5px;
       width: 75px;
       height: 80px;
+    }
+  }
+}
+
+.empty-image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 5px;
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #f5f5f5;
+    width: 68px;
+    height: 68px;
+
+    svg {
+      width: 23px;
+      height: 23px;
+    }
+
+    @include media.media-breakpoint(mobile) {
+      width: 75px;
     }
   }
 }

--- a/src/pages/Store/StoreDetailPage/MenuTable/index.tsx
+++ b/src/pages/Store/StoreDetailPage/MenuTable/index.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import { MenuCategory } from 'api/store/entity';
 import { cn } from '@bcsdlab/utils';
+import { ReactComponent as EmptyImageIcon } from 'assets/svg/empty-thumbnail.svg';
 import MENU_CATEGORY from 'static/menu';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import styles from './MenuTable.module.scss';
@@ -28,7 +29,6 @@ function MenuTable({ storeMenuCategories, onClickImage }: MenuTableProps) {
       }
     });
   };
-
   useEffect(() => {
     storeMenuCategories.forEach((menu) => {
       const element = document.getElementById(menu.name);
@@ -97,6 +97,23 @@ function MenuTable({ storeMenuCategories, onClickImage }: MenuTableProps) {
           {menuCategories.menus.map((menu) => (
             menu.option_prices === null ? (
               <div className={styles['menu-info']} key={menu.id}>
+                {menu.image_urls.length > 0 ? (
+                  <div key={`${menu.id}`} className={styles.image}>
+                    <button
+                      className={styles.image__button}
+                      type="button"
+                      onClick={() => onClickImage(menu.image_urls, 0)}
+                    >
+                      <img src={`${menu.image_urls[0]}`} alt={`${menu.name}`} />
+                    </button>
+                  </div>
+                ) : (
+                  <div className={styles['empty-image']}>
+                    <div>
+                      <EmptyImageIcon />
+                    </div>
+                  </div>
+                )}
                 <div className={styles['menu-info__card']}>
                   <span title={menu.name}>{menu.name}</span>
                   <span>
@@ -106,23 +123,25 @@ function MenuTable({ storeMenuCategories, onClickImage }: MenuTableProps) {
                     원
                   </span>
                 </div>
-                {menu.image_urls.length > 0 ? (
-                  menu.image_urls.map((img, idx) => (
-                    <div key={`${img}`} className={styles.image}>
-                      <button
-                        className={styles.image__button}
-                        type="button"
-                        onClick={() => onClickImage(menu.image_urls, idx)}
-                      >
-                        <img src={`${img}`} alt={`${menu.name}`} />
-                      </button>
-                    </div>
-                  )))
-                  : null}
               </div>
             ) : (
               menu.option_prices.map((item) => (
                 <div className={styles['menu-info']} key={menu.id + item.option + item.price}>
+                  {menu.image_urls.length > 0 ? (
+                    <div key={`${menu.id}`} className={styles.image}>
+                      <button
+                        className={styles.image__button}
+                        type="button"
+                        onClick={() => onClickImage(menu.image_urls, 0)}
+                      >
+                        <img src={`${menu.image_urls[0]}`} alt={`${menu.name}`} />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className={styles['empty-image']}>
+                      <EmptyImageIcon />
+                    </div>
+                  )}
                   <div className={styles['menu-info__card']}>
                     <span>{`${menu.name} - ${item.option}`}</span>
                     <span>
@@ -130,19 +149,6 @@ function MenuTable({ storeMenuCategories, onClickImage }: MenuTableProps) {
                       원
                     </span>
                   </div>
-                  {menu.image_urls.length > 0 ? (
-                    menu.image_urls.map((img, idx) => (
-                      <div key={`${img}`} className={styles.image}>
-                        <button
-                          className={styles.image__button}
-                          type="button"
-                          onClick={() => onClickImage(menu.image_urls, idx)}
-                        >
-                          <img src={`${img}`} alt={`${menu.name}`} />
-                        </button>
-                      </div>
-                    )))
-                    : null}
                 </div>
               ))
             )

--- a/src/pages/Store/StoreDetailPage/index.tsx
+++ b/src/pages/Store/StoreDetailPage/index.tsx
@@ -49,7 +49,7 @@ function StoreDetailPage() {
   const { data } = useGetReview(Number(params.id), 'LATEST');
   const setButtonContent = useHeaderButtonStore((state) => state.setButtonContent);
   const koreanCategory = storeDetail.shop_categories.filter((category) => category.name !== '전체보기')[0].name;
-
+  console.log(storeMenuCategories);
   const onClickCallNumber = () => {
     if (param.get('state') === '리뷰' && sessionStorage.getItem('enterReviewPage')) {
       logger.actionEventClick({

--- a/src/pages/Store/StoreDetailPage/index.tsx
+++ b/src/pages/Store/StoreDetailPage/index.tsx
@@ -49,7 +49,7 @@ function StoreDetailPage() {
   const { data } = useGetReview(Number(params.id), 'LATEST');
   const setButtonContent = useHeaderButtonStore((state) => state.setButtonContent);
   const koreanCategory = storeDetail.shop_categories.filter((category) => category.name !== '전체보기')[0].name;
-  console.log(storeMenuCategories);
+
   const onClickCallNumber = () => {
     if (param.get('state') === '리뷰' && sessionStorage.getItem('enterReviewPage')) {
       logger.actionEventClick({


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
* 상점 메뉴에서 이미지가 여러개 있는 경우에 대한 에러를 수정하였습니다.
* 이미지가 없는 경우에는 Empty-icon을 활용하여 없음을 표기했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="364" alt="image" src="https://github.com/user-attachments/assets/fb8caca4-ad6c-455e-8f03-1804d11a8315">

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
