### PR TITLE
[hotfix] 지금 출발 버튼 크기 수정

### DIFF
--- a/src/pages/Bus/BusRoutePage/components/TimeDetail/TimeDetailPC/TimeDetailPC.module.scss
+++ b/src/pages/Bus/BusRoutePage/components/TimeDetail/TimeDetailPC/TimeDetailPC.module.scss
@@ -50,8 +50,6 @@
   }
 
   &__button {
-    width: 87px;
-    height: 42px;
     padding: 6px 12px;
     margin-left: 16px;
     border-radius: 4px;


### PR DESCRIPTION
- Close #648 
  
## What is this PR? 🔍

- 기능 : 폰트 깨짐으로 인해 버튼 내부에서 줄바꿈이 일어나는 버그입니다.
- issue : #648 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
버튼에서 `width` 속성을 제거하였습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="422" alt="image" src="https://github.com/user-attachments/assets/0ed776d7-8a04-4d14-b851-031c8578ea62" />


## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
