### PR TITLE
[hotfix] 정보수정에서 닉네임이 필수값이 되어버리는 이슈

### DIFF
--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -240,7 +240,7 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     () => {
       // 닉네임 유효성 검사 로직
       let valid: string | true = true;
-      if (nicknameElementRef && nicknameElementRef.current?.value !== userInfo?.nickname && (status !== 'success' || nicknameElementRef.current?.value !== currentCheckedNickname)) {
+      if (!nicknameElementRef.current?.value !== !userInfo?.nickname && (status !== 'success' || nicknameElementRef.current?.value !== currentCheckedNickname)) {
         valid = '닉네임 중복확인을 해주세요.';
       }
       return {

--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -243,7 +243,8 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     () => {
       // 닉네임 유효성 검사 로직
       let valid: string | true = true;
-      if (currentNicknameValue !== (userInfo?.nickname || '') && (status !== 'success' || currentNicknameValue !== currentCheckedNickname)) {
+      const isNicknameVerified = currentNicknameValue === currentCheckedNickname;
+      if (currentNicknameValue !== (userInfo?.nickname || '') && (status !== 'success' || !isNicknameVerified)) {
         valid = '닉네임 중복확인을 해주세요.';
       }
       return {

--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -216,7 +216,7 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
   ref,
 ) => {
   const { data: userInfo } = useUser();
-  const [nickname, setNickname] = React.useState<string>(userInfo?.nickname || '');
+  const [currentNicknameValue, setCurrentNicknameValue] = React.useState<string>(userInfo?.nickname || '');
 
   const {
     changeTargetNickname,
@@ -225,18 +225,17 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
   } = useNicknameDuplicateCheck();
 
   const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNickname(e.target.value);
+    setCurrentNicknameValue(e.target.value);
   };
 
   // 닉네임 중복 확인 버튼 클릭 핸들러
   const onClickNicknameDuplicateCheckButton = () => {
-    const currentInputValue = nickname;
     // 현재 입력된 닉네임과 기존 닉네임이 같다면 중복 검사를 수행하지 않습니다.
-    if (currentInputValue === userInfo?.nickname) {
+    if (currentNicknameValue === userInfo?.nickname) {
       showToast('info', '기존의 닉네임과 동일합니다.');
       return;
     }
-    changeTargetNickname(currentInputValue);
+    changeTargetNickname(currentNicknameValue);
   };
 
   useImperativeHandle<ICustomFormInput | null, ICustomFormInput | null>(
@@ -244,15 +243,15 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     () => {
       // 닉네임 유효성 검사 로직
       let valid: string | true = true;
-      if (nickname !== (userInfo?.nickname || '') && (status !== 'success' || nickname !== currentCheckedNickname)) {
+      if (currentNicknameValue !== (userInfo?.nickname || '') && (status !== 'success' || currentNicknameValue !== currentCheckedNickname)) {
         valid = '닉네임 중복확인을 해주세요.';
       }
       return {
-        value: nickname,
+        value: currentNicknameValue,
         valid,
       };
     },
-    [currentCheckedNickname, nickname, status, userInfo?.nickname],
+    [currentCheckedNickname, currentNicknameValue, status, userInfo?.nickname],
   );
 
   return (

--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -244,7 +244,7 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     () => {
       // 닉네임 유효성 검사 로직
       let valid: string | true = true;
-      if (nickname !== userInfo?.nickname && (status !== 'success' || nickname !== currentCheckedNickname)) {
+      if (nickname !== (userInfo?.nickname || '') && (status !== 'success' || nickname !== currentCheckedNickname)) {
         valid = '닉네임 중복확인을 해주세요.';
       }
       return {

--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -216,7 +216,7 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
   ref,
 ) => {
   const { data: userInfo } = useUser();
-  const nicknameElementRef = React.useRef<HTMLInputElement>(null);
+  const [nickname, setNickname] = React.useState<string>(userInfo?.nickname || '');
 
   const {
     changeTargetNickname,
@@ -224,9 +224,13 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     currentCheckedNickname,
   } = useNicknameDuplicateCheck();
 
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
   // 닉네임 중복 확인 버튼 클릭 핸들러
   const onClickNicknameDuplicateCheckButton = () => {
-    const currentInputValue = nicknameElementRef.current?.value ?? '';
+    const currentInputValue = nickname;
     // 현재 입력된 닉네임과 기존 닉네임이 같다면 중복 검사를 수행하지 않습니다.
     if (currentInputValue === userInfo?.nickname) {
       showToast('info', '기존의 닉네임과 동일합니다.');
@@ -240,15 +244,15 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     () => {
       // 닉네임 유효성 검사 로직
       let valid: string | true = true;
-      if (!nicknameElementRef.current?.value !== !userInfo?.nickname && (status !== 'success' || nicknameElementRef.current?.value !== currentCheckedNickname)) {
+      if (nickname !== userInfo?.nickname && (status !== 'success' || nickname !== currentCheckedNickname)) {
         valid = '닉네임 중복확인을 해주세요.';
       }
       return {
-        value: nicknameElementRef.current?.value,
+        value: nickname,
         valid,
       };
     },
-    [currentCheckedNickname, status, nicknameElementRef, userInfo?.nickname],
+    [currentCheckedNickname, nickname, status, userInfo?.nickname],
   );
 
   return (
@@ -259,7 +263,7 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
       })}
     >
       <input
-        ref={nicknameElementRef}
+        onChange={handleNicknameChange}
         className={styles['form-input']}
         type="text"
         autoComplete="nickname"


### PR DESCRIPTION
- Close #561 
  
## What is this PR? 🔍

- 기능 :  닉네임을 필수가 아닌 선택이 되게 했습니다.
- issue : #561 

## Is It Hurry? 💨 
- 매우 큰 이슈는 아니라 급한 PR은 아닙니다.

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
1. 이번 이슈를 해결하면서 또다른 이슈를 발견하여 수정했습니다.
 **닉네임을 수정하고 중복 검사를 안 했지만 그대로 수정 완료가 되어 인덱스 페이지로 넘어가는 현상**을 발견했습니다. 물론 닉네임은 수정이 되지 않았습니다. 로직을 봤을 때는 닉네임을 수정하고 중복확인을 하지 않은 채 수정 완료를 누르면 '닉네임 중복확인을 해주세요' 토스트가 뜨는 게 정상으로 보였습니다. 하지만 `useImperativeHandle`의 사용과 동시에 ref로 input값을 받고 있어 수정완료를 누를 때 이전값을 참조하고 있어서 **`ref`대신 `nickname state`을 추가**했습니다.

2. 닉네임을 필수가 아닌 선택으로
`nicknameElementRef.current?.value !== userInfo?.nickname`
닉네임을 작성하지 않고 회원가입을 한 사용자는 `userInfo.nickname` 값이 `null`이 됩니다.
그리고 input에서 아무런 값을 입력하지 않은 초기값은 빈 문자열(`''`)이 됩니다. 따라서 위 로직의 결과값은 true가 됩니다.
저희가 원하는 결과는 닉네임을 수정 또는 추가하지 않고 정보수정을 성공적으로 마치는 것입니다. 하지만 위와 같은 경우에서는 `'' !== null` 의 결과가 true가 되기 때문에 `닉네임 중복확인을 해주세요.`토스트와 함께 정보수정을 마칠 수 없게 됩니다.
단지 **빈 값에 대해 빈 문자열과 null의 타입?차이 때문에 발생한 이슈로 `userInfo.nickname`이 `null`인 경우 빈 문자열과 비교하도록 수정했습니다.**

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
