### PR TITLE
[시간표] 시간표 이슈 해결

### DIFF
--- a/src/pages/TimetablePage/MainTimetablePage/index.tsx
+++ b/src/pages/TimetablePage/MainTimetablePage/index.tsx
@@ -5,6 +5,7 @@ import useTimetableFrameList from 'pages/TimetablePage/hooks/useTimetableFrameLi
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
 import useTokenState from 'utils/hooks/state/useTokenState';
+import { useLocation } from 'react-router-dom';
 import DefaultPage from './DefaultPage';
 import styles from './TimetablePage.module.scss';
 
@@ -13,21 +14,25 @@ function TimetablePage() {
   useScrollToTop();
   const token = useTokenState();
   const semester = useSemester();
-  const [currentFrameIndex, setCurrentFrameIndex] = React.useState(0);
+  const location = useLocation();
   const { data: timetableFrameList } = useTimetableFrameList(token, semester);
-  sessionStorage.setItem('enterTimetablePage', new Date().getTime().toString());
+  const mainFrame = timetableFrameList.find(
+    (frame) => frame.is_main === true,
+  );
+  const [currentFrameIndex, setCurrentFrameIndex] = React.useState(
+    mainFrame?.id ? mainFrame.id : 0,
+  );
 
   React.useEffect(() => {
-    if (timetableFrameList) {
-      const mainFrame = timetableFrameList.find(
-        (frame) => frame.is_main === true,
-      );
-      if (mainFrame && mainFrame.id) {
-        setCurrentFrameIndex(mainFrame.id);
-      }
+    if (location.state?.frameId) {
+      setCurrentFrameIndex(Number(location.state?.frameId));
+    } else {
+      setCurrentFrameIndex(mainFrame?.id ? mainFrame.id : 0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [semester]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  sessionStorage.setItem('enterTimetablePage', new Date().getTime().toString());
 
   return (
     <div className={styles.page}>

--- a/src/pages/TimetablePage/ModifyTimetablePage/DefaultPage/index.tsx
+++ b/src/pages/TimetablePage/ModifyTimetablePage/DefaultPage/index.tsx
@@ -99,7 +99,7 @@ export default function DefaultPage({ frameId }: { frameId: string | undefined }
               <button
                 type="button"
                 className={styles['page__save-button']}
-                onClick={() => navigate('/timetable')}
+                onClick={() => navigate('/timetable', { state: { frameId } })}
               >
                 <div className={styles['page__pen-icon']}>
                   <PenIcon />

--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -1,6 +1,6 @@
 import ErrorBoundary from 'components/common/ErrorBoundary';
 import LoadingSpinner from 'components/common/LoadingSpinner';
-import { MyLectureInfo } from 'api/timetable/entity';
+import { LectureInfo, MyLectureInfo } from 'api/timetable/entity';
 import React from 'react';
 import useTimetableMutation from 'pages/TimetablePage/hooks/useTimetableMutation';
 import { useSemester, useSemesterAction } from 'utils/zustand/semester';
@@ -26,7 +26,7 @@ interface CurrentSemesterLectureListProps {
     department: string;
     search: string;
   };
-  myLectures: Array<MyLectureInfo>;
+  myLectures: Array<MyLectureInfo> | Array<LectureInfo>;
   frameId: number;
 }
 
@@ -57,6 +57,10 @@ function CurrentSemesterLectureList({
   const { updateTempLecture } = useTempLectureAction();
   const { addMyLecture } = useTimetableMutation(frameId);
 
+  const isMyLectureInfo = (
+    lectures: LectureInfo[] | MyLectureInfo[],
+  ): lectures is MyLectureInfo[] => (lectures as MyLectureInfo[])[0]?.class_infos !== undefined;
+
   return (
     lectureList?.length !== 0 ? (
       <LectureTable
@@ -86,52 +90,57 @@ function CurrentSemesterLectureList({
         onClickRow={(clickedLecture) => ('class_time' in clickedLecture ? updateTempLecture(clickedLecture) : undefined)}
         onDoubleClickRow={
           (clickedLecture) => {
+            if ('class_title' in clickedLecture) {
+              return;
+            }
             const isContainedLecture = myLectures.some(
               (lecture) => lecture.code === clickedLecture.code
               && lecture.lecture_class === clickedLecture.lecture_class,
             );
-            if ('class_title' in clickedLecture) {
-              return;
-            }
             if (isContainedLecture) {
               showToast('error', '동일한 과목이 이미 추가되어 있습니다.');
               return;
             }
-            const myLectureTimeValue = myLectures.flatMap((item) => (
-              item.class_infos.flatMap((info) => info.class_time)
-            ));
-
+            const myLectureTimeValue = isMyLectureInfo(myLectures)
+              ? myLectures.flatMap((item) => (
+                item.class_infos.flatMap((info) => info.class_time)
+              ))
+              : myLectures.flatMap((item) => item.class_time);
             if (
               clickedLecture.class_time.some((time: number) => myLectureTimeValue.includes(time))
             ) {
-              const myLectureList = myLectures;
-              const alreadySelectedLecture = myLectureList.find(
-                (lecture) => lecture.class_infos.some((schedule) => (
-                  schedule.class_time.some(
-                    (time) => clickedLecture.class_time.includes(time),
-                  )
-                )),
-              );
+              const alreadySelectedLecture = isMyLectureInfo(myLectures)
+                ? myLectures.find(
+                  (lecture) => lecture.class_infos.some((schedule) => (
+                    schedule.class_time.some(
+                      (time) => clickedLecture.class_time.includes(time),
+                    )
+                  )),
+                )
+                : myLectures.find((lecture) => lecture.class_time.some(
+                  (time) => clickedLecture.class_time.includes(time),
+                ));
               if (!alreadySelectedLecture) {
                 return;
               }
+              const alreadySelectedLectureName = 'name' in alreadySelectedLecture ? alreadySelectedLecture.name : alreadySelectedLecture.class_title;
               if (userInfo) {
                 if (alreadySelectedLecture.lecture_class) { // 분반이 존재하는 경우
                   showToast(
                     'error',
-                    `${alreadySelectedLecture.class_title}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
+                    `${alreadySelectedLectureName}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
                   );
                   return;
                 }
                 showToast( // 직접 강의를 추가하여 분반이 존재하지 않는 경우
                   'error',
-                  `${alreadySelectedLecture.class_title} 강의가 중복되어 추가할 수 없습니다.`,
+                  `${alreadySelectedLectureName} 강의가 중복되어 추가할 수 없습니다.`,
                 );
                 return;
               }
               showToast(
                 'error',
-                `${alreadySelectedLecture.class_title}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
+                `${alreadySelectedLectureName}(${alreadySelectedLecture.lecture_class}) 강의가 중복되어 추가할 수 없습니다.`,
               );
             } else {
               addMyLecture(clickedLecture);

--- a/src/pages/TimetablePage/components/TimetableList/TimetableList.module.scss
+++ b/src/pages/TimetablePage/components/TimetableList/TimetableList.module.scss
@@ -1,4 +1,4 @@
-@mixin textOverflow {
+@mixin textEllipsis {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -92,12 +92,12 @@
 
     &--main-title {
       max-width: 193px;
-      @include textOverflow();
+      @include textEllipsis();
     }
 
     &--title {
       max-width: 223px;
-      @include textOverflow();
+      @include textEllipsis();
     }
 
     &--bookmark-icon {

--- a/src/pages/TimetablePage/components/TimetableList/TimetableList.module.scss
+++ b/src/pages/TimetablePage/components/TimetableList/TimetableList.module.scss
@@ -1,3 +1,9 @@
+@mixin textOverflow {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .timetable-list {
   display: flex;
   flex-direction: column;
@@ -82,7 +88,16 @@
       display: flex;
       gap: 10px;
       align-items: center;
-      text-align: center;
+    }
+
+    &--main-title {
+      max-width: 193px;
+      @include textOverflow();
+    }
+
+    &--title {
+      max-width: 223px;
+      @include textOverflow();
     }
 
     &--bookmark-icon {

--- a/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/TimetableSettingModal/index.tsx
@@ -5,7 +5,6 @@ import useDeleteTimetableFrame from 'pages/TimetablePage/hooks/useDeleteTimetabl
 import { useSemester } from 'utils/zustand/semester';
 import showToast from 'utils/ts/showToast';
 import useTokenState from 'utils/hooks/state/useTokenState';
-import useTimetableFrameList from 'pages/TimetablePage/hooks/useTimetableFrameList';
 import { isKoinError, sendClientError } from '@bcsdlab/koin';
 import useMyLectures from 'pages/TimetablePage/hooks/useMyLectures';
 import { useOutsideClick } from 'utils/hooks/ui/useOutsideClick';
@@ -14,19 +13,14 @@ import styles from './TimetableSettingModal.module.scss';
 export interface TimetableSettingModalProps {
   focusFrame: TimetableFrameInfo;
   onClose: () => void;
-  setCurrentFrameIndex: React.Dispatch<number>;
-  currentFrameIndex: number;
 }
 
 export default function TimetableSettingModal({
   focusFrame,
   onClose,
-  setCurrentFrameIndex,
-  currentFrameIndex,
 }: TimetableSettingModalProps) {
   const token = useTokenState();
   const semester = useSemester();
-  const { data: myFrames } = useTimetableFrameList(token, semester);
   const myLectures = useMyLectures(focusFrame.id!);
   const { mutate: updateFrameInfo } = useUpdateTimetableFrame();
   const { backgroundRef } = useOutsideClick({ onOutsideClick: onClose });
@@ -70,12 +64,6 @@ export default function TimetableSettingModal({
     }
     try {
       await deleteTimetableFrame({ id: focusFrame.id, frame: focusFrame });
-
-      // 현재 선택된 프레임이 삭제되면 메인 프레임으로 변경
-      if (currentFrameIndex === focusFrame.id) {
-        const defaultFrameId = myFrames.find((table) => table.is_main)?.id;
-        if (defaultFrameId) setCurrentFrameIndex(defaultFrameId);
-      }
       onClose();
     } catch (err) {
       if (isKoinError(err)) {

--- a/src/pages/TimetablePage/components/TimetableList/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/index.tsx
@@ -187,8 +187,6 @@ export default function TimetableList({
       {isModalOpen && (
         <TimetableSettingModal
           focusFrame={focusFrame!}
-          setCurrentFrameIndex={setCurrentFrameIndex}
-          currentFrameIndex={currentFrameIndex}
           onClose={closeModal}
         />
       )}

--- a/src/pages/TimetablePage/components/TimetableList/index.tsx
+++ b/src/pages/TimetablePage/components/TimetableList/index.tsx
@@ -123,7 +123,7 @@ export default function TimetableList({
               onClick={() => frame.id && setCurrentFrameIndex(frame.id)}
             >
               <div className={styles['timetable-list__item--title-container']}>
-                <li>{frame.timetable_name}</li>
+                <li className={styles['timetable-list__item--main-title']}>{frame.timetable_name}</li>
                 <div className={styles['timetable-list__item--bookmark-icon']}>
                   <BookMarkIcon />
                 </div>
@@ -156,7 +156,7 @@ export default function TimetableList({
               key={frame.id}
               onClick={() => frame.id && setCurrentFrameIndex(frame.id)}
             >
-              <li>{frame.timetable_name}</li>
+              <li className={styles['timetable-list__item--title']}>{frame.timetable_name}</li>
               <button
                 type="button"
                 className={styles['timetable-list__item--setting']}


### PR DESCRIPTION
- Close #597 
  
## What is this PR? 🔍

- 기능 : 시간표 페이지에 있던 이슈를 해결했습니다.
- issue : #597 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 시간표 프레임의 이름이 한 줄을 넘길 경우 `ellipsis(...)` 처리를 했습니다.
- 현재 보고 있는 시간표 프레임을 삭제하는 경우 메인 시간표로 이동하게 하는 로직이 두 군데 있어서 중복된 로직을 제거했습니다.
- 메인 시간표 프레임 외 다른 일반 시간표를 수정하고 수정 완료 버튼을 누르면 메인 시간표로 돌아가는 현상을 수정했습니다.(수정하던 시간표 프레임으로 돌아가도록)
- 비로그인 시 강의 추가가 안 되던 것을 수정했습니다. (그 이유는 로컬 스토리지에 있는 `myLectures`의 타입과 서버에서 반환하는 `myLectures` 타입이 맞지 않기 때문입니다.  로컬 스토리지에서는 `class_time`을 사용, 서버에서는 `class_infos`의 `class_time`을 사용)
  - 내 강의에 대해 두 가지 타입이 있습니다. `MyLectureInfo[]`와 `LectureInfo[]`입니다. `LectureInfo`는 현재 학기의 강의 목록에 대한 타입이고, `MyLectureInfo`는 서버에서 반환해주는 나의 강의 정보입니다. 비로그인 시에는 로컬 스토리지로 저장하고 그 값을 불러오는데, 강의 목록에서 바로 추가하다보니 그 강의 정보 그대로 로컬 스토리지에 저장합니다. 그 강의 정보를 `MyLectureInfo` 타입으로 변환하여 저장할 수 있지만, 변환하는 과정에 있어 `class_time`을 요일별로 분리되어 있는지 확인하고 class_infos의 `class_time`에 추가해야 하는 불편함이 있습니다. 서버에서 반환하는 강의 목록 응답값도 나중에는 현재의 `MyLectureInfo[]` 타입으로 바뀌어야 할 예정이기 때문에 일단은 두 가지 타입을 사용하는 판단을 했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
- 시간표 프레임 이름 한 줄 처리
![image](https://github.com/user-attachments/assets/3e036f0b-f1c9-4fda-80b4-52d9ac9a806b)

- 수정하던 시간표 프레임으로 돌아옴'

https://github.com/user-attachments/assets/3bb24d8f-b99f-4683-8f52-453e048c042a


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
