### PR TITLE
Feat/#493/adjust time correctly

### DIFF
--- a/src/components/TimetablePage/Listbox/NewListbox.module.scss
+++ b/src/components/TimetablePage/Listbox/NewListbox.module.scss
@@ -42,6 +42,11 @@
       }
     }
 
+    svg {
+      transform: rotate(360deg);
+      transition: transform 0.3s ease;
+    }
+
     &:hover {
       background-color: #f5f5f5;
     }
@@ -53,12 +58,9 @@
     &--selected {
       background-color: #175c8e33;
 
-      &:hover {
-        background-color: #175c8e33;
-      }
-
-      &:active {
-        background-color: #175c8e33;
+      svg {
+        transform: rotate(180deg);
+        transition: transform 0.3s ease;
       }
     }
 
@@ -68,6 +70,11 @@
 
       &--opened {
         border: 1px solid #cacaca;
+
+        svg {
+          transform: rotate(180deg);
+          transition: transform 0.3s ease;
+        }
       }
     }
 
@@ -78,6 +85,11 @@
 
       &--opened {
         border: 1px solid #cacaca;
+
+        svg {
+          transform: rotate(180deg);
+          transition: transform 0.3s ease;
+        }
       }
     }
   }

--- a/src/components/TimetablePage/Listbox/index.tsx
+++ b/src/components/TimetablePage/Listbox/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { cn } from '@bcsdlab/utils';
 import { ReactComponent as DownArrowIcon } from 'assets/svg/down-arrow-icon.svg';
-import { ReactComponent as UpArrowIcon } from 'assets/svg/up-arrow-icon.svg';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
 import { useOutsideClick } from 'utils/hooks/ui/useOutsideClick';
 import styles from './Listbox.module.scss';
@@ -63,7 +62,7 @@ function Listbox({
         })}
       >
         {value !== null ? list.find((item) => item.value === value)?.label : '학부'}
