### PR TITLE
[hotfix] 회원 학과 정보 불러오기

### DIFF
--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -285,7 +285,7 @@ const MajorInput = React.forwardRef<ICustomFormInput, ICustomFormInputProps>((pr
   const { data: userInfo } = useUser();
   const [studentNumber, setStudentNumber] = React.useState<string>(userInfo?.student_number || '');
   const { data: deptList } = useDeptList();
-  const [major, setMajor] = React.useState<string | null>(null);
+  const [major, setMajor] = React.useState<string | null>(userInfo?.major || '');
   const deptOptionList = deptList.map((dept) => ({
     label: dept.name,
     value: dept.name,


### PR DESCRIPTION
- Close #523 
  
## What is this PR? 🔍

- 기능 :  정보 수정 페이지 이동 시 회원의 기존 학과 정보를 불러옵니다.
- issue : #523 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 회원의 학과 정보를 불러오지 않았던 코드 문제를 해결했습니다.(이전에 revert하면서 생긴 이슈인 것 같습니다.)


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
