### PR TITLE
[QA] 검색 시 카테고리 선택 불가 에러와 정렬 기능 제거

### DIFF
--- a/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
+++ b/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
@@ -53,6 +53,7 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
             type="text"
             name="search"
             placeholder="검색어를 입력하세요"
+            autoComplete="off"
             onChange={handleInputChange}
             onKeyDown={(async (e) => {
               if (e.key === 'Enter') {

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  Suspense, useEffect, useRef, useState,
+  Suspense, useEffect, useRef,
 } from 'react';
 import { StoreSorterType, StoreFilterType } from 'api/store/entity';
 import * as api from 'api';
@@ -17,9 +17,6 @@ import DesktopStoreList from 'pages/Store/StorePage/components/DesktopStoreList'
 import MobileStoreList from 'pages/Store/StorePage/components/MobileStoreList';
 import { STORE_PAGE } from 'static/store';
 import IntroToolTip from 'components/common/IntroToolTip';
-import AscSelectArrow from 'assets/svg/store-filter-arrow-asc-select.svg';
-import DescSelectArrow from 'assets/svg/store-filter-arrow-desc-select.svg';
-import DescArrow from 'assets/svg/store-filter-arrow-desc.svg';
 import LoadingSpinner from 'components/common/LoadingSpinner';
 import styles from './StorePage.module.scss';
 import { useStoreCategories } from './hooks/useCategoryList';
@@ -139,10 +136,6 @@ function StorePage() {
     localStorage.setItem('store-review-tooltip', 'used');
     closeTooltip();
   };
-  const [filterSortingState, setFilterSortingState] = useState({
-    COUNT: false,
-    RATING: false,
-  });
 
   const koreanCategory = selectedCategory === -1
     ? '전체보기'
@@ -166,10 +159,6 @@ function StorePage() {
       setStoreMobileFilterState((prevState) => ({
         ...prevState,
         sorter: item,
-      }));
-      setFilterSortingState((preFilterSortingState) => ({
-        COUNT: item === 'COUNT' ? !preFilterSortingState.COUNT : false,
-        RATING: item === 'RATING' ? !preFilterSortingState.RATING : false,
       }));
 
       if (storeMobileFilterState.sorter !== item) {
@@ -226,18 +215,6 @@ function StorePage() {
   useScrollLogging(storeScrollLogging);
 
   const enterCategoryTimeRef = useRef<number | null>(null);
-  const handleIcon = (item: MobileCheckBoxItem) => {
-    if (item.id === 'COUNT' || item.id === 'RATING') {
-      const isSelected = storeMobileFilterState.sorter === item.id;
-
-      if (isSelected) {
-        return filterSortingState[item.id] ? <DescSelectArrow /> : <AscSelectArrow />;
-      }
-
-      return <DescArrow />;
-    }
-    return null;
-  };
   useEffect(() => {
     if (enterCategoryTimeRef.current === null) {
       const currentTime = new Date().getTime();
@@ -403,7 +380,6 @@ function StorePage() {
             type="button"
             onClick={() => onClickMobileStoreListFilter(item.id)}
           >
-            {handleIcon(item)}
             {item.content}
           </button>
         ))}
@@ -417,14 +393,12 @@ function StorePage() {
       <Suspense fallback={<LoadingSpinner size="100" />}>
         {!isMobile ? (
           <DesktopStoreList
-            storeListData={filterSortingState.COUNT || filterSortingState.RATING
-              ? storeList : storeList.reverse()}
+            storeListData={storeList}
             storeType={STORE_PAGE.MAIN}
           />
         ) : (
           <MobileStoreList
-            storeListData={filterSortingState.COUNT || filterSortingState.RATING
-              ? storeList : storeList.reverse()}
+            storeListData={storeList}
             storeType={STORE_PAGE.MAIN}
           />
         )}

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -116,12 +116,12 @@ const useStoreList = (
 };
 
 function StorePage() {
-  const [storeMobileFilterState, setStoreMobileFilterState] = React.useState<StoreMobileState>({
-    sorter: '',
-    filter: [],
-  });
   const [isToolTipOpen, setIsToolTipOpen] = React.useState(true);
   const { params, searchParams, setParams } = useParamsHandler();
+  const [storeMobileFilterState, setStoreMobileFilterState] = React.useState<StoreMobileState>({
+    sorter: searchParams.get('COUNT') ? 'COUNT' : '',
+    filter: [],
+  });
   const storeList = useStoreList(
     storeMobileFilterState.sorter,
     storeMobileFilterState.filter,
@@ -167,7 +167,7 @@ function StorePage() {
           title: 'shop_can',
           value: loggingCategoryToggleValue(
             item,
-            categories.shop_categories[selectedCategory].name,
+            categories.shop_categories[selectedCategory]?.name,
           ),
           event_category: 'click',
         });
@@ -189,7 +189,7 @@ function StorePage() {
           title: 'shop_can',
           value: loggingCategoryToggleValue(
             item,
-            categories.shop_categories[selectedCategory].name,
+            categories.shop_categories[selectedCategory]?.name,
           ),
           event_category: 'click',
         });

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -217,7 +217,7 @@ function StorePage() {
       actionTitle: 'BUSINESS',
       title: 'shop_categories',
       value: `scroll in ${
-        categories.shop_categories[currentCategoryId].name || '전체보기'
+        categories.shop_categories[currentCategoryId]?.name || '전체보기'
       }`,
       event_category: 'scroll',
     });
@@ -249,7 +249,7 @@ function StorePage() {
     }
     sessionStorage.setItem(
       'cameFrom',
-      categories.shop_categories[selectedCategory].name || '전체보기',
+      categories.shop_categories[selectedCategory]?.name || '전체보기',
     );
   }, [categories, selectedCategory]);
 


### PR DESCRIPTION
## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- QA에서 정상적으로 동작하지 않은 부분 수정하였습니다.
- SuspenseQuery를 적용하며 함수쪽에서 depth가 2개 이상인 경우에는 undefined로 에러로 인해 페이지가 중단되는 현상을 수정하였습니다.
- 모바일 화면에서 역정렬 기능을 전부 제거하였습니다.
- 검색 시 autocomplete 기능을 제거하였습니다.



- A/B 테스트를 위한 기능은 전체적으로 완료되어 stage 테스트 이후 배포하면 될 것 같습니다.
- 추가적인 키보드 UI 수정은 목요일 이내로 작업하겠습니다.
- 추가적으로 궁금한 점은 컴퓨터에서 엔터키를 눌렀을 때 가장 첫번째에 있는 페이지나 라우팅을 해야하는 기능을 넣어야 하나요?
## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
- 모바일 역정렬 기능 제거
![image](https://github.com/user-attachments/assets/e4da5243-2056-4a31-977d-65e06a75e701)

- 검색 시 상점 이동 기능
 

https://github.com/user-attachments/assets/7ad3dae0-c8e7-4ec0-ab87-ccd06d0ed848




## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
