### PR TITLE
[시간표] 학기 삭제 api 연동

### DIFF
--- a/src/api/timetable/APIDetail.ts
+++ b/src/api/timetable/APIDetail.ts
@@ -9,6 +9,7 @@ import {
   VersionInfoResponse,
   VersionType,
   SemesterCheckResponse,
+  DeleteSemesterResponse,
   AddTimetableFrameRequest,
   UpdateTimetableFrameRequest,
   TimetableFrameListResponse,
@@ -122,6 +123,26 @@ export class SemesterCheck<R extends SemesterCheckResponse> implements APIReques
   auth = true;
 
   constructor(public authorization: string) {}
+}
+
+export class DeleteSemester<R extends DeleteSemesterResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.DELETE;
+
+  path = '/v2/all/timetables/frame';
+
+  response!: R;
+
+  auth = true;
+
+  params: {
+    [index: string]: string;
+  };
+
+  constructor(public authorization: string, semester: string) {
+    this.params = {
+      semester,
+    };
+  }
 }
 
 export class TimetableFrameList<R extends TimetableFrameListResponse> implements APIRequest<R> {

--- a/src/api/timetable/entity.ts
+++ b/src/api/timetable/entity.ts
@@ -66,6 +66,8 @@ export interface SemesterCheckResponse extends APIResponse {
   semesters: string[];
 }
 
+export interface DeleteSemesterResponse extends APIResponse { }
+
 export type TimetableFrameListResponse = TimetableFrameInfo[];
 
 export type AddTimetableFrameResponse = TimetableFrameInfo;

--- a/src/api/timetable/index.ts
+++ b/src/api/timetable/index.ts
@@ -7,6 +7,7 @@ import {
   TimetableRemoveLecture,
   VersionInfo,
   SemesterCheck,
+  DeleteSemester,
   TimetableFrameList,
   AddTimetableFrame,
   UpdateTimetableFrame,
@@ -29,6 +30,8 @@ export const changeTimetableInfoByRemoveLecture = APIClient.of(TimetableRemoveLe
 export const getVersion = APIClient.of(VersionInfo);
 
 export const getMySemester = APIClient.of(SemesterCheck);
+
+export const deleteSemester = APIClient.of(DeleteSemester);
 
 export const getTimetableFrame = APIClient.of(TimetableFrameList);
 

--- a/src/pages/TimetablePage/hooks/useDeleteSemester.ts
+++ b/src/pages/TimetablePage/hooks/useDeleteSemester.ts
@@ -2,21 +2,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { timetable } from 'api';
 import useToast from 'components/common/Toast/useToast';
 import { MY_SEMESTER_INFO_KEY } from './useMySemester';
-import useTimetableFrameList, { TIMETABLE_FRAME_KEY } from './useTimetableFrameList';
+import { TIMETABLE_FRAME_KEY } from './useTimetableFrameList';
 
 export default function useDeleteSemester(token: string, semester: string) {
   const queryClient = useQueryClient();
-  const { data: timetableFrameList } = useTimetableFrameList(token, semester);
   const slicedSemester = `${semester.slice(0, 4)}년도 ${semester.slice(4)}학기`;
   const toast = useToast();
   return useMutation({
-    mutationFn: async () => {
-      if (timetableFrameList) {
-        await Promise.all(timetableFrameList.map((frame) => (
-          timetable.deleteTimetableFrame(token, frame.id!)
-        )));
-      }
-    },
+    mutationFn: () => timetable.deleteSemester(token, semester),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [MY_SEMESTER_INFO_KEY] });
       queryClient.invalidateQueries({ queryKey: [TIMETABLE_FRAME_KEY + semester] });


### PR DESCRIPTION
- Close #530 
  
## What is this PR? 🔍

- 기능 : 학기 삭제 api 연동
- issue : #530 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 기존에는 시간표 프레임을 삭제하는 api를 이용해서 그 학기에 있는 모든 시간표 프레임을 삭제해서 학기 삭제를 구현했는데 백엔에서 모든 시간표 프레임을 삭제하는 api를 만들어 주셔서 그것을 이용하여 학기 삭제를 구현했습니다.


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
