### PR TITLE
[유저] 회원가입 페이지 성별 선택 불가 이슈 해결

### DIFF
--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -343,7 +343,7 @@ const GenderListbox = React.forwardRef<ICustomFormInput, ICustomFormInputProps>(
               role="option"
               aria-selected={optionValue.value === currentValue}
               data-value={optionValue.value}
-              onClick={onClickOption}
+              onMouseDown={onClickOption}
               onKeyPress={onKeyPressOption}
             >
               {optionValue.label}


### PR DESCRIPTION
- Close #609 
  
## What is this PR? 🔍

- 기능 : 회원가입 페이지에서 성별 선택이 안 되는 것을 수정
- issue : #609

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 성별 선택 드롭다운에 `onBlur` 이벤트를 추가하여 바깥 클릭 시 드롭다운이 닫히도록 구현했었습니다. 그 상태로 성별 선택을 위해 `li` 아이템에 `onClick` 이벤트를 실행하려 하니 성별 선택이 되지 않은 채로 드롭다운 메뉴가 닫히는 현상이 발생했습니다. 그 이유가 이벤트 핸들러의 작동 순서 때문이라는 것을 알게되었습니다.
`onBlur -> onClick` 순으로 이벤트 핸들러가 작동하기 때문에 `onClick` 이벤트가 실행되지 않고 드롭다운이 닫히는 것이었습니다! 따라서 `onBlur`의 작동 순서보다 앞서는 `onMouseDown` 이벤트를 사용해 해결했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
