### PR TITLE
[버그수정] 시간표 삭제 이후 기존 프레임 id에 머무르는 현상 수정

### DIFF
--- a/src/api/timetable/entity.ts
+++ b/src/api/timetable/entity.ts
@@ -75,7 +75,7 @@ export interface AddTimetableFrameRequest {
 }
 
 export interface UpdateTimetableFrameRequest {
-  name: string,
+  timetable_name: string,
   is_main: boolean,
 }
 

--- a/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
@@ -10,22 +10,27 @@ import { useSemester } from 'utils/zustand/semester';
 import useToast from 'components/common/Toast/useToast';
 import showToast from 'utils/ts/showToast';
 import useTokenState from 'utils/hooks/state/useTokenState';
+import useTimetableFrameList from 'pages/TimetablePage/hooks/useTimetableFrameList';
+import { isKoinError, sendClientError } from '@bcsdlab/koin';
 import styles from './TimetableSettingModal.module.scss';
 
 export interface TimetableSettingModalProps {
   focusFrame: TimetableFrameInfo;
   setFocusFrame: (frame: TimetableFrameInfo) => void;
   onClose: () => void;
+  setCurrentFrameIndex: (id: number) => void;
 }
 
 export default function TimetableSettingModal({
   focusFrame,
   setFocusFrame,
   onClose,
+  setCurrentFrameIndex,
 }: TimetableSettingModalProps) {
   const token = useTokenState();
   const semester = useSemester();
   const toast = useToast();
+  const { data: myFrames } = useTimetableFrameList(token, semester);
   const toggleIsChecked = () => {
     if (focusFrame.is_main) setFocusFrame({ ...focusFrame, is_main: false });
     else setFocusFrame({ ...focusFrame, is_main: true });
@@ -48,18 +53,30 @@ export default function TimetableSettingModal({
     token,
     semester,
   );
-  const onDelete = (frame: TimetableFrameInfo) => {
+  const onDelete = async (frame: TimetableFrameInfo) => {
     if (!focusFrame.id) {
       showToast('warning', '로그인 후 이용 가능합니다.');
       return;
     }
-    toast.open({
-      message: `선택하신 [${frame.timetable_name}]이 삭제되었습니다.`,
-      recoverMessage: `[${frame.timetable_name}]이 복구되었습니다.`,
-      onRecover: recoverFrame,
-    });
-    deleteTimetableFrame(focusFrame.id);
-    onClose();
+    try {
+      await deleteTimetableFrame(focusFrame.id);
+      toast.open({
+        message: `선택하신 [${frame.timetable_name}]이 삭제되었습니다.`,
+        recoverMessage: `[${frame.timetable_name}]이 복구되었습니다.`,
+        onRecover: recoverFrame,
+      });
+
+      const defaultFrame = myFrames.find((table) => table.is_main);
+      if (defaultFrame && defaultFrame.id) setCurrentFrameIndex(defaultFrame.id);
+      onClose();
+    } catch (err) {
+      //
+      if (isKoinError(err)) {
+        showToast('error', err.message);
+        return;
+      }
+      sendClientError(err);
+    }
   };
 
   return (

--- a/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
@@ -19,6 +19,7 @@ export interface TimetableSettingModalProps {
   setFocusFrame: (frame: TimetableFrameInfo) => void;
   onClose: () => void;
   setCurrentFrameIndex: React.Dispatch<number>;
+  currentFrameIndex: number;
 }
 
 export default function TimetableSettingModal({
@@ -26,6 +27,7 @@ export default function TimetableSettingModal({
   setFocusFrame,
   onClose,
   setCurrentFrameIndex,
+  currentFrameIndex,
 }: TimetableSettingModalProps) {
   const token = useTokenState();
   const semester = useSemester();
@@ -66,8 +68,11 @@ export default function TimetableSettingModal({
         onRecover: recoverFrame,
       });
 
-      const defaultFrameId = myFrames.find((table) => table.is_main)?.id;
-      if (defaultFrameId) setCurrentFrameIndex(defaultFrameId);
+      // 현재 선택된 프레임이 삭제되면 메인 프레임으로 변경
+      if (currentFrameIndex === focusFrame.id) {
+        const defaultFrameId = myFrames.find((table) => table.is_main)?.id;
+        if (defaultFrameId) setCurrentFrameIndex(defaultFrameId);
+      }
       onClose();
     } catch (err) {
       if (isKoinError(err)) {

--- a/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
@@ -18,7 +18,7 @@ export interface TimetableSettingModalProps {
   focusFrame: TimetableFrameInfo;
   setFocusFrame: (frame: TimetableFrameInfo) => void;
   onClose: () => void;
-  setCurrentFrameIndex: (id: number) => void;
+  setCurrentFrameIndex: React.Dispatch<number>;
 }
 
 export default function TimetableSettingModal({
@@ -66,11 +66,10 @@ export default function TimetableSettingModal({
         onRecover: recoverFrame,
       });
 
-      const defaultFrame = myFrames.find((table) => table.is_main);
-      if (defaultFrame && defaultFrame.id) setCurrentFrameIndex(defaultFrame.id);
+      const defaultFrameId = myFrames.find((table) => table.is_main)?.id;
+      if (defaultFrameId) setCurrentFrameIndex(defaultFrameId);
       onClose();
     } catch (err) {
-      //
       if (isKoinError(err)) {
         showToast('error', err.message);
         return;

--- a/src/pages/TimetablePage/components/TimetableList/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-imports */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { cn } from '@bcsdlab/utils';
 import { useSemester } from 'utils/zustand/semester';
 import { TimetableFrameInfo } from 'api/timetable/entity';
@@ -80,6 +80,14 @@ export default function TimetableList({
     }
   };
 
+  useEffect(() => {
+    // console.log(defaultFrame.find((frame) => frame.id === currentFrameIndex));
+    if (!data.find((frame) => frame.id === currentFrameIndex)) {
+      const mainFrameId = data.find((frame) => frame.is_main)?.id;
+      if (mainFrameId) setCurrentFrameIndex(mainFrameId);
+    }
+  }, [data, setCurrentFrameIndex, currentFrameIndex]);
+
   return (
     <div className={styles['timetable-list']}>
       <SemesterList />
@@ -95,7 +103,7 @@ export default function TimetableList({
               className={cn({
                 [styles['timetable-list__item']]: true,
                 [styles['timetable-list__item--selected']]:
-                  currentFrameIndex === frame.id || !frame.id,
+                  currentFrameIndex === frame.id,
               })}
               key={frame.id}
               onClick={() => frame.id && setCurrentFrameIndex(frame.id)}
@@ -158,6 +166,7 @@ export default function TimetableList({
           focusFrame={focusFrame!}
           setFocusFrame={setFocusFrame}
           setCurrentFrameIndex={setCurrentFrameIndex}
+          currentFrameIndex={currentFrameIndex}
           onClose={closeModal}
         />
       )}

--- a/src/pages/TimetablePage/components/TimetableList/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/index.tsx
@@ -157,6 +157,7 @@ export default function TimetableList({
         <TimetableSettingModal
           focusFrame={focusFrame!}
           setFocusFrame={setFocusFrame}
+          setCurrentFrameIndex={setCurrentFrameIndex}
           onClose={closeModal}
         />
       )}

--- a/src/pages/TimetablePage/hooks/useUpdateTimetableFrame.ts
+++ b/src/pages/TimetablePage/hooks/useUpdateTimetableFrame.ts
@@ -16,7 +16,7 @@ export default function useUpdateTimetableFrame() {
         updateTimetableFrame(
           token,
           frameInfo.id!,
-          { name: frameInfo.timetable_name, is_main: frameInfo.is_main },
+          { timetable_name: frameInfo.timetable_name, is_main: frameInfo.is_main },
         )
       ),
       onSuccess: () => {


### PR DESCRIPTION

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
삭제된 시간표 id에서 머무르는 현상을 수정했습니다.
현재 시간표가 삭제될 시 메인 시간표로 변경됩니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
