### PR TITLE
[비즈니스] 상점 상세 페이지 waterfall 현상 막기

### DIFF
--- a/src/pages/Store/StoreDetailPage/index.tsx
+++ b/src/pages/Store/StoreDetailPage/index.tsx
@@ -42,7 +42,7 @@ function StoreDetailPage() {
   const token = useTokenState();
   // waterfall 현상 막기
   const { data: paralleData } = useSuspenseQuery({
-    queryKey: [],
+    queryKey: ['storeDetail', 'storeDetailMenu', 'review'],
     queryFn: () => Promise.all([
       queryClient.fetchQuery({
         queryKey: ['storeDetail', params.id],
@@ -63,7 +63,7 @@ function StoreDetailPage() {
     ? storeDetail?.description.replace(/(?:\/)/g, '\n')
     : '-';
   const storeMenus = paralleData[1];
-  const data = paralleData[2];
+  const reviews = paralleData[2];
   const storeMenuCategories = storeMenus ? storeMenus.menu_categories : null;
   const [param, setParam] = useSearchParams();
   const tapType = param.get('state') ?? '메뉴';
@@ -390,7 +390,7 @@ function StoreDetailPage() {
           >
             리뷰
             {' '}
-            {`(${data.total_count})`}
+            {`(${reviews.total_count})`}
           </button>
         </div>
         {tapType === '메뉴' && storeMenuCategories && storeMenuCategories.length > 0 && (


### PR DESCRIPTION
- Close #504 
  
## What is this PR? 🔍

- 기능 : api 병럴 처리
- issue : #504 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
한 컴포넌트 내에서 useSuspenseQuery가 여러 번 호출되면서 waterfall 현상이 일어나고 있었습니다.
promise.all을 통해 호출을 병렬처리 해줌으로써 위 현상을 막고 더 빠른 응답을 기대할 수 있습니다.
queryClient를 이용해서 tanstack query의 캐시 능력을 충분히 사용할 수 있도록 코드를 작성했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
기존 네트워크 요청
![image](https://github.com/user-attachments/assets/757fe4b3-e98e-4bae-b339-a2d349737cdf)
변경된 네트워크 요청
![image](https://github.com/user-attachments/assets/b22db654-e2b1-4c36-9fd1-f81cfda65886)

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
