### PR TITLE
[시간표] 새로고침 시 학기 데이터 날라감 수정

### DIFF
--- a/src/utils/zustand/semester.ts
+++ b/src/utils/zustand/semester.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 type State = {
   semester: string
@@ -10,12 +11,20 @@ type Action = {
   }
 };
 
-const useSemesterStore = create<State & Action>((set) => ({
-  semester: '',
-  action: {
-    updateSemester: (semester) => set(() => ({ semester })),
-  },
-}));
+const useSemesterStore = create(
+  persist<State & Action>(
+    (set) => ({
+      semester: '',
+      action: {
+        updateSemester: (semester) => set(() => ({ semester })),
+      },
+    }),
+    {
+      name: 'semester',
+      partialize: (state) => ({ semester: state.semester }) as State & Action,
+    },
+  ),
+);
 
 export const useSemester = () => useSemesterStore((state) => state.semester);
 


### PR DESCRIPTION
- Close #474 
  
## What is this PR? 🔍

- 기능 :  비로그인 시에 현재 학기를 로컬스토리지에 저장합니다.
- issue : #474 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 현재 학기를 로컬스토리지에 저장하도록 했습니다.


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
