### PR TITLE
[시간표] 빈 강의 목록에 대한 문구 추가

### DIFF
--- a/src/components/TimetablePage/LectureTable/LectureTable.module.scss
+++ b/src/components/TimetablePage/LectureTable/LectureTable.module.scss
@@ -1,17 +1,9 @@
 .table {
   width: 613px;
-  height: 609px;
   text-align: left;
   word-break: break-all;
   border: none;
   white-space: nowrap;
-
-  &__header {
-    display: flex;
-    padding: 10px 16px;
-    text-align: left;
-    background-color: #175c8e1a;
-  }
 
   &__col {
     position: relative;

--- a/src/components/TimetablePage/LectureTable/index.tsx
+++ b/src/components/TimetablePage/LectureTable/index.tsx
@@ -9,7 +9,7 @@ import { useOutsideClick } from 'utils/hooks/ui/useOutsideClick';
 import styles from './LectureTable.module.scss';
 
 interface LectureTableProps {
-  rowWidth: number[];
+  rowWidthList: number[];
   frameId: number;
   list: Array<LectureInfo> | Array<TimetableLectureInfoV2>;
   myLecturesV2: Array<LectureInfo> | Array<TimetableLectureInfoV2>;
@@ -40,7 +40,7 @@ export const LECTURE_TABLE_HEADER = [
 ] as const;
 
 function LectureTable({
-  rowWidth,
+  rowWidthList,
   frameId,
   list,
   myLecturesV2,
@@ -193,7 +193,7 @@ function LectureTable({
                 (headerItem, headerItemIndex) => headerItem.key !== null && (
                   <div
                     style={{
-                      width: `${rowWidth[headerItemIndex]}px`,
+                      width: `${rowWidthList[headerItemIndex]}px`,
                     }}
                     className={cn({
                       [styles.table__col]: true,

--- a/src/components/TimetablePage/LectureTable/index.tsx
+++ b/src/components/TimetablePage/LectureTable/index.tsx
@@ -161,7 +161,6 @@ function LectureTable({
           >
             <button
               type="button"
-              role={onClickRow !== undefined ? undefined : 'null'}
               aria-label={
                     onClickRow !== undefined
                       ? '시간표에서 미리 보기'

--- a/src/pages/TimetablePage/components/LectureList/LectureList.module.scss
+++ b/src/pages/TimetablePage/components/LectureList/LectureList.module.scss
@@ -124,11 +124,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-family: Pretendard;
+  font-family: Pretendard, sans-serif;
   font-size: 18px;
   font-weight: 400;
   line-height: 28.8px;
   text-align: center;
   color: #727272;
-
 }

--- a/src/pages/TimetablePage/components/LectureList/LectureList.module.scss
+++ b/src/pages/TimetablePage/components/LectureList/LectureList.module.scss
@@ -80,3 +80,55 @@
     cursor: pointer;
   }
 }
+
+.table {
+  width: 613px;
+  height: 609px;
+  text-align: left;
+  word-break: break-all;
+  border: none;
+  white-space: nowrap;
+
+  &__header {
+    display: flex;
+    padding: 10px 16px;
+    text-align: left;
+    background-color: #175c8e1a;
+  }
+
+  &__col {
+    position: relative;
+    padding-right: 5px;
+    align-items: center;
+    overflow: hidden;
+    box-sizing: border-box;
+    font-family: Pretendard, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 22px;
+    text-align: left;
+    word-break: break-all;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    .table__row > &:last-child {
+      border: none;
+      padding: 0;
+    }
+  }
+}
+
+.empty-list {
+  height: 567px;
+  background-color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: Pretendard;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 28.8px;
+  text-align: center;
+  color: #727272;
+
+}

--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -23,7 +23,7 @@ import LastUpdatedDate from './LastUpdatedDate';
 import styles from './LectureList.module.scss';
 
 interface CurrentSemesterLectureListProps {
-  rowWidth: number[];
+  rowWidthList: number[];
   semesterKey: string;
   filter: {
     department: string;
@@ -34,7 +34,7 @@ interface CurrentSemesterLectureListProps {
 }
 
 interface MyLectureListBoxProps {
-  rowWidth: number[];
+  rowWidthList: number[];
   myLectures: Array<LectureInfo> | Array<TimetableLectureInfoV2>;
   frameId: number;
 }
@@ -48,7 +48,7 @@ const useFlexibleWidth = (length: number, initialValue: number[]) => {
 };
 
 function CurrentSemesterLectureList({
-  rowWidth,
+  rowWidthList,
   semesterKey,
   filter,
   myLecturesV2,
@@ -63,7 +63,7 @@ function CurrentSemesterLectureList({
   return (
     lectureList?.length !== 0 ? (
       <LectureTable
-        rowWidth={rowWidth}
+        rowWidthList={rowWidthList}
         frameId={Number(frameId)}
         list={(lectureList ?? []).filter((lecture) => {
           const searchFilter = filter.search.toUpperCase();
@@ -157,11 +157,11 @@ function CurrentSemesterLectureList({
   );
 }
 
-function MyLectureListBox({ rowWidth, myLectures, frameId }: MyLectureListBoxProps) {
+function MyLectureListBox({ rowWidthList, myLectures, frameId }: MyLectureListBoxProps) {
   return (
     myLectures.length !== 0 ? (
       <LectureTable
-        rowWidth={rowWidth}
+        rowWidthList={rowWidthList}
         frameId={frameId}
         list={myLectures}
         myLecturesV2={myLectures}
@@ -271,7 +271,7 @@ function LectureList({ frameId }: { frameId: number }) {
         <React.Suspense fallback={<LoadingSpinner size="50" />}>
           {!isToggled ? (
             <CurrentSemesterLectureList
-              rowWidth={widthInfo}
+              rowWidthList={widthInfo}
               frameId={frameId}
               semesterKey={semester}
               filter={{
@@ -283,7 +283,7 @@ function LectureList({ frameId }: { frameId: number }) {
             />
           ) : (
             <MyLectureListBox
-              rowWidth={widthInfo}
+              rowWidthList={widthInfo}
               myLectures={myLecturesV2}
               frameId={frameId}
             />

--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -11,7 +11,7 @@ import useSelect from 'pages/TimetablePage/hooks/useSelect';
 import showToast from 'utils/ts/showToast';
 import useLectureList from 'pages/TimetablePage/hooks/useLectureList';
 import useSearch from 'pages/TimetablePage/hooks/useSearch';
-import LectureTable from 'components/TimetablePage/LectureTable';
+import LectureTable, { LECTURE_TABLE_HEADER } from 'components/TimetablePage/LectureTable';
 import { useParams } from 'react-router-dom';
 import useMyLecturesV2 from 'pages/TimetablePage/hooks/useMyLecturesV2';
 import { useUser } from 'utils/hooks/state/useUser';
@@ -23,6 +23,7 @@ import LastUpdatedDate from './LastUpdatedDate';
 import styles from './LectureList.module.scss';
 
 interface CurrentSemesterLectureListProps {
+  rowWidth: number[];
   semesterKey: string;
   filter: {
     department: string;
@@ -33,11 +34,21 @@ interface CurrentSemesterLectureListProps {
 }
 
 interface MyLectureListBoxProps {
+  rowWidth: number[];
   myLectures: Array<LectureInfo> | Array<TimetableLectureInfoV2>;
   frameId: number;
 }
 
+const useFlexibleWidth = (length: number, initialValue: number[]) => {
+  const [widthInfo] = React.useState(() => initialValue);
+  // TODO: flexible width 생성(mouseMove 이벤트)
+  return {
+    widthInfo,
+  };
+};
+
 function CurrentSemesterLectureList({
+  rowWidth,
   semesterKey,
   filter,
   myLecturesV2,
@@ -50,105 +61,120 @@ function CurrentSemesterLectureList({
   const { addMyLectureV2 } = useTimetableV2Mutation(frameId);
 
   return (
-    <LectureTable
-      frameId={Number(frameId)}
-      list={(lectureList ?? []).filter((lecture) => {
-        const searchFilter = filter.search.toUpperCase();
-        const departmentFilter = filter.department;
-        const searchCondition = lecture.name.toUpperCase().includes(searchFilter)
-            || lecture.code.toUpperCase().includes(searchFilter)
-            || lecture.professor.toUpperCase().includes(searchFilter);
+    lectureList?.length !== 0 ? (
+      <LectureTable
+        rowWidth={rowWidth}
+        frameId={Number(frameId)}
+        list={(lectureList ?? []).filter((lecture) => {
+          const searchFilter = filter.search.toUpperCase();
+          const departmentFilter = filter.department;
+          const searchCondition = lecture.name.toUpperCase().includes(searchFilter)
+              || lecture.code.toUpperCase().includes(searchFilter)
+              || lecture.professor.toUpperCase().includes(searchFilter);
 
-        if (searchFilter !== '' && departmentFilter !== '전체') {
-          return searchCondition && lecture.department === departmentFilter;
-        }
-        if (searchFilter !== '') {
-          return searchCondition;
-        }
-        if (departmentFilter !== '전체') {
-          return lecture.department === departmentFilter;
-        }
-
-        return true;
-      })}
-      myLecturesV2={myLecturesV2}
-      selectedLecture={tempLecture ?? undefined}
-      onClickRow={(clickedLecture) => ('code' in clickedLecture ? updateTempLecture(clickedLecture) : undefined)}
-      onDoubleClickRow={
-        (clickedLecture) => {
-          const isContainedLecture = myLecturesV2.some(
-            (lecture) => lecture.code === clickedLecture.code
-            && lecture.lecture_class === clickedLecture.lecture_class,
-          );
-          if ('class_title' in clickedLecture) {
-            return;
+          if (searchFilter !== '' && departmentFilter !== '전체') {
+            return searchCondition && lecture.department === departmentFilter;
           }
-          if (isContainedLecture) {
-            showToast('error', '동일한 과목이 이미 추가되어 있습니다.');
-            return;
+          if (searchFilter !== '') {
+            return searchCondition;
           }
-          const myLectureTimeValue = (
-            myLecturesV2 as Array<LectureInfo | TimetableLectureInfoV2>
-          ).reduce((acc, cur) => {
-            if (cur.class_time) {
-              return acc.concat(cur.class_time);
-            }
-            return acc;
-          }, [] as number[]);
+          if (departmentFilter !== '전체') {
+            return lecture.department === departmentFilter;
+          }
 
-          if (
-            clickedLecture.class_time.some((time) => myLectureTimeValue.includes(time))
-          ) {
-            const myLectureList = myLecturesV2 as Array<
-            LectureInfo & TimetableLectureInfoV2
-            >;
-            const alreadySelectedLecture = myLectureList.find(
-              (lecture) => lecture.class_time.some(
-                (time) => clickedLecture.class_time.includes(time),
-              ),
+          return true;
+        })}
+        myLecturesV2={myLecturesV2}
+        selectedLecture={tempLecture ?? undefined}
+        onClickRow={(clickedLecture) => ('code' in clickedLecture ? updateTempLecture(clickedLecture) : undefined)}
+        onDoubleClickRow={
+          (clickedLecture) => {
+            const isContainedLecture = myLecturesV2.some(
+              (lecture) => lecture.code === clickedLecture.code
+              && lecture.lecture_class === clickedLecture.lecture_class,
             );
-            if (!alreadySelectedLecture) {
+            if ('class_title' in clickedLecture) {
               return;
             }
-            if (userInfo) {
-              if (alreadySelectedLecture.lecture_class) { // 분반이 존재하는 경우
-                showToast(
+            if (isContainedLecture) {
+              showToast('error', '동일한 과목이 이미 추가되어 있습니다.');
+              return;
+            }
+            const myLectureTimeValue = (
+              myLecturesV2 as Array<LectureInfo | TimetableLectureInfoV2>
+            ).reduce((acc, cur) => {
+              if (cur.class_time) {
+                return acc.concat(cur.class_time);
+              }
+              return acc;
+            }, [] as number[]);
+
+            if (
+              clickedLecture.class_time.some((time) => myLectureTimeValue.includes(time))
+            ) {
+              const myLectureList = myLecturesV2 as Array<
+              LectureInfo & TimetableLectureInfoV2
+              >;
+              const alreadySelectedLecture = myLectureList.find(
+                (lecture) => lecture.class_time.some(
+                  (time) => clickedLecture.class_time.includes(time),
+                ),
+              );
+              if (!alreadySelectedLecture) {
+                return;
+              }
+              if (userInfo) {
+                if (alreadySelectedLecture.lecture_class) { // 분반이 존재하는 경우
+                  showToast(
+                    'error',
+                    `${alreadySelectedLecture.class_title}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
+                  );
+                  return;
+                }
+                showToast( // 직접 강의를 추가하여 분반이 존재하지 않는 경우
                   'error',
-                  `${alreadySelectedLecture.class_title}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
+                  `${alreadySelectedLecture.class_title} 강의가 중복되어 추가할 수 없습니다.`,
                 );
                 return;
               }
-              showToast( // 직접 강의를 추가하여 분반이 존재하지 않는 경우
+              showToast(
                 'error',
-                `${alreadySelectedLecture.class_title} 강의가 중복되어 추가할 수 없습니다.`,
+                `${alreadySelectedLecture.name}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
               );
-              return;
+            } else {
+              addMyLectureV2(clickedLecture);
             }
-            showToast(
-              'error',
-              `${alreadySelectedLecture.name}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
-            );
-          } else {
-            addMyLectureV2(clickedLecture);
           }
         }
-      }
-      version="semesterLectureList"
-    />
+        version="semesterLectureList"
+      />
+    )
+      : (
+        <div className={styles['empty-list']}>
+          강의 정보가 없습니다.
+        </div>
+      )
   );
 }
 
-function MyLectureListBox({ myLectures, frameId }: MyLectureListBoxProps) {
+function MyLectureListBox({ rowWidth, myLectures, frameId }: MyLectureListBoxProps) {
   return (
-    <LectureTable
-      frameId={frameId}
-      list={myLectures}
-      myLecturesV2={myLectures}
-      selectedLecture={undefined}
-      onClickRow={undefined}
-      onDoubleClickRow={undefined}
-      version="myLectureList"
-    />
+    myLectures.length !== 0 ? (
+      <LectureTable
+        rowWidth={rowWidth}
+        frameId={frameId}
+        list={myLectures}
+        myLecturesV2={myLectures}
+        selectedLecture={undefined}
+        onClickRow={undefined}
+        onDoubleClickRow={undefined}
+        version="myLectureList"
+      />
+    ) : (
+      <div className={styles['empty-list']}>
+        현재 등록된 강의가 없습니다. 강의를 추가해 시간표를 완성해 보세요!
+      </div>
+    )
   );
 }
 
@@ -175,6 +201,7 @@ function LectureList({ frameId }: { frameId: number }) {
     value: searchValue,
     searchInputRef,
   } = useSearch();
+  const { widthInfo } = useFlexibleWidth(9, [61, 173, 41, 61, 61, 41, 41, 41, 61]);
 
   const toggleLectureList = () => {
     setIsToggled((prev) => !prev);
@@ -217,10 +244,34 @@ function LectureList({ frameId }: { frameId: number }) {
           </React.Suspense>
         </div>
       </div>
+      <div className={styles.table__header} role="row">
+        {LECTURE_TABLE_HEADER.map((header, headerIndex) => (
+          <div
+            style={{
+              width: `${widthInfo[headerIndex]}px`,
+            }}
+            className={styles.table__col}
+            role="columnheader"
+            key={header.key}
+          >
+            {header.label}
+            {/* 내림차순 기능 추가할때 다시 복구 */}
+            {/* {headerIndex !== LECTURE_TABLE_HEADER.length - 1 && (
+            <>
+              <button type="button" className={styles.table__button}>
+                <img src="https://static.koreatech.in/assets/img/ic-arrow-down.png" alt="내림차순" />
+              </button>
+              <div className={styles.table__resize} aria-hidden />
+            </>
+          )} */}
+          </div>
+        ))}
+      </div>
       <ErrorBoundary fallbackClassName="loading">
         <React.Suspense fallback={<LoadingSpinner size="50" />}>
           {!isToggled ? (
             <CurrentSemesterLectureList
+              rowWidth={widthInfo}
               frameId={frameId}
               semesterKey={semester}
               filter={{
@@ -231,7 +282,11 @@ function LectureList({ frameId }: { frameId: number }) {
               myLecturesV2={myLecturesV2}
             />
           ) : (
-            <MyLectureListBox myLectures={myLecturesV2} frameId={frameId} />
+            <MyLectureListBox
+              rowWidth={widthInfo}
+              myLectures={myLecturesV2}
+              frameId={frameId}
+            />
           )}
         </React.Suspense>
       </ErrorBoundary>


### PR DESCRIPTION
- Close #518 
  
## What is this PR? 🔍

- 기능 : 빈 강의 목록(계절학기 등)과 시간표에 담은 강의가 없을 시 문구를 추가합니다.
- issue : #518 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
**코드 이동으로 추가 코드가 많은 만큼 삭제 코드도 많습니다. 변경한 내용은 별로 없습니다!** 
- 코드 길이를 줄이고자 시간표 테이블 헤더(코드, 과목명, 분반 등..) 코드 위치를 변경했습니다.
- 강의 목록이 비어 있을 시, 내 시간표에 강의가 없을 시 안내 문구를 보여줍니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
-빈 강의 목록

![image](https://github.com/user-attachments/assets/2010fc17-8342-4938-b4ab-2b70cd01ef42)

- 시간표에 추가한 과목이 없을 시

![image](https://github.com/user-attachments/assets/3d01ca61-805f-497b-b27e-a00020ee6f0b)

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
