### PR TITLE
[비즈니스] 카테고리 추가에 따른 UI 대응

### DIFF
--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -34,6 +34,7 @@
     flex-wrap: wrap;
     padding: 18px 5px;
     gap: 11px;
+    overflow: hidden;
 
     @include media.media-breakpoint(mobile) {
       width: 100%;
@@ -45,7 +46,7 @@
   }
 
   &__item {
-    width: 73px;
+    width: 60px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -53,6 +54,7 @@
     color: black;
     text-decoration: none;
     cursor: pointer;
+    font-size: 12px;
 
     &:hover {
       color: #f7941e;
@@ -60,7 +62,7 @@
 
     @include media.media-breakpoint(mobile) {
       letter-spacing: -0.8px;
-      width: 15%;
+      width: 12%;
       padding-top: 11px;
       margin-right: 8px;
       font-size: 12px;

--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -55,6 +55,7 @@
     text-decoration: none;
     cursor: pointer;
     font-size: 12px;
+    white-space: nowrap;
 
     &:hover {
       color: #f7941e;
@@ -65,7 +66,7 @@
       width: 12%;
       padding-top: 11px;
       margin-right: 8px;
-      font-size: 12px;
+      font-size: 10px;
       color: #252525;
     }
   }

--- a/src/pages/IndexPage/components/IndexStore/index.tsx
+++ b/src/pages/IndexPage/components/IndexStore/index.tsx
@@ -84,7 +84,7 @@ function IndexStore() {
               </button>
             </div>
           )
-          : categories?.shop_categories.map((category) => (
+          : categories?.shop_categories.slice(isMobile ? 1 : 0, 12).map((category) => (
             category.name === '전체보기' && ABView === 'B' ? (
               <div
                 className={styles.category__benefit}

--- a/src/pages/Store/StorePage/StorePage.module.scss
+++ b/src/pages/Store/StorePage/StorePage.module.scss
@@ -71,7 +71,7 @@
     width: calc(100% - 182px);
 
     @include media.media-breakpoint(mobile) {
-      width: 330px;
+      width: 100%;
     }
   }
 
@@ -88,7 +88,7 @@
     border: 0;
     line-height: 1.2;
     height: 100%;
-    width: 70px;
+    width: 6%;
     padding: 0;
     color: rgb(37 37 37);
     margin-right: 22px;
@@ -121,7 +121,7 @@
 
     @include media.media-breakpoint(mobile) {
       letter-spacing: -0.8px;
-      width: 64px;
+      width: 15%;
       padding-top: 11px;
       margin-right: 2px;
     }

--- a/src/pages/Store/StorePage/StorePage.module.scss
+++ b/src/pages/Store/StorePage/StorePage.module.scss
@@ -82,7 +82,7 @@
     flex-direction: column;
     font-family: NanumBarunGothic, serif;
     font-weight: normal;
-    font-size: 15px;
+    font-size: 12px;
     text-align: center;
     background-color: #fff;
     border: 0;
@@ -93,13 +93,14 @@
     color: rgb(37 37 37);
     margin-right: 22px;
     cursor: pointer;
+    white-space: nowrap;
 
     & span {
       text-align: center;
       width: 100%;
 
       @include media.media-breakpoint(mobile) {
-        font-size: 14px;
+        font-size: 12px;
         font-weight: 400;
       }
     }
@@ -134,8 +135,8 @@
     margin: 0 auto 13px;
 
     @include media.media-breakpoint(mobile) {
-      width: 50px;
-      height: 50px;
+      width: 40px;
+      height: 40px;
     }
   }
 }

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -255,7 +255,7 @@ function StorePage() {
       <div className={styles.category}>
         <div className={styles.category__header}>CATEGORY</div>
         <div className={styles.category__wrapper}>
-          {categories?.shop_categories.map((category) => (
+          {categories?.shop_categories.slice(isMobile ? 1 : 0, 12).map((category) => (
             <button
               className={cn({
                 [styles.category__menu]: true,


### PR DESCRIPTION
카테고리 개수가 2개 늘어남에 따라 UI가 깨진 현상을 수정했습니다.
카테고리는 현재 스프린트 기획상 12개만 보여줍니다.

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/77dc0c43-4e22-49ff-9c39-f03c13cea99c)
![image](https://github.com/user-attachments/assets/84c98f4f-69ce-4d4e-9864-b5fb1f707fd5)
![image](https://github.com/user-attachments/assets/65fb2e87-4d97-4e32-83fe-ce3dea2ad066)
![image](https://github.com/user-attachments/assets/3bcffb0a-f4d2-422d-9b8b-43930c83d057)


<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