-        {version !== 'default' && (isOpenedPopup ? <UpArrowIcon /> : <DownArrowIcon />)}
+        {version !== 'default' && <DownArrowIcon />}
       </button>
       {isOpenedPopup && (
         <ul className={styleClasses.select__content} role="listbox">

--- a/src/pages/TimetablePage/ModifyTimetablePage/DefaultPage/DefaultPage.module.scss
+++ b/src/pages/TimetablePage/ModifyTimetablePage/DefaultPage/DefaultPage.module.scss
@@ -90,7 +90,6 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width: 139px;
     height: 48px;
     border: 0;
     border-radius: 5px;

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -176,11 +176,31 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
     e: { target: { value: string } },
   ) => {
     const { target } = e;
-    const newTimeInfo = {
+    let newTimeInfo = {
       ...timeSpaceComponents[index].time,
       [key]: target?.value,
     };
-    const newTimetableTime = changeToTimetableTime(newTimeInfo);
+
+    let newTimetableTime = changeToTimetableTime(newTimeInfo);
+    // 올바르지 않은 시간을 선택했을 시
+    if (newTimetableTime.length === 0) {
+      const newStartTime = Number(newTimeInfo.startHour.slice(0, 2));
+      const newEndTime = Number(newTimeInfo.endHour.slice(0, 2));
+      if (key.slice(0, 5) === 'start') {
+        newTimeInfo = {
+          ...newTimeInfo,
+          endHour: `${newStartTime + 1}시`,
+          endMinute: newStartTime + 1 === 24 ? '00분' : newTimeInfo.startMinute,
+        };
+      } else {
+        newTimeInfo = {
+          ...newTimeInfo,
+          startHour: newEndTime - 1 < 10 ? '09시' : `${newEndTime - 1}시`,
+          startMinute: newEndTime - 1 < 9 ? '00분' : newTimeInfo.endMinute,
+        };
+      }
+      newTimetableTime = changeToTimetableTime(newTimeInfo);
+    }
     const updatedTime = addWeekTime(timeSpaceComponents[index].week, newTimetableTime);
     const updatedComponents = [...timeSpaceComponents];
     updatedComponents[index] = {
@@ -344,8 +364,8 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
                     <Listbox list={HOUR} value={time.startHour} onChange={handleLectureTimeByTime('startHour', index)} version="addLecture" />
                     <Listbox list={MINUTE} value={time.startMinute} onChange={handleLectureTimeByTime('startMinute', index)} version="addLecture" />
                     <span>-</span>
-                    <Listbox list={HOUR} value={time.endHour} onChange={handleLectureTimeByTime('endHour', index)} version="addLecture" />
-                    <Listbox list={MINUTE} value={time.endMinute} onChange={handleLectureTimeByTime('endMinute', index)} version="addLecture" />
+                    <Listbox list={[...HOUR, { label: '24시', value: '24시' }]} value={time.endHour} onChange={handleLectureTimeByTime('endHour', index)} version="addLecture" />
+                    <Listbox list={time.endHour === '24시' ? [{ label: '00분', value: '00분' }] : MINUTE} value={time.endMinute} onChange={handleLectureTimeByTime('endMinute', index)} version="addLecture" />
                   </div>
                 </div>
               </div>

--- a/src/pages/TimetablePage/components/MainTimetable/MyLectureTimetable.module.scss
+++ b/src/pages/TimetablePage/components/MainTimetable/MyLectureTimetable.module.scss
@@ -8,14 +8,17 @@
   }
 
   &__total-grades {
-    margin-right: 75px;
+    position: absolute;
+    left: 16px;
+    top: 18px;
   }
 
   &__filter {
     display: flex;
     position: relative;
-    justify-content: flex-end;
+    width: 776px;
     align-items: flex-end;
+    justify-content: flex-end;
     gap: 16px;
     margin-bottom: 14px;
   }
@@ -27,9 +30,9 @@
     border: none;
     border-radius: 5px;
     padding: 12px 20px;
-    width: 155px;
     height: 48px;
     background-color: #fff;
+    font-family: Pretendard, sans-serif;
     cursor: pointer;
     justify-content: center;
     font-weight: 500;


### PR DESCRIPTION
- Close #493 
  
## What is this PR? 🔍

- 기능 :  올바르지 않은 시간 선택 시 시간 자동 조정
- issue : #493 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 윈도우 환경에서 버튼 내 글자가 깨지는 부분을 수정했습니다.
- 일부 드롭다운 펼칠 시 downArrow 이미지가 어색한 부분을 수정했습니다.
- 종료 시간을 `24시 00분` 까지 선택 가능하게 했습니다.
- **시작 시간이 `12:00`인데 종료 시간을 `10:00`로 선택하는 경우와 같이 올바르지 않은 시간을 선택하는 경우 자동으로 시간 조정이 되도록 했습니다. 올바르지 않은 시간을 선택하는 경우 선택한 시간에서 +1시간 혹은 -1시간을 하여 자동 조정해줍니다.**

> 위의 예시에서는 12:00 ~ 10:00(선택) -> 09:00 ~ 10:00
 10:00(선택) ~ 10:00 -> 10:00 ~ 11:00

**예외의 경우**
- `startTime`을 23:30으로 선택했을 때 `endTime`은 24:00으로 설정
- `endTime`을 09:00이나 09:30으로 선택하면 `startTime`은 09:00로 설정

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
- 버튼 내 글자 깨짐
![image](https://github.com/user-attachments/assets/9aaa4558-5f16-4a9b-80b0-20d5fcc2ab80) ![image](https://github.com/user-attachments/assets/7329f97d-91bf-4957-b2b4-fd08e5021443)
![image](https://github.com/user-attachments/assets/7039f483-9d93-4e8a-a06f-1aca0d53aab3) ![image](https://github.com/user-attachments/assets/377b46ce-9764-4e14-9a5e-d53c0c695c06)

- 드롭다운 downArrow 이미지 수정
![image](https://github.com/user-attachments/assets/1f3ee5bd-0a65-40b4-ab81-dceb8adbb1c5)  ![image](https://github.com/user-attachments/assets/6f15df89-5147-457e-870c-fa618db08678) ![image](https://github.com/user-attachments/assets/71d1923f-33c5-42e8-9d78-9a5f0e14f3ee)


## Test CheckList ✅


## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
