### PR TITLE
[시간표] 시간 및 장소 삭제 기능 추가

### DIFF
--- a/src/pages/TimetablePage/components/CustomLecture/CustomLecture.module.scss
+++ b/src/pages/TimetablePage/components/CustomLecture/CustomLecture.module.scss
@@ -190,10 +190,36 @@
   @include scrollbar(6px);
 
   &__component {
-    padding: 1px 2px 0 0;
+    background-color: #fff;
+    box-shadow: 0 2px 4px 0 #0000000a;
+    box-shadow: 0 1px 1px 0 #00000005;
+    padding: 8px;
     display: flex;
     flex-direction: column;
     gap: 10px;
+    border-radius: 5px;
+  }
+
+  &__delete-button {
+    align-self: flex-end;
+    cursor: pointer;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background-color: transparent;
+    border-radius: 4px;
+
+    &:hover {
+      background-color: #eee;
+    }
+
+    &:active {
+      background-color: #cacaca;
+    }
+
+    &--invisible {
+      z-index: -1;
+    }
   }
 }
 
@@ -251,7 +277,7 @@
 
   &__container {
     display: flex;
-    width: 100%;
+    width: 502px;
     flex-direction: column;
     gap: 3px;
   }
@@ -259,14 +285,14 @@
   &__weekdays {
     display: flex;
     gap: 13px;
-    width: 100%;
+    width: 502px;
     justify-content: space-between;
   }
 
   &__weekdays-button {
     display: flex;
-    width: 94px;
-    height: 32px;
+    width: 90px;
+    height: 29px;
     padding: 5px 8px;
     justify-content: center;
     align-items: center;
@@ -287,7 +313,7 @@
   &__time {
     display: flex;
     position: relative;
-    width: 522px;
+    width: 502px;
     height: 46px;
     gap: 8px;
     align-items: center;

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cn } from '@bcsdlab/utils';
 import { ReactComponent as AddIcon } from 'assets/svg/add-icon.svg';
+import { ReactComponent as CloseIcon } from 'assets/svg/close-icon-black.svg';
 import useTimetableV2Mutation from 'pages/TimetablePage/hooks/useTimetableV2Mutation';
 import Listbox from 'components/TimetablePage/Listbox';
 import { DAYS_STRING, HOUR, MINUTE } from 'static/timetable';
@@ -175,6 +176,14 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
     }, 0);
   };
 
+  const handleDeleteTimeSpaceComponent = (index: number) => {
+    setTimeSpaceComponents((prev) => {
+      const updatedComponent = [...prev];
+      updatedComponent.splice(index, 1);
+      return updatedComponent;
+    });
+  };
+
   const handleLectureTimeByTime = (key: string, index: number) => (
     e: { target: { value: string } },
   ) => {
@@ -325,6 +334,17 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
             place,
           }, index) => (
             <div className={styles['time-space-container__component']}>
+              <button
+                aria-label="delete-time-space-component"
+                type="button"
+                onClick={() => handleDeleteTimeSpaceComponent(index)}
+                className={cn({
+                  [styles['time-space-container__delete-button']]: true,
+                  [styles['time-space-container__delete-button--invisible']]: index === 0,
+                })}
+              >
+                <CloseIcon />
+              </button>
               <div className={styles['form-group-time']}>
                 <label
                   htmlFor="place"

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -60,6 +60,7 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
       ? timeSpaceContainerRef.current.getBoundingClientRect().bottom - value < 150
       : false),
   );
+  const isOneComponent = timeSpaceComponents.length === 1;
 
   const changeToTimetableTime = (timeInfo: {
     startHour: string;
@@ -340,7 +341,7 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
                 onClick={() => handleDeleteTimeSpaceComponent(index)}
                 className={cn({
                   [styles['time-space-container__delete-button']]: true,
-                  [styles['time-space-container__delete-button--invisible']]: index === 0,
+                  [styles['time-space-container__delete-button--invisible']]: isOneComponent,
                 })}
               >
                 <CloseIcon />

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -60,7 +60,7 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
       ? timeSpaceContainerRef.current.getBoundingClientRect().bottom - value < 150
       : false),
   );
-  const isOneComponent = timeSpaceComponents.length === 1;
+  const isSingleTimeSpaceComponent = timeSpaceComponents.length === 1;
 
   const changeToTimetableTime = (timeInfo: {
     startHour: string;
@@ -341,7 +341,7 @@ function CustomLecture({ frameId }: { frameId: string | undefined }) {
                 onClick={() => handleDeleteTimeSpaceComponent(index)}
                 className={cn({
                   [styles['time-space-container__delete-button']]: true,
-                  [styles['time-space-container__delete-button--invisible']]: isOneComponent,
+                  [styles['time-space-container__delete-button--invisible']]: isSingleTimeSpaceComponent,
                 })}
               >
                 <CloseIcon />


### PR DESCRIPTION
- Close #525 
  
## What is this PR? 🔍

- 기능 : 직접 추가 페이지에서 시간 및 장소 컴포넌트의 삭제 기능을 추가했습니다.
- issue : #525 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 첫 '시간 및 장소' 박스는 삭제할 수 없게 X버튼이 안 보이게 했습니다.
- 그 외 추가된 '시간 및 장소' 박스에는 삭제 가능한 X버튼을 추가했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
![image](https://github.com/user-attachments/assets/e6cea476-015b-424a-bafc-ffc97f77172b)


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
