### PR TITLE
[hotfix, 시간표] 계절학기 시 강의 수정 페이지 안 들어가지는 오류 수정

### DIFF
--- a/src/components/TimetablePage/LectureTable/index.tsx
+++ b/src/components/TimetablePage/LectureTable/index.tsx
@@ -145,7 +145,7 @@ function LectureTable({
           <div
             className={cn({
               [styles.table__row]: true,
-              [styles['table__row--include']]: version === 'semesterLectureList' ? myLectures.some(
+              [styles['table__row--include']]: (version === 'semesterLectureList' && myLectures) ? myLectures.some(
                 (item) => item.code === lecture.code
                   && item.lecture_class === lecture.lecture_class,
               ) : false,

--- a/src/pages/TimetablePage/ModifyTimetablePage/index.tsx
+++ b/src/pages/TimetablePage/ModifyTimetablePage/index.tsx
@@ -12,12 +12,12 @@ export default function ModifyTimetablePage() {
   const navigation = useNavigate();
 
   useEffect(() => {
-    if (frameId === null || Number.isNaN(frameId)) {
+    if (frameId === null) {
       navigation('/timetable');
     }
   }, [frameId, navigation]);
 
-  if (frameId === null || Number.isNaN(frameId)) {
+  if (frameId === null) {
     return null;
   }
 

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -134,6 +134,8 @@ function CustomLecture({ frameId }: { frameId: number }) {
 
     if (hasOverlapInCurrent) return true;
 
+    if (!existingLectures) return false;
+
     // 기존 강의와 중복 검사
     return existingLectures.some((myLecture) => {
       if (excludeLectureId && myLecture.id === excludeLectureId) {

--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -93,6 +93,9 @@ function CurrentSemesterLectureList({
             if ('class_title' in clickedLecture) {
               return;
             }
+            if (!myLectures) {
+              addMyLecture(clickedLecture);
+            }
             const isContainedLecture = myLectures.some(
               (lecture) => lecture.code === clickedLecture.code
                 && lecture.lecture_class === clickedLecture.lecture_class,

--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -95,6 +95,7 @@ function CurrentSemesterLectureList({
             }
             if (!myLectures) {
               addMyLecture(clickedLecture);
+              return;
             }
             const isContainedLecture = myLectures.some(
               (lecture) => lecture.code === clickedLecture.code


### PR DESCRIPTION
- Close #615 
  
## What is this PR? 🔍

- 기능 : 계절학기 시 강의 수정 페이지 안 들어가지는 오류 수정
- issue : #615 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 학기가 계절학기인 경우 강의 수정 페이지가 안 들어가지는 오류를 수정했습니다.
- 또한 내 강의정보(`myLectures`)가 `undefined`인 경우가 있어 이 경우 일부 `Array` 메서드를 사용하지 못하므로 조건 처리했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
