### PR TITLE
[시간표] 강의 추가 api 요청값 수정

### DIFF
--- a/src/api/timetable/entity.ts
+++ b/src/api/timetable/entity.ts
@@ -115,10 +115,10 @@ export interface TimetableDetailInfo {
 export interface AddTimetableLectureV2Request {
   timetable_frame_id: number;
   timetable_lecture: [{
-    class_title: string;
-    class_time: number[];
+    class_title: string | null;
+    class_time: number[] | null;
     class_place?: string;
-    professor?: string;
+    professor?: string | null;
     memo?: string;
     grades?: string;
     lecture_id?: number;

--- a/src/components/Cafeteria/CafeteriaInfo/index.tsx
+++ b/src/components/Cafeteria/CafeteriaInfo/index.tsx
@@ -4,7 +4,6 @@ import type { Opens, CoopShopDetailResponse } from 'api/coopshop/entity';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import { useOutsideClick } from 'utils/hooks/ui/useOutsideClick';
 import { useEscapeKeyDown } from 'utils/hooks/ui/useEscapeKeyDown';
-import { useBodyScrollLock } from 'utils/hooks/ui/useBodyScrollLock';
 import styles from './CafeteriaInfo.module.scss';
 
 interface ScheduleTableProps {

--- a/src/pages/TimetablePage/hooks/useTimetableV2Mutation.ts
+++ b/src/pages/TimetablePage/hooks/useTimetableV2Mutation.ts
@@ -45,7 +45,10 @@ export default function useTimetableV2Mutation(frameId: number) {
           timetable_lecture: [
             {
               ...clickedLecture,
-              class_title: clickedLecture.name,
+              class_title: null,
+              class_time: null,
+              professor: null,
+              grades: '0',
               lecture_id: clickedLecture.id,
             },
           ],


### PR DESCRIPTION
- Close #579 
  
## What is this PR? 🔍

- 기능 : 정규 강의 추가 api(POST/v2/timetables/lecture)의 요청값 중 `classTitle`, `classTime`, `professor`을 `null`로, `grades`를 `'0'`으로 수정했습니다.
- issue : #579 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
백엔드 측에서 커스텀 강의와 정규 강의 구분을 위해 요청값에 null을 넣어달라는 요청으로 정규 강의 추가 api(POST/v2/timetables/lecture)의 요청값 중 `classTitle`, `classTime`, `professor`을 `null`로, `grades`를 `'0'`으로 수정했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
