### PR TITLE
[주변상점] 모바일 툴팁 오류 수정

### DIFF
--- a/src/components/common/IntroToolTip/index.tsx
+++ b/src/components/common/IntroToolTip/index.tsx
@@ -4,14 +4,18 @@ import styles from './IntroToolTip.module.scss';
 
 interface IntroToolTipProps {
   content:string;
-  setCloseState: React.Dispatch<React.SetStateAction<boolean>>;
+  closeTooltip: ()=>void;
 }
 
-export default function IntroToolTip({ content, setCloseState } : IntroToolTipProps) {
+export default function IntroToolTip({ content, closeTooltip } : IntroToolTipProps) {
+  const handleTooltipCloseButtonClick = () => {
+    localStorage.setItem('store-review-tooltip', 'used');
+    closeTooltip();
+  };
   return (
     <div className={styles.tooltip}>
       {content}
-      <button type="button" className={styles['close-button']} onClick={() => setCloseState(false)}>
+      <button type="button" className={styles['close-button']} onClick={() => handleTooltipCloseButtonClick()}>
         <CloseIcon />
       </button>
     </div>

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -116,7 +116,6 @@ const useStoreList = (
 };
 
 function StorePage() {
-  const [isToolTipOpen, setIsToolTipOpen] = React.useState(true);
   const { params, searchParams, setParams } = useParamsHandler();
   const [storeMobileFilterState, setStoreMobileFilterState] = React.useState<StoreMobileState>({
     sorter: searchParams.get('COUNT') ? 'COUNT' : '',
@@ -383,10 +382,10 @@ function StorePage() {
             {item.content}
           </button>
         ))}
-        {isToolTipOpen && (
+        {isTooltipOpen && (
           <IntroToolTip
             content="지금 리뷰가 가장 많은 상점을 확인해보세요!"
-            setCloseState={setIsToolTipOpen}
+            closeTooltip={closeTooltip}
           />
         )}
       </div>


### PR DESCRIPTION
모바일 툴팁을 닫은 후에도 새로고침 시 계속 팝업되는 오류 수정

- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 모바일 화면 툴팁 계속 뜨는 오류 수정
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

모바일 팝업을 띄우는 state가 isTooltipOpen,과 isToolTipOpen 두개가 있어 발생한 문제를 해결했습니다.


## ScreenShot 📷

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/6da2569a-070e-4242-a1ab-7cff462feba6">

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
