### PR TITLE
[비즈니스] 카테고리 이미지 크기를 조정해서 깨지지 않도록 수정

### DIFF
--- a/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
+++ b/src/pages/IndexPage/components/IndexStore/IndexStore.module.scss
@@ -97,13 +97,13 @@
   }
 
   &__image {
-    width: 56px;
-    height: 56px;
+    width: 48px;
+    height: 48px;
     border-width: 50%;
 
     @media (max-width: 576px) {
-      width: 40px;
-      height: 40px;
+      width: 48px;
+      height: 48px;
     }
   }
 }

--- a/src/pages/Store/StorePage/StorePage.module.scss
+++ b/src/pages/Store/StorePage/StorePage.module.scss
@@ -129,8 +129,8 @@
   }
 
   &__image {
-    width: 57px;
-    height: 57px;
+    width: 48px;
+    height: 48px;
     border-width: 50%;
     margin: 0 auto 13px;
 

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -316,7 +316,7 @@ function StorePage() {
       <div className={styles.category}>
         <div className={styles.category__header}>CATEGORY</div>
         <div className={styles.category__wrapper}>
-          {categories?.shop_categories.slice(isMobile ? 1 : 0, 12).map((category) => (
+          {categories?.shop_categories.slice(0, 12).map((category) => (
             <button
               className={cn({
                 [styles.category__menu]: true,


### PR DESCRIPTION
## Changes 📝
카테고리 이미지가 원본보다 커서 비교적 흐려보이는 현상을 수정했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
변경 전
![image](https://github.com/user-attachments/assets/ee491b90-969d-48d4-9d69-52f10a0902d4)
변경 후
![image](https://github.com/user-attachments/assets/345b69f0-3921-43a3-aa9a-c14a048fbb88)

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
