### PR TITLE
[시간표] 비로그인 시 중복 시간표 토스트에러 문구 수정

### DIFF
--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -111,9 +111,16 @@ function CurrentSemesterLectureList({
               return;
             }
             if (userInfo) {
-              showToast(
+              if (alreadySelectedLecture.lecture_class) { // 분반이 존재하는 경우
+                showToast(
+                  'error',
+                  `${alreadySelectedLecture.class_title}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
+                );
+                return;
+              }
+              showToast( // 직접 강의를 추가하여 분반이 존재하지 않는 경우
                 'error',
-                `${alreadySelectedLecture.class_title}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
+                `${alreadySelectedLecture.class_title} 강의가 중복되어 추가할 수 없습니다.`,
               );
               return;
             }

--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -119,7 +119,7 @@ function CurrentSemesterLectureList({
             }
             showToast(
               'error',
-              `${alreadySelectedLecture.class_title}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
+              `${alreadySelectedLecture.name}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
             );
           } else {
             addMyLectureV2(clickedLecture);

--- a/src/pages/TimetablePage/components/Timetable/index.tsx
+++ b/src/pages/TimetablePage/components/Timetable/index.tsx
@@ -287,8 +287,7 @@ function Timetable({
                     }}
                   >
                     {lecture_class}
-                    &nbsp;
-                    {professor}
+                    {` ${professor}`}
                   </span>
                   <div
                     style={{


### PR DESCRIPTION
- Close #502 
  
## What is this PR? 🔍

- 기능 : 비로그인 시 중복 시간표 토스트에러 문구 수정
- issue : #502 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
기존의 qa 요소 중 하나였던, 커스텀 시간표에서 분반이 없을 때, 생기는 띄어쓰기를 삭제하였습니다.
* `분반 + 교수명 ` + 부분에 띄어쓰기가 하나 들어가 있어 나타나는 문제였습니다. 따라서 해당 공백을 삭제하고 템플릿 문자열 교수명 앞에 공백을 추가하는 방식으로 수정하였습니다.
* 중복 시간표 토스트 에러 문구 수정
    * 비로그인 시 중복 시간표를 넣을 때 에러 문구 가 null로 떴습니다. 이는 로그인을 하지 않았을 때 받아오는 api res의 타입이 달라서 그런 것으로 파악하였습니다. 
    *  토스트 에러에서는 모두 `alreadySelectedLecture.class_title`로 에러문구를 나타내고 있었지만, 로그인을 하지 않았을 경우에는 해당 정보가 `alreadySelectedLecture.name`에 들어있는 것으로 확인하여 에러 문구를 표시하는 분기에서 다르게 표현하였습니다.
    * 또한, 커스텀 시간표로 시간표를 넣었을 경우에는 분반이 존재하지 않아 에러 문구를 표시할때 분반을 제거하는 분기를 하나 만들었습니다.



## ScreenShot 📷
![image](https://github.com/user-attachments/assets/6f2b2f8a-f999-46c7-9e77-a0fbb0ea771a)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
![image](https://github.com/user-attachments/assets/70601e40-50fb-4bb5-b300-9df273bb48d3)
![image](https://github.com/user-attachments/assets/f236c79e-75ee-4610-b6fb-69623e35a5a9)

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
