### PR TITLE
[캠퍼스] 교내 시설물 정보 로깅 추가

### DIFF
--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -17,6 +17,7 @@ function Footer(): JSX.Element {
     if (title === '주변상점') logger.actionEventClick({ actionTitle: 'BUSINESS', title: 'footer', value: '주변상점' });
     if (title === '복덕방') logger.actionEventClick({ actionTitle: 'BUSINESS', title: 'footer', value: '복덕방' });
     if (title === '시간표') logger.actionEventClick({ actionTitle: 'USER', title: 'footer', value: '시간표' });
+    if (title === '교내 시설물 정보') logger.actionEventClick({ actionTitle: 'CAMPUS', title: 'footer', value: '교내 시설물 정보' });
   };
 
   return (

--- a/src/components/common/Header/MobileHeader/Panel/index.tsx
+++ b/src/components/common/Header/MobileHeader/Panel/index.tsx
@@ -34,6 +34,7 @@ export default function Panel({ openModal }: PanelProps) {
     if (title === '주변상점') logger.actionEventClick({ actionTitle: 'BUSINESS', title: 'hamburger_shop', value: '주변상점' });
     if (title === '복덕방') logger.actionEventClick({ actionTitle: 'BUSINESS', title: 'hamburger', value: '복덕방' });
     if (title === '시간표') logger.actionEventClick({ actionTitle: 'USER', title: 'hamburger', value: '시간표' });
+    if (title === '교내 시설물 정보') logger.actionEventClick({ actionTitle: 'CAMPUS', title: 'hamburger', value: '교내 시설물 정보' });
   };
 
   // 기존 페이지에서 햄버거를 통해 다른 페이지로 이동할 때의 로그입니다.

--- a/src/components/common/Header/PCHeader/index.tsx
+++ b/src/components/common/Header/PCHeader/index.tsx
@@ -79,6 +79,11 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
     }
     if (title === '복덕방') logger.actionEventClick({ actionTitle: 'BUSINESS', title: 'header', value: '복덕방' });
     if (title === '시간표') logger.actionEventClick({ actionTitle: 'USER', title: 'header', value: '시간표' });
+    if (title === '교내 시설물 정보') {
+      logger.actionEventClick({
+        actionTitle: 'CAMPUS', title: 'header', value: '교내 시설물 정보', event_category: 'click',
+      });
+    }
   };
 
   const escapeByLogo = async () => {


### PR DESCRIPTION
- Close #559
  
## What is this PR? 🔍

- 기능 : 교내 시설물 정보 로깅
- issue : #559

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 교내 시설물 정보 진입점 헤더, 푸터, 햄버거에 로깅을 추가했습니다.
- 교내 시설물 정보 로깅의 경우 급하게 추가할 필요가 있어 핫픽스로 추가합니다.



## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
