### PR TITLE
Vite 마이그레이션 빌드 폴더 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
@@ -12,5 +13,8 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+  },
+  build: {
+    outDir: 'build',
   },
 });


### PR DESCRIPTION
- Close #553
  
- yarn build했을 때 Vite는 기본적으로 /dist폴더를 생성하지만, 기존처럼 /build폴더에 build산출물을 만들도록 수정했습니다.



## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
