### PR TITLE
[공통] 핸들링 되지 않은 에러를 슬랙에 알림 발송

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,8 @@ import './index.scss';
 import { BrowserRouter } from 'react-router-dom';
 import PortalProvider from 'components/common/Modal/PortalProvider';
 import { RecoilRoot } from 'recoil';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { sendClientError } from '@bcsdlab/koin';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
@@ -15,6 +16,9 @@ const queryClient = new QueryClient({
       retry: false,
     },
   },
+  queryCache: new QueryCache({
+    onError: (error) => sendClientError(error),
+  }),
 });
 
 const root = ReactDOM.createRoot(


### PR DESCRIPTION
프론트엔드 에러가 발생해도 개발자들이 인지를 못하는 상황이 반복되고 있으므로 우선 임시 조치로 queryCache의 onError 콜백을 통해 핸들링 되지 않은 에러를 전역적으로 잡아서 슬랙에 알림을 발송하도록 설정했습니다.
추후 에러 바운더리를 곁들인 코드로 리팩토링 하겠습니다


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
