### PR TITLE
[QA] 혜택페이지 카테고리 클릭 이후 뒤로가기 동작 시 히스토리 남기는 기능 제거

### DIFF
--- a/src/pages/Store/StoreBenefitPage/index.tsx
+++ b/src/pages/Store/StoreBenefitPage/index.tsx
@@ -35,7 +35,7 @@ function StoreBenefitPage() {
       current_page: value,
       duration_time: (new Date().getTime() - Number(sessionStorage.getItem('enterMain'))) / 1000,
     });
-    setParams('category', `${id}`, { deleteBeforeParam: false, replacePage: false });
+    setParams('category', `${id}`, { deleteBeforeParam: true, replacePage: true });
   };
 
   return (

--- a/src/utils/hooks/routing/useParamsHandler.ts
+++ b/src/utils/hooks/routing/useParamsHandler.ts
@@ -3,25 +3,28 @@ import { useSearchParams } from 'react-router-dom';
 const useParamsHandler = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const params = Object.fromEntries(searchParams);
+
   const setParams = (
     key: string,
     value: string,
     option: {
-      deleteBeforeParam: boolean,
-      replacePage: boolean,
-    },
+      deleteBeforeParam?: boolean;
+      replacePage?: boolean;
+    } = {},
   ) => {
-    if (option.deleteBeforeParam) {
-      const param = searchParams.get(key);
-      if (param) {
-        searchParams.delete(key);
-        setSearchParams(searchParams, { replace: option.replacePage });
-        return;
-      }
+    const { deleteBeforeParam = false, replacePage = false } = option;
+
+    const newSearchParams = new URLSearchParams(searchParams);
+
+    if (deleteBeforeParam) {
+      newSearchParams.delete(key);
     }
-    searchParams.set(key, value);
-    setSearchParams(searchParams, { replace: option.replacePage });
+
+    newSearchParams.set(key, value);
+
+    setSearchParams(newSearchParams, { replace: replacePage });
   };
+
   return {
     params,
     searchParams,


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 혜택페이지 카테고리 클릭 이후 뒤로가기 동작 시 히스토리 남기는 기능 제거

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
setParams 과정에서 replace 옵션 제어를 통해 에러를 수정했습니다.
그리고 또한 searchParams 훅에 대한 기능 수정을 통해 옵션이 리렌더링 과정에서의 호출을 줄이고, 기능 중 earchParams 객체는 React 상태와 동기화되지 않는 가변 객체인 문제로, 이를 직접 수정(delete 또는 set)한 뒤, 다시 setSearchParams를 호출해야 상태가 반영되도록 로직을 수정했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

https://github.com/user-attachments/assets/50a30715-d9d4-42af-9bb7-db29edfc01e9


## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
