### PR TITLE
[시간표] 시간표에 시간 잘못 나오는 이슈 해결

### DIFF
--- a/src/pages/TimetablePage/hooks/useTimetableDayListV2.ts
+++ b/src/pages/TimetablePage/hooks/useTimetableDayListV2.ts
@@ -14,6 +14,7 @@ export default function useTimetableDayListV2(
     (myLectures ?? []).forEach((lecture, lectureIndex) => {
       let currentDayClassTimeArr: number[][] = [];
       let currentDayClassPlaceArr: string[] | undefined = [];
+      // 커스텀 시간표 구성 시 시간표 미리보기를 위함.
       if (!('code' in lecture)) {
         currentDayClassTimeArr = (lecture.class_time ?? [])
           .map((item) => (
@@ -67,7 +68,7 @@ export default function useTimetableDayListV2(
           .sort((a, b) => a - b);
         if (currentDayClassTime.length) {
           const groups = currentDayClassTime.reduce((acc, curr, i) => {
-            if (curr === currentDayClassTime[i]) {
+            if (i === 0 || curr === currentDayClassTime[i - 1] + 1) {
               acc[acc.length - 1].push(curr);
             } else {
               acc.push([curr]);


### PR DESCRIPTION
- Close #515 
  
## What is this PR? 🔍

- 기능 :  시간표에 시간이 잘못 나오지 않게 했습니다.
- issue : #515 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 기존에 시간표에 강의가 9 to 6로 시간이 표시되었는데(_이슈 참고_) 로직이 잘못되어 있어 수정했습니다.


## ScreenShot 📷
![image](https://github.com/user-attachments/assets/e16ef1fa-61e5-4e44-bd9a-d752e0aa4a9c)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
