### PR TITLE
[유저] 모바일웹 사이드 내비바 UI 수정

### DIFF
--- a/src/components/common/Header/MobileHeader/Panel/index.tsx
+++ b/src/components/common/Header/MobileHeader/Panel/index.tsx
@@ -96,7 +96,13 @@ export default function Panel({ openModal }: PanelProps) {
       <div className={styles.greet}>
         {userInfo ? (
           <div className={styles.greet__font}>
-            <span className={styles['greet--highlight']}>{userInfo.nickname}</span>
+            <span
+              className={cn({
+                [styles['greet--highlight']]: !!((userInfo.nickname || userInfo.name)),
+              })}
+            >
+              {userInfo.nickname ?? userInfo.name ?? '회원'}
+            </span>
             님, 안녕하세요!
           </div>
         ) : (

--- a/src/pages/Auth/ModifyInfoPage/hooks/useUserInfoUpdate.ts
+++ b/src/pages/Auth/ModifyInfoPage/hooks/useUserInfoUpdate.ts
@@ -22,8 +22,8 @@ const useUserInfoUpdate = (options: UserUpdateOption) => {
         showToast('success', '성공적으로 정보를 수정하였습니다.');
       },
       onError: (error: AxiosError<{ message?: string }>) => {
-        if (error?.response?.data) {
-          showToast('error', error.response.data.message || '에러가 발생했습니다.');
+        if (error.message) {
+          showToast('error', error.message || '에러가 발생했습니다.');
         }
       },
     },

--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -243,20 +243,22 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     ref,
     () => {
       // 닉네임 유효성 검사 로직
-      let valid: string | true = true;
+      const isNicknameVerified = currentNicknameValue === currentCheckedNickname;
       if (currentNicknameValue === '') {
         return {
           value: currentNicknameValue,
-          valid,
+          valid: true,
         };
       }
-      const isNicknameVerified = currentNicknameValue === currentCheckedNickname;
       if (currentNicknameValue !== (userInfo?.nickname || '') && (status !== 'success' || !isNicknameVerified)) {
-        valid = '닉네임 중복확인을 해주세요.';
+        return {
+          value: currentNicknameValue,
+          valid: '닉네임 중복확인을 해주세요.',
+        };
       }
       return {
         value: currentNicknameValue,
-        valid,
+        valid: true,
       };
     },
     [currentCheckedNickname, currentNicknameValue, status, userInfo?.nickname],

--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -244,6 +244,12 @@ const NicknameForm = React.forwardRef<ICustomFormInput | null, ICustomFormInputP
     () => {
       // 닉네임 유효성 검사 로직
       let valid: string | true = true;
+      if (currentNicknameValue === '') {
+        return {
+          value: currentNicknameValue,
+          valid,
+        };
+      }
       const isNicknameVerified = currentNicknameValue === currentCheckedNickname;
       if (currentNicknameValue !== (userInfo?.nickname || '') && (status !== 'success' || !isNicknameVerified)) {
         valid = '닉네임 중복확인을 해주세요.';

--- a/src/pages/Auth/SignupPage/hooks/useNicknameCheckServer.ts
+++ b/src/pages/Auth/SignupPage/hooks/useNicknameCheckServer.ts
@@ -13,7 +13,7 @@ function useNicknameCheckServer() {
     onError: (error) => {
       if (isKoinError(error)) {
         if (error.status === 409) {
-          showToast('error', '사용 불가능한 닉네임입니다.');
+          showToast('error', error.message);
           return;
         }
         if (error.status === 412) {

--- a/src/static/category.ts
+++ b/src/static/category.ts
@@ -1,4 +1,4 @@
-export type SubmenuTitle = '공지사항' | '버스/교통' | '식단' | '시간표' | '복덕방' | '주변상점' | '교내 시설물 정보' | '코인 for Business' | '리뷰 작성하기' | '리뷰 수정하기' | '리뷰 신고하기' | '전화 주문 혜택';// 헤더에 리뷰 신고하기 제목 추가
+export type SubmenuTitle = '공지사항' | '버스/교통' | '식단' | '시간표' | '복덕방' | '주변상점' | '교내 시설물 정보' | '코인 사장님' | '리뷰 작성하기' | '리뷰 수정하기' | '리뷰 신고하기' | '전화 주문 혜택';// 헤더에 리뷰 신고하기 제목 추가
 
 export interface Submenu {
   title: SubmenuTitle;
@@ -73,7 +73,7 @@ export const CATEGORY: Category[] = [
         tag: null,
       },
       {
-        title: '코인 for Business',
+        title: '코인 사장님',
         link: 'https://owner.koreatech.in/',
         newFlag: true,
         planFlag: false,


### PR DESCRIPTION
- Close #596 
  
## What is this PR? 🔍

- 기능 : 사이드 내비바 UI 수정, 닉네임 제거 가능하게 수정
- issue : #596 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 사이드 내비바에서 닉네임과 이름이 모두 없는 경우 "`님, 안녕하세요!`"라고 표시되던 것을 "`회원님, 안녕하세요!`"로 수정했습니다. 닉네임이 있는 경우는 닉네임이, 닉네임이 없고, 이름이 있는 경우는 이름이 표시되도록 수정했습니다.
- 정보 수정에서 submit 시 409에러를 반환하는 경우가 이미 존재하는 닉네임이 있을 때 반환하는 경우여서 에러 메시지를 수정했습니다.
- `코인 for business`로 되어 있던 것을 `코인 사장님`으로 수정했습니다. (헤더, 푸터, 사이드내브바 모두 반영)
- 닉네임이 기존에 있는 사용자의 경우, 닉네임을 제거하기 위해 빈 문자열로 남기고 제출 시 닉네임 input에 변동이 있었기 때문에 중복확인을 요합니다. 하지만 빈 문자열로 중복확인을 했을 때는 닉네임을 입력하라고 합니다. 이를 막기 위해 닉네임을 빈 문자열로 제출 시 중복확인을 요하지 않고 제출이 가능하게 수정했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
- 닉네임, 이름 모두 없는 경우
![image](https://github.com/user-attachments/assets/9eb0ff6c-f278-4d75-8344-29101cf9c28e)


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
