### PR TITLE
[시간표] 커스텀 시간표 페이지 리팩터링

### DIFF
--- a/src/api/timetable/APIDetail.ts
+++ b/src/api/timetable/APIDetail.ts
@@ -234,8 +234,8 @@ implements APIRequest<R> {
 
   auth = true;
 
-  constructor(public authorization: string, frameId: number) {
-    this.path = `/v3/timetables/frame/rollback?timetable_frame_id=${frameId}`;
+  constructor(public authorization: string, timetableFrameId: number) {
+    this.path = `/v3/timetables/frame/rollback?timetable_frame_id=${timetableFrameId}`;
   }
 }
 

--- a/src/components/TimetablePage/LectureTable/index.tsx
+++ b/src/components/TimetablePage/LectureTable/index.tsx
@@ -13,7 +13,7 @@ import styles from './LectureTable.module.scss';
 
 interface LectureTableProps {
   rowWidthList: number[];
-  frameId: number;
+  timetableFrameId: number;
   list: Array<Lecture> | Array<MyLectureInfo>;
   myLectures: Array<Lecture> | Array<MyLectureInfo>;
   selectedLecture: Lecture | undefined;
@@ -40,7 +40,7 @@ export const LECTURE_TABLE_HEADER = [
 
 function LectureTable({
   rowWidthList,
-  frameId,
+  timetableFrameId,
   list,
   myLectures,
   selectedLecture,
@@ -66,10 +66,10 @@ function LectureTable({
       return;
     }
 
-    navigate(`/timetable/modify/direct/${frameId}?lectureIndex=${lectureIndex}`);
+    navigate(`/timetable/modify/direct/${timetableFrameId}?lectureIndex=${lectureIndex}`);
   };
 
-  const { removeMyLecture } = useTimetableMutation(frameId);
+  const { removeMyLecture } = useTimetableMutation(timetableFrameId);
   const handleRemoveLectureClick = ({ id }: RemoveLectureProps) => {
     myLectures.forEach((lecture) => {
       if (lecture.id === id) {

--- a/src/components/TimetablePage/Listbox/index.tsx
+++ b/src/components/TimetablePage/Listbox/index.tsx
@@ -17,7 +17,7 @@ export interface ListItem {
 }
 
 export interface ListboxProps {
-  list: ListItem[];
+  list: readonly ListItem[];
   value: string | null;
   onChange: (event: { target: ListboxRef }) => void;
   version?: 'default' | 'new' | 'inModal' | 'addLecture';

--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -29,7 +29,7 @@ function CurrentSemesterTimetable() {
 
   return (
     <Timetable
-      frameId={currentFrameIndex}
+      timetableFrameId={currentFrameIndex}
       columnWidth={44}
       firstColumnWidth={29}
       rowHeight={17.3}

--- a/src/pages/TimetablePage/MainTimetablePage/DefaultPage/index.tsx
+++ b/src/pages/TimetablePage/MainTimetablePage/DefaultPage/index.tsx
@@ -8,11 +8,11 @@ import TimetableIcon from 'assets/svg/timetable-icon.svg';
 import styles from './DefaultPage.module.scss';
 
 interface DefaultPageProps {
-  frameId: number,
+  timetableFrameId: number,
   setCurrentFrameId: (index: number) => void,
 }
 
-export default function DefaultPage({ frameId, setCurrentFrameId }: DefaultPageProps) {
+export default function DefaultPage({ timetableFrameId, setCurrentFrameId }: DefaultPageProps) {
   const logger = useLogger();
   const handlePopState = React.useCallback(() => {
     history.back();
@@ -82,10 +82,10 @@ export default function DefaultPage({ frameId, setCurrentFrameId }: DefaultPageP
       >
         <div className={styles.page__content}>
           <TimetableList
-            currentFrameIndex={frameId}
+            currentFrameIndex={timetableFrameId}
             setCurrentFrameIndex={setCurrentFrameId}
           />
-          <MainTimetable frameId={frameId} />
+          <MainTimetable timetableFrameId={timetableFrameId} />
         </div>
       </Suspense>
     </div>

--- a/src/pages/TimetablePage/MainTimetablePage/MobilePage/index.tsx
+++ b/src/pages/TimetablePage/MainTimetablePage/MobilePage/index.tsx
@@ -8,7 +8,7 @@ import useLogger from 'utils/hooks/analytics/useLogger';
 import useImageDownload from 'utils/hooks/ui/useImageDownload';
 import styles from './MobilePage.module.scss';
 
-function MobilePage({ frameId }: { frameId: number }) {
+function MobilePage({ timetableFrameId }: { timetableFrameId: number }) {
   const logger = useLogger();
   const { onImageDownload: onTimetableImageDownload, divRef: timetableRef } = useImageDownload();
   const handleImageDownloadClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -57,7 +57,7 @@ function MobilePage({ frameId }: { frameId: number }) {
               )}
             >
               <Timetable
-                frameId={frameId}
+                timetableFrameId={timetableFrameId}
                 columnWidth={55}
                 firstColumnWidth={52}
                 rowHeight={21}

--- a/src/pages/TimetablePage/MainTimetablePage/index.tsx
+++ b/src/pages/TimetablePage/MainTimetablePage/index.tsx
@@ -36,7 +36,10 @@ function TimetablePage() {
   return (
     <div className={styles.page}>
       {!isMobile ? (
-        <DefaultPage timetableFrameId={currentFrameIndex} setCurrentFrameId={setCurrentFrameIndex} />
+        <DefaultPage
+          timetableFrameId={currentFrameIndex}
+          setCurrentFrameId={setCurrentFrameIndex}
+        />
       ) : (
         <MobilePage timetableFrameId={currentFrameIndex} />
       )}

--- a/src/pages/TimetablePage/MainTimetablePage/index.tsx
+++ b/src/pages/TimetablePage/MainTimetablePage/index.tsx
@@ -24,8 +24,8 @@ function TimetablePage() {
   );
 
   React.useEffect(() => {
-    if (location.state?.frameId) {
-      setCurrentFrameIndex(Number(location.state?.frameId));
+    if (location.state?.timetableFrameId) {
+      setCurrentFrameIndex(Number(location.state?.timetableFrameId));
     } else {
       setCurrentFrameIndex(mainFrame?.id ? mainFrame.id : 0);
     }
@@ -36,9 +36,9 @@ function TimetablePage() {
   return (
     <div className={styles.page}>
       {!isMobile ? (
-        <DefaultPage frameId={currentFrameIndex} setCurrentFrameId={setCurrentFrameIndex} />
+        <DefaultPage timetableFrameId={currentFrameIndex} setCurrentFrameId={setCurrentFrameIndex} />
       ) : (
-        <MobilePage frameId={currentFrameIndex} />
+        <MobilePage timetableFrameId={currentFrameIndex} />
       )}
     </div>
   );

--- a/src/pages/TimetablePage/ModifyTimetablePage/DefaultPage/index.tsx
+++ b/src/pages/TimetablePage/ModifyTimetablePage/DefaultPage/index.tsx
@@ -15,11 +15,11 @@ import { useTempLecture } from 'utils/zustand/myTempLecture';
 import TimetableIcon from 'assets/svg/timetable-icon.svg';
 import styles from './DefaultPage.module.scss';
 
-export default function DefaultPage({ frameId }: { frameId: number }) {
+export default function DefaultPage({ timetableFrameId }: { timetableFrameId: number }) {
   const navigate = useNavigate();
   const semester = useSemester();
   const { pathname } = useLocation();
-  const { myLectures } = useMyLectures(Number(frameId));
+  const { myLectures } = useMyLectures(Number(timetableFrameId));
   const { data: lectureList } = useLectureList(semester);
   const tempLecture = useTempLecture();
   const similarSelectedLecture = lectureList
@@ -29,7 +29,7 @@ export default function DefaultPage({ frameId }: { frameId: number }) {
     .findIndex(({ lecture_class }) => lecture_class === tempLecture?.lecture_class);
   const handleCourseClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const { value: courseType } = e.currentTarget;
-    navigate(`/timetable/modify/${courseType}/${frameId}`);
+    navigate(`/timetable/modify/${courseType}/${timetableFrameId}`);
   };
 
   return (
@@ -83,9 +83,9 @@ export default function DefaultPage({ frameId }: { frameId: number }) {
             </div>
             {/* TODO: 직접 추가 UI, 강의 리스트 UI 추가 */}
             {pathname.includes('/regular') ? (
-              <LectureList frameId={frameId} />
+              <LectureList timetableFrameId={timetableFrameId} />
             ) : (
-              <CustomLecture frameId={frameId} />
+              <CustomLecture timetableFrameId={timetableFrameId} />
             )}
           </div>
           <div className={styles.page__timetable}>
@@ -96,7 +96,7 @@ export default function DefaultPage({ frameId }: { frameId: number }) {
               <button
                 type="button"
                 className={styles['page__save-button']}
-                onClick={() => navigate('/timetable', { state: { frameId } })}
+                onClick={() => navigate('/timetable', { state: { timetableFrameId } })}
               >
                 <div className={styles['page__pen-icon']}>
                   <PenIcon />
@@ -107,7 +107,7 @@ export default function DefaultPage({ frameId }: { frameId: number }) {
             <ErrorBoundary fallbackClassName="loading">
               <React.Suspense fallback={<LoadingSpinner size="50" />}>
                 <Timetable
-                  frameId={frameId}
+                  timetableFrameId={timetableFrameId}
                   similarSelectedLecture={similarSelectedLecture}
                   selectedLectureIndex={selectedLectureIndex}
                   columnWidth={88.73}

--- a/src/pages/TimetablePage/ModifyTimetablePage/index.tsx
+++ b/src/pages/TimetablePage/ModifyTimetablePage/index.tsx
@@ -8,25 +8,25 @@ import styles from './ModifyTimetablePage.module.scss';
 export default function ModifyTimetablePage() {
   const isMobile = useMediaQuery();
   const { id } = useParams();
-  const frameId = id ? Number(id) : null;
+  const timetableFrameId = id ? Number(id) : null;
   const navigation = useNavigate();
 
   useEffect(() => {
-    if (frameId === null) {
+    if (timetableFrameId === null) {
       navigation('/timetable');
     }
-  }, [frameId, navigation]);
+  }, [timetableFrameId, navigation]);
 
-  if (frameId === null) {
+  if (timetableFrameId === null) {
     return null;
   }
 
   return (
     <div className={styles.page}>
       {!isMobile ? (
-        <DefaultPage frameId={frameId} />
+        <DefaultPage timetableFrameId={timetableFrameId} />
       ) : (
-        <MobilePage frameId={frameId} />
+        <MobilePage timetableFrameId={timetableFrameId} />
       )}
     </div>
   );

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -83,14 +83,16 @@ function TimeSpaceInput({
       (info) => {
         const findKeyByValue = (object: Record<Hour, number>, value: number) => Object
           .entries(object).find(([, val]) => val === value)?.[0] as Hour;
-        const startHour = info.start_time % 2 === 0
-          ? findKeyByValue(START_TIME, info.start_time % 100)
-          : findKeyByValue(START_TIME, (info.start_time % 100) - 1);
-        const startMinute: Minute = info.start_time % 2 === 0 ? '00분' : '30분';
-        const endHour = info.end_time % 2 !== 0
-          ? findKeyByValue(END_TIME, info.end_time % 100)
-          : findKeyByValue(END_TIME, (info.end_time % 100) - 1);
-        const endMinute: Minute = info.end_time % 2 !== 0 ? '00분' : '30분';
+        const getHour = (time: number, key: Record<Hour, number>, isStart: boolean) => {
+          const adjustedTime = time % 2 === (isStart ? 0 : 1) ? time : time - 1;
+          return findKeyByValue(key, adjustedTime);
+        };
+        const getMinute = (time: number, isStart: boolean): Minute => (time % 2 === (isStart ? 0 : 1) ? '00분' : '30분');
+
+        const startHour = getHour(info.start_time, START_TIME, true);
+        const startMinute: Minute = getMinute(info.start_time, true);
+        const endHour = getHour(info.end_time, END_TIME, false);
+        const endMinute: Minute = getMinute(info.end_time, false);
 
         return {
           time: {

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -1,4 +1,6 @@
-import { useState, useEffect, useRef } from 'react';
+import {
+  useState, useEffect, useRef,
+} from 'react';
 import { cn } from '@bcsdlab/utils';
 import AddIcon from 'assets/svg/add-icon.svg';
 import CloseIcon from 'assets/svg/close-icon-black.svg';
@@ -12,7 +14,7 @@ import { useCustomTempLecture, useCustomTempLectureAction } from 'utils/zustand/
 import showToast from 'utils/ts/showToast';
 import useMyLectures from 'pages/TimetablePage/hooks/useMyLectures';
 import { useSearchParams } from 'react-router-dom';
-import { LectureInfo, MyLectureInfo } from 'api/timetable/entity';
+import { MyLectureInfo } from 'api/timetable/entity';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import uuidv4 from 'utils/ts/uuidGenerater';
 import styles from './CustomLecture.module.scss';
@@ -32,7 +34,6 @@ type TimeSpaceComponents = {
   startTime: number,
   endTime: number,
   place: string,
-  id: string,
 };
 
 const initialTimeSpaceComponent: TimeSpaceComponents = {
@@ -46,294 +47,40 @@ const initialTimeSpaceComponent: TimeSpaceComponents = {
   startTime: 0,
   endTime: 1,
   place: '',
-  id: uuidv4(),
 };
 
-function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
-  const token = useTokenState();
-  const customTempLecture = useCustomTempLecture();
-  const { updateCustomTempLecture } = useCustomTempLectureAction();
-  const { myLectures } = useMyLectures(timetableFrameId);
-  const { addMyLecture, editMyLecture } = useTimetableMutation(timetableFrameId);
+const timeOffsets: Record<string, number> = {
+  월: 0,
+  화: 1,
+  수: 2,
+  목: 3,
+  금: 4,
+};
 
+function TimeSpaceInput({
+  id,
+  isEditStandardLecture,
+  isSingleTimeSpaceComponent,
+  handleDeleteTimeSpaceComponent,
+  isFirstSubmit,
+  isReverseDropdown,
+}: {
+  id: string,
+  isEditStandardLecture: boolean,
+  isSingleTimeSpaceComponent: boolean,
+  handleDeleteTimeSpaceComponent: () => void,
+  isFirstSubmit: boolean,
+  isReverseDropdown: boolean
+}) {
   const [searchParams] = useSearchParams();
   const lectureIndex = searchParams.get('lectureIndex');
-  const selectedLecture = lectureIndex ? myLectures[Number(lectureIndex)] : null;
-  const selectedEditLecture = selectedLecture as MyLectureInfo | null;
-  const isEditStandardLecture = selectedEditLecture?.lecture_id !== null && !!selectedEditLecture;
+  const customTempLecture = useCustomTempLecture();
+  const { updateCustomTempLecture } = useCustomTempLectureAction();
 
-  // 직접 추가 input 값
-  const [lectureName, setLectureName] = useState('');
-  const [professorName, setProfessorName] = useState('');
-  const [timeSpaceComponents, setTimeSpaceComponents] = useState<TimeSpaceComponents[]>(
-    [initialTimeSpaceComponent],
-  );
-
-  const timeSpaceContainerRef = useRef<HTMLDivElement>(null);
-  const reverseRef = useRef<HTMLDivElement[] | null[]>([]);
-  const [positionValues, setPositionValues] = useState<number[]>([]);
-  const [isFirstSubmit, setIsFirstSubmit] = useState(true);
-
-  const isValid = (lectureName !== ''
-    && !timeSpaceComponents.some(
-      (time) => time.endTime - time.startTime < 0 || time.week.length === 0,
-    )
-  );
-  const isOverflow = timeSpaceContainerRef.current
-    ? timeSpaceContainerRef.current.getBoundingClientRect().height > 400
-    : false;
-  const isReverseDropdown = positionValues.map(
-    (value) => (timeSpaceContainerRef.current
-      ? timeSpaceContainerRef.current.getBoundingClientRect().bottom - value < 150
-      : false),
-  );
-  const isSingleTimeSpaceComponent = timeSpaceComponents.length === 1;
-
-  const changeToTimetableTime = (timeInfo: {
-    startHour: Hour;
-    startMinute: Minute;
-    endHour: Hour;
-    endMinute: Minute;
-  }) => {
-    const timetableStart = START_TIME[timeInfo.startHour] + (timeInfo.startMinute === '00분' ? 0 : 1);
-    const timetableEnd = END_TIME[timeInfo.endHour] + (timeInfo.endMinute === '00분' ? 0 : 1);
-
-    return {
-      startTime: timetableStart,
-      endTime: timetableEnd,
-    };
-  };
-  const addWeekTime = (
-    weekInfo: string[],
-    startTime: number,
-    endTime: number,
-  ) => weekInfo.map((week) => {
-    switch (week) {
-      case '월':
-        return {
-          startTime,
-          endTime,
-        };
-      case '화':
-        return {
-          startTime: startTime + 100,
-          endTime: endTime + 100,
-        };
-      case '수':
-        return {
-          startTime: startTime + 200,
-          endTime: endTime + 200,
-        };
-      case '목':
-        return {
-          startTime: startTime + 300,
-          endTime: endTime + 300,
-        };
-      default:
-        return {
-          startTime: startTime + 400,
-          endTime: endTime + 400,
-        };
-    }
-  });
-
-  const hasTimeConflict = (
-    excludeLectureId?: number,
-  ): boolean => {
-    const currentComponents = customTempLecture?.lecture_infos;
-    const hasOverlapInCurrent = currentComponents!.some(
-      (item, index) => currentComponents!.slice(index + 1).some(
-        (other) => Math.floor(item.start_time / 100) === Math.floor(other.start_time / 100)
-        && item.start_time <= other.end_time && other.start_time <= item.end_time,
-      ),
-    );
-    if (hasOverlapInCurrent) return true;
-
-    if (!myLectures) return false;
-
-    return myLectures.some((myLecture) => {
-      if (excludeLectureId && myLecture.id === excludeLectureId) {
-        return false;
-      }
-      return myLecture.lecture_infos.some(
-        (info) => currentComponents!.some(
-          (times) => Math.floor(times.start_time / 100) === info.day
-            && info.start_time % 100 <= times.end_time % 100
-            && times.start_time % 100 <= info.end_time % 100,
-        ),
-      );
-    });
-  };
-  const handleSubmitLecture = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!isValid) {
-      setIsFirstSubmit(false);
-      return;
-    }
-
-    // 중복 시간 검사
-    if (hasTimeConflict(selectedEditLecture?.id)) {
-      showToast('error', '강의가 중복되어 추가할 수 없습니다.');
-      return;
-    }
-
-    const isContainComma = timeSpaceComponents.some((item) => item.place.includes(','));
-    if (isContainComma) {
-      showToast('error', '쉼표 문자 ( , )를 제외하고 입력해 주세요.');
-      return;
-    }
-
-    if (selectedEditLecture && customTempLecture) {
-      editMyLecture({
-        id: selectedEditLecture.id,
-        class_title: lectureName,
-        lecture_infos: customTempLecture.lecture_infos.map((schedule) => ({
-          start_time: schedule.start_time,
-          end_time: schedule.end_time,
-          place: schedule.place,
-        })),
-        professor: professorName,
-      });
-      return;
-    }
-    addMyLecture(customTempLecture!);
-
-    setLectureName('');
-    setProfessorName('');
-    setTimeSpaceComponents([initialTimeSpaceComponent]);
-    setIsFirstSubmit(true);
-  };
-
-  const handleScroll = () => {
-    const updatedValues = reverseRef.current
-      .map((element) => element?.getBoundingClientRect().bottom || 0);
-    setPositionValues(updatedValues);
-  };
-
-  const handleAddTimeSpaceComponent = () => {
-    if (timeSpaceComponents.length > 4) {
-      showToast(
-        'info',
-        '"시간 및 장소 추가"는 최대 5개까지 가능합니다.',
-      );
-      return;
-    }
-
-    setTimeSpaceComponents(
-      (prevComponents) => [...prevComponents, { ...initialTimeSpaceComponent, id: uuidv4() }],
-    );
-
-    setTimeout(() => {
-      timeSpaceContainerRef.current!.scrollTo({
-        behavior: 'smooth',
-        top: 999,
-      });
-    }, 0);
-  };
-
-  const handleDeleteTimeSpaceComponent = (index: number) => {
-    setTimeSpaceComponents((prev) => {
-      const updatedComponent = [...prev];
-      updatedComponent.splice(index, 1);
-      return updatedComponent;
-    });
-  };
-
-  const handleLectureTimeByTime = (key: string, index: number) => (
-    e: { target: { value: string } },
-  ) => {
-    const { target } = e;
-    let newTimeInfo = {
-      ...timeSpaceComponents[index].time,
-      [key]: target?.value,
-    };
-
-    let newTimetableTime = changeToTimetableTime(newTimeInfo);
-    // 올바르지 않은 시간을 선택했을 시
-    if (newTimetableTime.endTime - newTimetableTime.startTime < 0) {
-      const newStartHour = Number(newTimeInfo.startHour.slice(0, 2));
-      const newEndHour = Number(newTimeInfo.endHour.slice(0, 2));
-      if (key.slice(0, 5) === 'start') {
-        newTimeInfo = {
-          ...newTimeInfo,
-          endHour: `${newStartHour + 1}시` as Hour,
-          endMinute: newStartHour + 1 === 24 ? '00분' : newTimeInfo.startMinute,
-        };
-      } else {
-        newTimeInfo = {
-          ...newTimeInfo,
-          startHour: newEndHour - 1 < 10 ? '09시' : `${newEndHour - 1}시` as Hour,
-          startMinute: newEndHour - 1 < 9 ? '00분' : newTimeInfo.endMinute,
-        };
-      }
-      newTimetableTime = changeToTimetableTime(newTimeInfo);
-    }
-
-    const updatedComponents = [...timeSpaceComponents];
-    updatedComponents[index] = {
-      ...updatedComponents[index],
-      time: newTimeInfo,
-      startTime: newTimetableTime.startTime,
-      endTime: newTimetableTime.endTime,
-    };
-    setTimeSpaceComponents(updatedComponents);
-  };
-
-  const handleLectureTimeByWeek = (weekday: string, index: number) => {
-    let newWeekInfo = [...timeSpaceComponents[index].week];
-    if (newWeekInfo.includes(weekday)) {
-      newWeekInfo = newWeekInfo.filter((day) => day !== weekday);
-      (newWeekInfo.filter((day) => day !== weekday));
-    } else {
-      newWeekInfo = [...newWeekInfo, weekday];
-    }
-    const updatedComponents = [...timeSpaceComponents];
-    updatedComponents[index] = {
-      ...updatedComponents[index],
-      week: newWeekInfo,
-    };
-    setTimeSpaceComponents(updatedComponents);
-  };
-
-  const handlePlaceName = (placeName: string, index: number) => {
-    const updatedComponents = [...timeSpaceComponents];
-    updatedComponents[index] = {
-      ...updatedComponents[index],
-      place: placeName,
-    };
-    setTimeSpaceComponents(updatedComponents);
-  };
-
-  useEffect(() => {
-    if (customTempLecture) {
-      const transformedLectureInfos = timeSpaceComponents.flatMap((info) => {
-        const totals = addWeekTime(info.week, info.startTime, info.endTime);
-
-        return totals.map((times) => ({
-          start_time: times.startTime,
-          end_time: times.endTime,
-          place: info.place,
-        }));
-      });
-
-      updateCustomTempLecture({
-        ...customTempLecture,
-        class_title: lectureName,
-        professor: professorName,
-        lecture_infos: transformedLectureInfos,
-      });
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lectureName, professorName, timeSpaceComponents]);
-
-  useEffect(() => {
-    if (!selectedEditLecture) return;
-
-    setLectureName(selectedEditLecture.class_title);
-    setProfessorName(selectedEditLecture.professor);
-
-    const updatedComponents = selectedEditLecture.lecture_infos.map(
-      (info: LectureInfo) => {
+  // updatedTimeSpaceComponent: 강의 수정 시 해당 강의 정보를 TimeSpaceComponent로 옮긴 변수.
+  const updatedTimeSpaceComponent = lectureIndex
+    ? customTempLecture!.lecture_infos.filter((info) => info.id === id).map(
+      (info) => {
         const findKeyByValue = (object: Record<Hour, number>, value: number) => Object
           .entries(object).find(([, val]) => val === value)?.[0] as Hour;
         const startHour = info.start_time % 2 === 0
@@ -352,16 +99,459 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
             endHour,
             endMinute,
           },
-          week: [DAYS_STRING[Math.floor(info.start_time / 100)]],
+          week: info.days,
           startTime: info.start_time % 100,
           endTime: info.end_time % 100,
           place: info.place || '',
-          id: uuidv4(),
         };
       },
-    );
+    ) : null;
 
-    setTimeSpaceComponents(updatedComponents);
+  const [
+    weeks, setWeeks,
+  ] = useState<string[]>(lectureIndex
+    ? updatedTimeSpaceComponent![0].week : initialTimeSpaceComponent.week);
+  const [time, setTime] = useState<{
+    startHour: Hour,
+    startMinute: Minute,
+    endHour: Hour,
+    endMinute: Minute,
+  }>(lectureIndex
+    ? updatedTimeSpaceComponent![0].time : initialTimeSpaceComponent.time);
+  const [place, setPlace] = useState(lectureIndex
+    ? updatedTimeSpaceComponent![0].place : initialTimeSpaceComponent.place);
+
+  const timeSpaceComponentIndex = customTempLecture!.lecture_infos.findIndex(
+    (info) => info.id === id,
+  );
+
+  // 시간표용 시간으로 바꾸는 함수 ex) 09시 30분 -> 시작 시간은 1, 종료 시간은 0
+  const changeToTimetableTime = (timeInfo: {
+    startHour: Hour;
+    startMinute: Minute;
+    endHour: Hour;
+    endMinute: Minute;
+  }) => {
+    const timetableStartTime = START_TIME[timeInfo.startHour] + (timeInfo.startMinute === '00분' ? 0 : 1);
+    const timetableEndTime = END_TIME[timeInfo.endHour] + (timeInfo.endMinute === '00분' ? 0 : 1);
+
+    return {
+      startTime: timetableStartTime,
+      endTime: timetableEndTime,
+    };
+  };
+
+  const handleLectureTimeByTime = (key: string) => (
+    e: { target: { value: string } },
+  ) => {
+    const { target } = e;
+    const newTimeInfo = ({
+      ...time,
+      [key]: target?.value,
+    });
+
+    const newTimetableTime = changeToTimetableTime(newTimeInfo);
+    // 올바르지 않은 시간을 선택했을 시
+    if (newTimetableTime.endTime - newTimetableTime.startTime < 0) {
+      const newStartHour = Number(newTimeInfo.startHour.slice(0, 2));
+      const newEndHour = Number(newTimeInfo.endHour.slice(0, 2));
+      if (key.slice(0, 5) === 'start') {
+        setTime({
+          ...newTimeInfo,
+          endHour: `${newStartHour + 1}시` as Hour,
+          endMinute: newStartHour + 1 === 24 ? '00분' : newTimeInfo.startMinute,
+        });
+      } else {
+        setTime({
+          ...newTimeInfo,
+          startHour: newEndHour - 1 < 10 ? '09시' : `${newEndHour - 1}시` as Hour,
+          startMinute: newEndHour - 1 < 9 ? '00분' : newTimeInfo.endMinute,
+        });
+      }
+    } else {
+      setTime(newTimeInfo);
+    }
+  };
+
+  const handleLectureTimeByWeek = (weekday: string) => {
+    if (weeks.includes(weekday)) {
+      setWeeks((week) => week.filter((day) => day !== weekday));
+    } else {
+      setWeeks((week) => [...week, weekday]);
+    }
+  };
+
+  const handlePlaceName = (placeName: string) => {
+    setPlace(placeName);
+  };
+
+  const isWrongTime = customTempLecture!.lecture_infos[timeSpaceComponentIndex].end_time
+  - customTempLecture!.lecture_infos[timeSpaceComponentIndex].start_time < 0 || weeks.length === 0;
+
+  useEffect(() => {
+    const timetableTime = changeToTimetableTime(time);
+    if (customTempLecture) {
+      updateCustomTempLecture({
+        ...customTempLecture,
+        lecture_infos: customTempLecture.lecture_infos.map(
+          (info) => (info.id === id
+            ? {
+              ...info,
+              days: weeks,
+              start_time: timetableTime.startTime,
+              end_time: timetableTime.endTime,
+              place,
+            } : info),
+        ),
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [place, time, weeks]);
+
+  return (
+    <div className={styles['time-space-container__component']}>
+      <button
+        aria-label="delete-time-space-component"
+        type="button"
+        onClick={handleDeleteTimeSpaceComponent}
+        disabled={isEditStandardLecture}
+        className={cn({
+          [styles['time-space-container__delete-button']]: true,
+          [styles['time-space-container__delete-button--invisible']]: isSingleTimeSpaceComponent,
+        })}
+      >
+        <CloseIcon />
+      </button>
+      <div className={styles['form-group-time']}>
+        <label
+          htmlFor="place"
+          className={cn({
+            [styles['form-group-time__title']]: true,
+            [styles['form-group-time__title--require']]: !isFirstSubmit && isWrongTime,
+            [styles['form-group-time__title--disabled']]: isEditStandardLecture,
+          })}
+        >
+          <div className={styles['form-group-time__title--text']}>
+            시간
+            <span className={styles['require-mark']}>*</span>
+          </div>
+        </label>
+        <div className={styles['form-group-time__container']}>
+          <div className={styles['form-group-time__weekdays']}>
+            {DAYS_STRING.map((weekday) => (
+              <div key={weekday}>
+                <button
+                  type="button"
+                  className={cn({
+                    [styles['form-group-time__weekdays-button']]: true,
+                    [styles['form-group-time__weekdays-button--checked']]: weeks.includes(weekday),
+                    [styles['form-group-time__weekdays-button--checked--disabled']]: isEditStandardLecture && weeks.includes(weekday),
+                    [styles['form-group-time__weekdays-button--disabled']]: isEditStandardLecture,
+                  })}
+                  onClick={() => handleLectureTimeByWeek(weekday)}
+                  disabled={isEditStandardLecture}
+                >
+                  {weekday}
+                </button>
+              </div>
+            ))}
+          </div>
+          <div
+            className={cn({
+              [styles['form-group-time__time']]: true,
+              [styles['form-group-time__time--reverse']]: isReverseDropdown,
+            })}
+          >
+            <Listbox list={HOUR} value={time.startHour} onChange={handleLectureTimeByTime('startHour')} version="addLecture" disabled={isEditStandardLecture} />
+            <Listbox list={MINUTE} value={time.startMinute} onChange={handleLectureTimeByTime('startMinute')} version="addLecture" disabled={isEditStandardLecture} />
+            <span>-</span>
+            <Listbox list={time.endMinute === '30분' ? HOUR : [...HOUR, { label: '24시', value: '24시' }]} value={time.endHour} onChange={handleLectureTimeByTime('endHour')} version="addLecture" disabled={isEditStandardLecture} />
+            <Listbox list={time.endHour === '24시' ? [{ label: '00분', value: '00분' }] : MINUTE} value={time.endMinute} onChange={handleLectureTimeByTime('endMinute')} version="addLecture" disabled={isEditStandardLecture} />
+          </div>
+        </div>
+      </div>
+      {!isFirstSubmit
+        && isWrongTime && (
+        <div className={cn({
+          [styles.inputbox__warning]: true,
+          [styles['inputbox__warning--time']]: true,
+        })}
+        >
+          <WarningIcon />
+          시간을 입력해주세요.
+        </div>
+      )}
+      <div className={styles.inputbox__name}>
+        <label htmlFor="courseName">
+          <div className={styles['inputbox__name--title']}>
+            장소
+          </div>
+        </label>
+        <div className={styles['inputbox__name--block']} />
+        <input
+          type="text"
+          placeholder="장소를 입력하세요. (쉼표(,) 제외)"
+          value={place}
+          onChange={(e) => handlePlaceName(e.target.value)}
+          autoComplete="off"
+          maxLength={29}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
+  const token = useTokenState();
+  const customTempLecture = useCustomTempLecture();
+  const { updateCustomTempLecture } = useCustomTempLectureAction();
+  const { myLectures } = useMyLectures(timetableFrameId);
+  const { addMyLecture, editMyLecture } = useTimetableMutation(timetableFrameId);
+
+  const [searchParams] = useSearchParams();
+  const lectureIndex = searchParams.get('lectureIndex');
+  const selectedLecture = lectureIndex ? myLectures[Number(lectureIndex)] : null;
+  const selectedEditLecture = selectedLecture as MyLectureInfo | null;
+  const isEditStandardLecture = selectedEditLecture?.lecture_id !== null && !!selectedEditLecture;
+
+  // 직접 추가 input 값
+  const [lectureName, setLectureName] = useState('');
+  const [professorName, setProfessorName] = useState('');
+  const [timeSpaceComponents, setTimeSpaceComponents] = useState<{ id: string }[]>([]);
+
+  const timeSpaceContainerRef = useRef<HTMLDivElement>(null);
+  const timeSpaceComponentRef = useRef<HTMLDivElement[] | null[]>([]);
+  const [positionValues, setPositionValues] = useState<number[]>([]);
+  const [isFirstSubmit, setIsFirstSubmit] = useState(true);
+
+  const isValid = (lectureName !== ''
+    && !customTempLecture?.lecture_infos.some(
+      (time) => time.end_time < time.start_time,
+    ) && !customTempLecture?.lecture_infos.some((info) => info.days.length === 0)
+  );
+  const isOverflow = timeSpaceContainerRef.current
+    ? timeSpaceContainerRef.current.getBoundingClientRect().height > 400
+    : false;
+  const isReverseDropdown = positionValues.map(
+    (value) => (timeSpaceContainerRef.current
+      ? timeSpaceContainerRef.current.getBoundingClientRect().bottom - value < 20
+      : false),
+  );
+
+  const hasTimeConflict = (
+    excludeLectureId?: number,
+  ): boolean => {
+    const customLectureInfos = customTempLecture?.lecture_infos.flat();
+    const hasOverlapInCurrent = customLectureInfos!.some(
+      (item, index) => customLectureInfos!.slice(index + 1).some(
+        (other) => (item.start_time <= other.end_time && other.start_time <= item.end_time)
+        && item.days.some((day) => other.days.includes(day)),
+      ),
+    );
+    if (hasOverlapInCurrent) return true;
+
+    if (!myLectures) return false;
+
+    return myLectures.some((myLecture) => {
+      if (excludeLectureId && myLecture.id === excludeLectureId) {
+        return false;
+      }
+      return myLecture.lecture_infos.some(
+        (info) => customLectureInfos!.some(
+          (times) => (info.start_time % 100 <= times.end_time
+            && times.start_time <= info.end_time % 100)
+            && (times.days.some((day) => timeOffsets[day] === info.day)),
+        ),
+      );
+    });
+  };
+
+  const handleLectureName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLectureName(e.target.value);
+    updateCustomTempLecture({
+      ...customTempLecture!,
+      class_title: e.target.value,
+    });
+  };
+
+  const handleProfessorName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setProfessorName(e.target.value);
+    updateCustomTempLecture({
+      ...customTempLecture!,
+      professor: e.target.value,
+    });
+  };
+
+  const handleSubmitLecture = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!isValid) {
+      setIsFirstSubmit(false);
+      return;
+    }
+
+    // 중복 시간 검사
+    if (hasTimeConflict(selectedEditLecture?.id)) {
+      showToast('error', '강의가 중복되어 추가할 수 없습니다.');
+      return;
+    }
+
+    const isContainComma = customTempLecture?.lecture_infos.some((item) => item.place.includes(','));
+    if (isContainComma) {
+      showToast('error', '쉼표 문자 ( , )를 제외하고 입력해 주세요.');
+      return;
+    }
+
+    if (selectedEditLecture && customTempLecture) {
+      editMyLecture({
+        id: selectedEditLecture.id,
+        class_title: lectureName,
+        lecture_infos: customTempLecture.lecture_infos.flatMap(
+          (info) => info.days.map((day) => ({
+            ...info,
+            start_time: info.start_time + timeOffsets[day] * 100,
+            end_time: info.end_time + timeOffsets[day] * 100,
+            place: info.place,
+          })),
+        ),
+        professor: professorName,
+      });
+      return;
+    }
+
+    addMyLecture({
+      class_title: lectureName,
+      professor: professorName,
+      lecture_infos: customTempLecture!.lecture_infos.flatMap(
+        (info) => info.days.map((day) => ({
+          ...info,
+          start_time: info.start_time + timeOffsets[day] * 100,
+          end_time: info.end_time + timeOffsets[day] * 100,
+          place: info.place,
+        })),
+      ),
+    });
+
+    setLectureName('');
+    setProfessorName('');
+    const newId = uuidv4();
+    setTimeSpaceComponents([
+      { id: newId },
+    ]);
+    updateCustomTempLecture({
+      class_title: '',
+      professor: '',
+      lecture_infos: [
+        {
+          id: newId,
+          days: ['월'],
+          start_time: 0,
+          end_time: 1,
+          place: '',
+        },
+      ],
+    });
+    setIsFirstSubmit(true);
+  };
+
+  const handleScroll = () => {
+    const updatedValues = timeSpaceComponentRef.current
+      .map((element) => element?.getBoundingClientRect().bottom || 0);
+    setPositionValues(updatedValues);
+  };
+  const handleDeleteTimeSpaceComponent = (id: string) => {
+    setTimeSpaceComponents((prev) => prev.filter((component) => component.id !== id));
+    if (customTempLecture?.lecture_infos) {
+      updateCustomTempLecture({
+        ...customTempLecture,
+        lecture_infos: customTempLecture?.lecture_infos.filter((info) => info.id !== id),
+      });
+    }
+  };
+
+  const handleAddTimeSpaceComponent = () => {
+    const newId = uuidv4();
+    if (timeSpaceComponents.length > 4) {
+      showToast(
+        'info',
+        '"시간 및 장소 추가"는 최대 5개까지 가능합니다.',
+      );
+      return;
+    }
+
+    setTimeSpaceComponents((prev) => [
+      ...prev,
+      { id: newId },
+    ]);
+
+    if (customTempLecture) {
+      updateCustomTempLecture({
+        ...customTempLecture,
+        lecture_infos: [
+          ...customTempLecture.lecture_infos,
+          {
+            id: newId,
+            days: ['월'],
+            start_time: 0,
+            end_time: 1,
+            place: '',
+          },
+        ],
+      });
+    }
+
+    setTimeout(() => {
+      timeSpaceContainerRef.current!.scrollTo({
+        behavior: 'smooth',
+        top: 999,
+      });
+      handleScroll();
+    }, 0);
+  };
+
+  // 직접 추가 페이지 진입 시 form컴포넌트 초기화
+  useEffect(() => {
+    const newId = uuidv4();
+    setTimeSpaceComponents([{ id: newId }]);
+    updateCustomTempLecture({
+      class_title: '',
+      professor: '',
+      lecture_infos: [{
+        id: newId,
+        days: ['월'],
+        start_time: 0,
+        end_time: 1,
+        place: '',
+      }],
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!selectedEditLecture) return;
+
+    setLectureName(selectedEditLecture.class_title);
+    setProfessorName(selectedEditLecture.professor);
+    const newLectureInfos = selectedEditLecture.lecture_infos.map((info) => {
+      const newId = uuidv4();
+
+      return {
+        id: newId,
+        days: [Object.keys(timeOffsets).find((key) => timeOffsets[key] === info.day) as string],
+        start_time: info.start_time % 100,
+        end_time: info.end_time % 100,
+        place: info.place,
+      };
+    });
+
+    setTimeSpaceComponents([
+      ...newLectureInfos.map(({ id }) => ({ id })),
+    ]);
+
+    updateCustomTempLecture({
+      class_title: selectedEditLecture.class_title,
+      professor: selectedEditLecture.professor,
+      lecture_infos: newLectureInfos,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedEditLecture]);
 
@@ -392,7 +582,7 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
               type="text"
               placeholder="수업명을 입력하세요."
               value={lectureName}
-              onChange={(e) => setLectureName(e.target.value)}
+              onChange={handleLectureName}
               autoComplete="off"
             />
           </div>
@@ -419,7 +609,7 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
               type="text"
               placeholder="교수명을 입력하세요."
               value={professorName}
-              onChange={(e) => setProfessorName(e.target.value)}
+              onChange={handleProfessorName}
               autoComplete="off"
               maxLength={29}
               disabled={isEditStandardLecture}
@@ -434,107 +624,18 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
           ref={timeSpaceContainerRef}
           onScroll={handleScroll}
         >
-          {timeSpaceComponents.map(({
-            time,
-            week,
-            startTime,
-            endTime,
-            place,
-            id,
-          }, index) => (
-            <div className={styles['time-space-container__component']} key={id}>
-              <button
-                aria-label="delete-time-space-component"
-                type="button"
-                onClick={() => handleDeleteTimeSpaceComponent(index)}
-                disabled={isEditStandardLecture}
-                className={cn({
-                  [styles['time-space-container__delete-button']]: true,
-                  [styles['time-space-container__delete-button--invisible']]: isSingleTimeSpaceComponent,
-                })}
-              >
-                <CloseIcon />
-              </button>
-              <div className={styles['form-group-time']}>
-                <label
-                  htmlFor="place"
-                  className={cn({
-                    [styles['form-group-time__title']]: true,
-                    [styles['form-group-time__title--require']]: !isFirstSubmit && (endTime - startTime < 0 || week.length === 0),
-                    [styles['form-group-time__title--disabled']]: selectedEditLecture?.lecture_id !== null && (!!selectedEditLecture),
-                  })}
-                >
-                  <div className={styles['form-group-time__title--text']}>
-                    시간
-                    <span className={styles['require-mark']}>*</span>
-                  </div>
-                </label>
-                <div className={styles['form-group-time__container']}>
-                  <div className={styles['form-group-time__weekdays']}>
-                    {DAYS_STRING.map((weekday) => (
-                      <div key={weekday}>
-                        <button
-                          type="button"
-                          className={cn({
-                            [styles['form-group-time__weekdays-button']]: true,
-                            [styles['form-group-time__weekdays-button--checked']]: week.includes(weekday),
-                            [styles['form-group-time__weekdays-button--checked--disabled']]: selectedEditLecture?.lecture_id !== null
-                              && (!!selectedEditLecture) && week.includes(weekday),
-                            [styles['form-group-time__weekdays-button--disabled']]: selectedEditLecture?.lecture_id !== null && (!!selectedEditLecture),
-                          })}
-                          onClick={() => handleLectureTimeByWeek(weekday, index)}
-                          disabled={selectedEditLecture?.lecture_id !== null
-                            && !!selectedEditLecture}
-                        >
-                          {weekday}
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                  <div
-                    className={cn({
-                      [styles['form-group-time__time']]: true,
-                      [styles['form-group-time__time--reverse']]: isReverseDropdown[index],
-                    })}
-                    ref={(element) => {
-                      reverseRef.current[index] = element;
-                    }}
-                  >
-                    <Listbox list={HOUR} value={time.startHour} onChange={handleLectureTimeByTime('startHour', index)} version="addLecture" disabled={isEditStandardLecture} />
-                    <Listbox list={MINUTE} value={time.startMinute} onChange={handleLectureTimeByTime('startMinute', index)} version="addLecture" disabled={isEditStandardLecture} />
-                    <span>-</span>
-                    <Listbox list={time.endMinute === '30분' ? HOUR : [...HOUR, { label: '24시', value: '24시' }]} value={time.endHour} onChange={handleLectureTimeByTime('endHour', index)} version="addLecture" disabled={isEditStandardLecture} />
-                    <Listbox list={time.endHour === '24시' ? [{ label: '00분', value: '00분' }] : MINUTE} value={time.endMinute} onChange={handleLectureTimeByTime('endMinute', index)} version="addLecture" disabled={isEditStandardLecture} />
-                  </div>
-                </div>
-              </div>
-              {!isFirstSubmit && (endTime - startTime < 0 || week.length === 0) && (
-                <div className={cn({
-                  [styles.inputbox__warning]: true,
-                  [styles['inputbox__warning--time']]: true,
-                })}
-                >
-                  <WarningIcon />
-                  시간을 입력해주세요.
-                </div>
-              )}
-              <div className={styles.inputbox__name}>
-                <label htmlFor="courseName">
-                  <div className={styles['inputbox__name--title']}>
-                    장소
-                  </div>
-                </label>
-                <div className={styles['inputbox__name--block']} />
-                <input
-                  type="text"
-                  placeholder="장소를 입력하세요. (쉼표(,) 제외)"
-                  value={place}
-                  onChange={(e) => handlePlaceName(e.target.value, index)}
-                  autoComplete="off"
-                  maxLength={29}
-                />
-              </div>
-            </div>
+          {timeSpaceComponents.map((component, index) => (
+            <TimeSpaceInput
+              key={component.id}
+              id={component.id}
+              isEditStandardLecture={isEditStandardLecture}
+              isSingleTimeSpaceComponent={timeSpaceComponents.length === 1}
+              handleDeleteTimeSpaceComponent={
+                () => handleDeleteTimeSpaceComponent(component.id)
+              }
+              isFirstSubmit={isFirstSubmit}
+              isReverseDropdown={isReverseDropdown[index]}
+            />
           ))}
         </div>
         <button

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -57,6 +57,14 @@ const timeOffsets: Record<string, number> = {
   금: 4,
 };
 
+const findKeyByValue = (object: Record<Hour, number>, value: number) => Object
+  .entries(object).find(([, val]) => val === value)?.[0] as Hour;
+const getHour = (time: number, key: Record<Hour, number>, isStart: boolean) => {
+  const adjustedTime = time % 2 === (isStart ? 0 : 1) ? time : time - 1;
+  return findKeyByValue(key, adjustedTime);
+};
+const getMinute = (time: number, isStart: boolean): Minute => (time % 2 === (isStart ? 0 : 1) ? '00분' : '30분');
+
 function TimeSpaceInput({
   id,
   isEditStandardLecture,
@@ -81,14 +89,6 @@ function TimeSpaceInput({
   const updatedTimeSpaceComponent = lectureIndex
     ? customTempLecture!.lecture_infos.filter((info) => info.id === id).map(
       (info) => {
-        const findKeyByValue = (object: Record<Hour, number>, value: number) => Object
-          .entries(object).find(([, val]) => val === value)?.[0] as Hour;
-        const getHour = (time: number, key: Record<Hour, number>, isStart: boolean) => {
-          const adjustedTime = time % 2 === (isStart ? 0 : 1) ? time : time - 1;
-          return findKeyByValue(key, adjustedTime);
-        };
-        const getMinute = (time: number, isStart: boolean): Minute => (time % 2 === (isStart ? 0 : 1) ? '00분' : '30분');
-
         const startHour = getHour(info.start_time, START_TIME, true);
         const startMinute: Minute = getMinute(info.start_time, true);
         const endHour = getHour(info.end_time, END_TIME, false);

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -17,9 +17,9 @@ import useTokenState from 'utils/hooks/state/useTokenState';
 import uuidv4 from 'utils/ts/uuidGenerater';
 import styles from './CustomLecture.module.scss';
 
-type Hour = '09시' | '10시' | '11시' | '12시' | '13시' | '14시' | '15시' | '16시' | '17시' | '18시' | '19시' | '20시' | '21시' | '22시' | '23시' | '24시';
+type Hour = (typeof HOUR)[number]['value'] | '24시';
 
-type Minute = '00분' | '30분';
+type Minute = (typeof MINUTE)[number]['value'];
 
 type TimeSpaceComponents = {
   time: {

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -49,12 +49,12 @@ const initialTimeSpaceComponent: TimeSpaceComponents = {
   id: uuidv4(),
 };
 
-function CustomLecture({ frameId }: { frameId: number }) {
+function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
   const token = useTokenState();
   const customTempLecture = useCustomTempLecture();
   const { updateCustomTempLecture } = useCustomTempLectureAction();
-  const { myLectures } = useMyLectures(frameId);
-  const { addMyLecture, editMyLecture } = useTimetableMutation(frameId);
+  const { myLectures } = useMyLectures(timetableFrameId);
+  const { addMyLecture, editMyLecture } = useTimetableMutation(timetableFrameId);
 
   const [searchParams] = useSearchParams();
   const lectureIndex = searchParams.get('lectureIndex');

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -338,8 +338,8 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
       : false),
   );
 
-  const hasTimeConflict = (
-    excludeLectureId?: number,
+  const checkTimeOverlap = (
+    editingLectureId?: number,
   ): boolean => {
     const customLectureInfos = customTempLecture?.lecture_infos.flat();
     const hasOverlapInCurrent = customLectureInfos!.some(
@@ -353,7 +353,7 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
     if (!myLectures) return false;
 
     return myLectures.some((myLecture) => {
-      if (excludeLectureId && myLecture.id === excludeLectureId) {
+      if (editingLectureId && myLecture.id === editingLectureId) {
         return false;
       }
       return myLecture.lecture_infos.some(
@@ -390,7 +390,7 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
     }
 
     // 중복 시간 검사
-    if (hasTimeConflict(selectedEditLecture?.id)) {
+    if (checkTimeOverlap(selectedEditLecture?.id)) {
       showToast('error', '강의가 중복되어 추가할 수 없습니다.');
       return;
     }

--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -326,6 +326,8 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
   const [positionValues, setPositionValues] = useState<number[]>([]);
   const [isFirstSubmit, setIsFirstSubmit] = useState(true);
 
+  const prevLengthRef = useRef(timeSpaceComponents.length);
+
   const isValid = (lectureName !== ''
     && !customTempLecture?.lecture_infos.some(
       (time) => time.end_time < time.start_time,
@@ -336,7 +338,7 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
     : false;
   const isReverseDropdown = positionValues.map(
     (value) => (timeSpaceContainerRef.current
-      ? timeSpaceContainerRef.current.getBoundingClientRect().bottom - value < 20
+      ? timeSpaceContainerRef.current.getBoundingClientRect().bottom - value < 130
       : false),
   );
 
@@ -500,14 +502,6 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
         ],
       });
     }
-
-    setTimeout(() => {
-      timeSpaceContainerRef.current!.scrollTo({
-        behavior: 'smooth',
-        top: 999,
-      });
-      handleScroll();
-    }, 0);
   };
 
   // 직접 추가 페이지 진입 시 form컴포넌트 초기화
@@ -527,6 +521,18 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (timeSpaceComponents.length > prevLengthRef.current) {
+      timeSpaceContainerRef.current!.scrollTo({
+        behavior: 'smooth',
+        top: 999,
+      });
+      handleScroll();
+    }
+
+    prevLengthRef.current = timeSpaceComponents.length;
+  }, [timeSpaceComponents]);
 
   useEffect(() => {
     if (!selectedEditLecture) return;
@@ -627,17 +633,23 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
           onScroll={handleScroll}
         >
           {timeSpaceComponents.map((component, index) => (
-            <TimeSpaceInput
+            <div
+              ref={(element) => {
+                timeSpaceComponentRef.current[index] = element;
+              }}
               key={component.id}
-              id={component.id}
-              isEditStandardLecture={isEditStandardLecture}
-              isSingleTimeSpaceComponent={timeSpaceComponents.length === 1}
-              handleDeleteTimeSpaceComponent={
+            >
+              <TimeSpaceInput
+                id={component.id}
+                isEditStandardLecture={isEditStandardLecture}
+                isSingleTimeSpaceComponent={timeSpaceComponents.length === 1}
+                handleDeleteTimeSpaceComponent={
                 () => handleDeleteTimeSpaceComponent(component.id)
               }
-              isFirstSubmit={isFirstSubmit}
-              isReverseDropdown={isReverseDropdown[index]}
-            />
+                isFirstSubmit={isFirstSubmit}
+                isReverseDropdown={isReverseDropdown[index]}
+              />
+            </div>
           ))}
         </div>
         <button

--- a/src/pages/TimetablePage/components/LectureList/index.tsx
+++ b/src/pages/TimetablePage/components/LectureList/index.tsx
@@ -28,13 +28,13 @@ interface CurrentSemesterLectureListProps {
     search: string;
   };
   myLectures: Array<MyLectureInfo>;
-  frameId: number;
+  timetableFrameId: number;
 }
 
 interface MyLectureListBoxProps {
   rowWidthList: number[];
   myLectures: Array<MyLectureInfo>;
-  frameId: number;
+  timetableFrameId: number;
 }
 
 const useFlexibleWidth = (length: number, initialValue: number[]) => {
@@ -50,13 +50,13 @@ function CurrentSemesterLectureList({
   currentSemester,
   filter,
   myLectures,
-  frameId,
+  timetableFrameId,
 }: CurrentSemesterLectureListProps) {
   const tempLecture = useTempLecture();
   const { data: userInfo } = useUser();
   const { data: lectureList } = useLectureList(currentSemester);
   const { updateTempLecture } = useTempLectureAction();
-  const { addMyLecture } = useTimetableMutation(frameId);
+  const { addMyLecture } = useTimetableMutation(timetableFrameId);
 
   const isOverlapping = (selected: LectureInfo, existing: LectureInfo) => {
     if (selected.day !== existing.day) {
@@ -90,7 +90,7 @@ function CurrentSemesterLectureList({
     lectureList?.length !== 0 ? (
       <LectureTable
         rowWidthList={rowWidthList}
-        frameId={frameId}
+        timetableFrameId={timetableFrameId}
         list={(lectureList ?? []).filter((lecture) => {
           const searchFilter = filter.search.toUpperCase();
           const departmentFilter = filter.department;
@@ -167,12 +167,12 @@ function CurrentSemesterLectureList({
   );
 }
 
-function MyLectureListBox({ rowWidthList, myLectures, frameId }: MyLectureListBoxProps) {
+function MyLectureListBox({ rowWidthList, myLectures, timetableFrameId }: MyLectureListBoxProps) {
   return (
     myLectures.length !== 0 ? (
       <LectureTable
         rowWidthList={rowWidthList}
-        frameId={frameId}
+        timetableFrameId={timetableFrameId}
         list={myLectures}
         myLectures={myLectures}
         selectedLecture={undefined}
@@ -188,7 +188,7 @@ function MyLectureListBox({ rowWidthList, myLectures, frameId }: MyLectureListBo
   );
 }
 
-function LectureList({ frameId }: { frameId: number }) {
+function LectureList({ timetableFrameId }: { timetableFrameId: number }) {
   const logger = useLogger();
 
   const {
@@ -205,7 +205,7 @@ function LectureList({ frameId }: { frameId: number }) {
   // 가장 최신연도와 월을 가져옴
   const semester = useSemester();
 
-  const { myLectures } = useMyLectures(frameId);
+  const { myLectures } = useMyLectures(timetableFrameId);
 
   const [isToggled, setIsToggled] = React.useState(false);
   const { widthInfo } = useFlexibleWidth(9, [61, 173, 41, 61, 61, 41, 41, 41, 61]);
@@ -279,7 +279,7 @@ function LectureList({ frameId }: { frameId: number }) {
           {!isToggled ? (
             <CurrentSemesterLectureList
               rowWidthList={widthInfo}
-              frameId={frameId}
+              timetableFrameId={timetableFrameId}
               currentSemester={semester}
               filter={{
                 // 백엔드 수정하면 제거
@@ -292,7 +292,7 @@ function LectureList({ frameId }: { frameId: number }) {
             <MyLectureListBox
               rowWidthList={widthInfo}
               myLectures={(myLectures ?? []) as MyLectureInfo[]}
-              frameId={frameId}
+              timetableFrameId={timetableFrameId}
             />
           )}
         </React.Suspense>

--- a/src/pages/TimetablePage/components/MainTimetable/DownloadTimetableModal/index.tsx
+++ b/src/pages/TimetablePage/components/MainTimetable/DownloadTimetableModal/index.tsx
@@ -8,19 +8,19 @@ import styles from './DownloadTimetableModal.module.scss';
 
 interface DownloadTimetableModalProps {
   onClose: () => void,
-  frameId: number
+  timetableFrameId: number
 }
 
 interface TimetableDownloadProps {
   rowNumber: number,
   forMobile: boolean,
-  frameId: number,
+  timetableFrameId: number,
 }
 
-function TimetableDownload({ rowNumber, forMobile, frameId }: TimetableDownloadProps) {
+function TimetableDownload({ rowNumber, forMobile, timetableFrameId }: TimetableDownloadProps) {
   return (
     <Timetable
-      frameId={frameId}
+      timetableFrameId={timetableFrameId}
       columnWidth={forMobile ? 88.73 : 140}
       firstColumnWidth={forMobile ? 44.36 : 70}
       rowHeight={forMobile ? 33.07 : 33}
@@ -32,7 +32,7 @@ function TimetableDownload({ rowNumber, forMobile, frameId }: TimetableDownloadP
 
 export default function DownloadTimetableModal({
   onClose,
-  frameId,
+  timetableFrameId,
 }: DownloadTimetableModalProps) {
   const { onImageDownload: DownloadForPC, divRef: pcTimetableRef } = useImageDownload();
   const { onImageDownload: DownloadForMobile, divRef: mobileTimetableRef } = useImageDownload();
@@ -69,10 +69,18 @@ export default function DownloadTimetableModal({
         </div>
       </div>
       <div ref={pcTimetableRef} className={styles['container__timetable-image']}>
-        <TimetableDownload rowNumber={timeString.length} forMobile={false} frameId={frameId} />
+        <TimetableDownload
+          rowNumber={timeString.length}
+          forMobile={false}
+          timetableFrameId={timetableFrameId}
+        />
       </div>
       <div ref={mobileTimetableRef} className={styles['container__timetable-image']}>
-        <TimetableDownload rowNumber={timeString.length} forMobile frameId={frameId} />
+        <TimetableDownload
+          rowNumber={timeString.length}
+          forMobile
+          timetableFrameId={timetableFrameId}
+        />
       </div>
     </div>
   );

--- a/src/pages/TimetablePage/components/MainTimetable/index.tsx
+++ b/src/pages/TimetablePage/components/MainTimetable/index.tsx
@@ -20,14 +20,14 @@ import ROUTES from 'static/routes';
 import styles from './MyLectureTimetable.module.scss';
 import DownloadTimetableModal from './DownloadTimetableModal';
 
-function MainTimetable({ frameId }: { frameId: number }) {
+function MainTimetable({ timetableFrameId }: { timetableFrameId: number }) {
   const [isModalOpen, openModal, closeModal] = useBooleanState(false);
   const token = useTokenState();
   const semester = useSemester();
   const logger = useLogger();
   const navigate = useNavigate();
   const { data: timeTableFrameList } = useTimetableFrameList(token, semester);
-  const { myLectures } = useMyLectures(frameId);
+  const { myLectures } = useMyLectures(timetableFrameId);
   const { data: deptList } = useDeptList();
   const { data: mySemester } = useSemesterCheck(token);
 
@@ -62,7 +62,7 @@ function MainTimetable({ frameId }: { frameId: number }) {
 
   const onClickEdit = () => {
     if (isSemesterAndTimetableExist()) {
-      navigate(`/${ROUTES.TimetableRegular({ id: String(frameId), isLink: true })}?year=${semester?.year}&term=${semester?.term}`);
+      navigate(`/${ROUTES.TimetableRegular({ id: String(timetableFrameId), isLink: true })}?year=${semester?.year}&term=${semester?.term}`);
     }
   };
 
@@ -96,7 +96,7 @@ function MainTimetable({ frameId }: { frameId: number }) {
         <ErrorBoundary fallbackClassName="loading">
           <React.Suspense fallback={<LoadingSpinner size="50" />}>
             <Timetable
-              frameId={frameId}
+              timetableFrameId={timetableFrameId}
               columnWidth={140}
               firstColumnWidth={70}
               rowHeight={33}
@@ -107,7 +107,7 @@ function MainTimetable({ frameId }: { frameId: number }) {
       </div>
       <div>
         {isModalOpen && (
-          <DownloadTimetableModal onClose={closeModal} frameId={frameId} />
+          <DownloadTimetableModal onClose={closeModal} timetableFrameId={timetableFrameId} />
         )}
       </div>
     </div>

--- a/src/pages/TimetablePage/components/Timetable/Timetable.module.scss
+++ b/src/pages/TimetablePage/components/Timetable/Timetable.module.scss
@@ -151,7 +151,7 @@
 
     &--preview {
       border-top: solid 2px #cacaca;
-      background-color: #ddd9;
+      background-color: #ebebeb;
     }
   }
 

--- a/src/pages/TimetablePage/components/Timetable/Timetable.module.scss
+++ b/src/pages/TimetablePage/components/Timetable/Timetable.module.scss
@@ -151,6 +151,11 @@
 
     &--preview {
       border-top: solid 2px #cacaca;
+      background-color: #ddd9;  
+    }
+
+    &--fixing-preview {
+      border-top: solid 2px #cacaca;
       background-color: #ebebeb;
     }
   }

--- a/src/pages/TimetablePage/components/Timetable/Timetable.module.scss
+++ b/src/pages/TimetablePage/components/Timetable/Timetable.module.scss
@@ -151,7 +151,7 @@
 
     &--preview {
       border-top: solid 2px #cacaca;
-      background-color: #ddd9;  
+      background-color: #ddd9;
     }
 
     &--fixing-preview {

--- a/src/pages/TimetablePage/components/Timetable/index.tsx
+++ b/src/pages/TimetablePage/components/Timetable/index.tsx
@@ -51,6 +51,7 @@ function Timetable({
   const customTempLecture = useCustomTempLecture();
   const { timeString, setTimeString } = useTimeString();
   const token = useTokenState();
+  const location = useLocation();
 
   const handleEditLectureClick = (lectureIndex: number) => {
     if (!token) {
@@ -122,6 +123,8 @@ function Timetable({
 
     return 2;
   };
+
+  const isEditing = location.search.includes('lectureIndex');
 
   useEffect(() => {
     const fixedMaxTime = findMaxTime(myLectures);
@@ -368,7 +371,7 @@ function Timetable({
                   <div
                     className={cn({
                       [styles.timetable__lecture]: true,
-                      [styles['timetable__lecture--preview']]: true,
+                      [styles[`timetable__lecture${isEditing ? '--fixing-preview' : '--preview'}`]]: true,
                     })}
                     style={{
                       top: `${(info.start_time % 100) * rowHeight + 1}px`,

--- a/src/pages/TimetablePage/components/Timetable/index.tsx
+++ b/src/pages/TimetablePage/components/Timetable/index.tsx
@@ -363,62 +363,65 @@ function Timetable({
             >
               {customTempLecture.lecture_infos.map((info, idx) => (
                 (info.end_time % 100) !== undefined
-                && Math.floor(info.end_time / 100) === index && (
-                <div
-                  className={cn({
-                    [styles.timetable__lecture]: true,
-                    [styles['timetable__lecture--preview']]: true,
-                  })}
-                  style={{
-                    top: `${(info.start_time % 100) * rowHeight + 1}px`,
-                    left: `${firstColumnWidth + index * columnWidth + index + 1}px`,
-                    width: isMobile ? undefined : `${columnWidth}px`,
-                    height: `${((info.end_time % 100) - (info.start_time % 100) + 1) * rowHeight - 1}px`,
-                    padding: `${rowHeight / 4}px ${rowHeight / 4}px
-                    ${rowHeight / 4 - 2}px ${rowHeight / 4}px`,
-                    gap: `${rowHeight / 5.5}px`,
-                  }}
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`${idx}-${info.start_time}-${info.end_time}`}
-                >
+                && info.days.map((weekday) => (
+                  weekday === day && (
                   <div
-                    className={styles['timetable__lecture-name']}
+                    className={cn({
+                      [styles.timetable__lecture]: true,
+                      [styles['timetable__lecture--preview']]: true,
+                    })}
                     style={{
-                      fontSize: `${rowHeight / 3 + 1}px`,
-                      fontWeight: '500',
-                      lineHeight: `${rowHeight / 2}px`,
-                      minHeight: `${calculateMinHeight(((info.end_time % 100) - (info.start_time % 100) + 1), 'name')}px`,
-                      WebkitLineClamp: calculateLineClamp(((info.end_time % 100) - (info.start_time % 100) + 1), 'name', !!info.place),
+                      top: `${(info.start_time % 100) * rowHeight + 1}px`,
+                      left: `${firstColumnWidth + index * columnWidth + index + 1}px`,
+                      width: isMobile ? undefined : `${columnWidth}px`,
+                      height: `${((info.end_time % 100) - (info.start_time % 100) + 1) * rowHeight - 1}px`,
+                      padding: `${rowHeight / 4}px ${rowHeight / 4}px
+                      ${rowHeight / 4 - 2}px ${rowHeight / 4}px`,
+                      gap: `${rowHeight / 5.5}px`,
                     }}
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={`${idx}-${info.start_time}-${info.end_time}`}
                   >
-                    {customTempLecture.class_title}
+                    <div
+                      className={styles['timetable__lecture-name']}
+                      style={{
+                        fontSize: `${rowHeight / 3 + 1}px`,
+                        fontWeight: '500',
+                        lineHeight: `${rowHeight / 2}px`,
+                        minHeight: `${calculateMinHeight(((info.end_time % 100) - (info.start_time % 100) + 1), 'name')}px`,
+                        WebkitLineClamp: calculateLineClamp(((info.end_time % 100) - (info.start_time % 100) + 1), 'name', !!info.place),
+                      }}
+                    >
+                      {customTempLecture.class_title}
+                    </div>
+                    <span
+                      className={styles['timetable__lecture-professor']}
+                      style={{
+                        fontSize: `${rowHeight / 3 + 1}px`,
+                        fontWeight: '400',
+                        lineHeight: `${rowHeight / 2}px`,
+                        minHeight: `${calculateMinHeight(((info.end_time % 100) - (info.start_time % 100) + 1), 'professor')}px`,
+                        WebkitLineClamp: calculateLineClamp(((info.end_time % 100) - (info.start_time % 100) + 1), 'professor', !!info.place),
+                      }}
+                    >
+                      {customTempLecture.professor}
+                    </span>
+                    <div
+                      className={styles['timetable__lecture-place']}
+                      style={{
+                        fontSize: `${rowHeight / 3 - 1}px`,
+                        fontWeight: '500',
+                        lineHeight: `${rowHeight / 2}px`,
+                        minHeight: `${calculateMinHeight(((info.end_time % 100) - (info.start_time % 100) + 1), 'place')}px`,
+                        WebkitLineClamp: calculateLineClamp(((info.end_time % 100) - (info.start_time % 100) + 1), 'place', !!info.place),
+                      }}
+                    >
+                      {info.place}
+                    </div>
                   </div>
-                  <span
-                    className={styles['timetable__lecture-professor']}
-                    style={{
-                      fontSize: `${rowHeight / 3 + 1}px`,
-                      fontWeight: '400',
-                      lineHeight: `${rowHeight / 2}px`,
-                      minHeight: `${calculateMinHeight(((info.end_time % 100) - (info.start_time % 100) + 1), 'professor')}px`,
-                      WebkitLineClamp: calculateLineClamp(((info.end_time % 100) - (info.start_time % 100) + 1), 'professor', !!info.place),
-                    }}
-                  >
-                    {customTempLecture.professor}
-                  </span>
-                  <div
-                    className={styles['timetable__lecture-place']}
-                    style={{
-                      fontSize: `${rowHeight / 3 - 1}px`,
-                      fontWeight: '500',
-                      lineHeight: `${rowHeight / 2}px`,
-                      minHeight: `${calculateMinHeight(((info.end_time % 100) - (info.start_time % 100) + 1), 'place')}px`,
-                      WebkitLineClamp: calculateLineClamp(((info.end_time % 100) - (info.start_time % 100) + 1), 'place', !!info.place),
-                    }}
-                  >
-                    {info.place}
-                  </div>
-                </div>
-                )))}
+                  )
+                ))
+              ))}
             </div>
           ))
         )}

--- a/src/pages/TimetablePage/components/Timetable/index.tsx
+++ b/src/pages/TimetablePage/components/Timetable/index.tsx
@@ -27,11 +27,11 @@ interface TimetableProps {
   rowHeight: number;
   totalHeight: number;
   forDownload?: boolean;
-  frameId: number;
+  timetableFrameId: number;
 }
 
 function Timetable({
-  frameId,
+  timetableFrameId,
   selectedLectureIndex,
   similarSelectedLecture,
   firstColumnWidth,
@@ -45,8 +45,8 @@ function Timetable({
   const { pathname } = useLocation();
   const [isMouseOver, setIsMouseOver] = useState('');
   const isEditable = pathname.includes('/timetable/modify');
-  const { removeMyLecture } = useTimetableMutation(frameId);
-  const { myLectures } = useMyLectures(frameId);
+  const { removeMyLecture } = useTimetableMutation(timetableFrameId);
+  const { myLectures } = useMyLectures(timetableFrameId);
   const tempLecture = useTempLecture();
   const customTempLecture = useCustomTempLecture();
   const { timeString, setTimeString } = useTimeString();
@@ -58,7 +58,7 @@ function Timetable({
       return;
     }
 
-    navigate(`/timetable/modify/direct/${frameId}?lectureIndex=${lectureIndex}`);
+    navigate(`/timetable/modify/direct/${timetableFrameId}?lectureIndex=${lectureIndex}`);
   };
 
   const handleRemoveLectureClick = (id: number) => {

--- a/src/pages/TimetablePage/hooks/useEditTimetableLectureCustom.ts
+++ b/src/pages/TimetablePage/hooks/useEditTimetableLectureCustom.ts
@@ -9,17 +9,17 @@ export default function useEditTimetableLectureCustom() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ frameId, editedLecture, token }: {
-      frameId: number;
+    mutationFn: ({ timetableFrameId, editedLecture, token }: {
+      timetableFrameId: number;
       editedLecture: TimetableCustomLecture;
       token: string
     }) => editTimetableLectureCustom(
-      { timetable_frame_id: frameId, timetable_lecture: editedLecture },
+      { timetable_frame_id: timetableFrameId, timetable_lecture: editedLecture },
       token,
     ),
     onSuccess: (data, variables) => {
       queryClient.setQueryData(
-        [TIMETABLE_INFO_LIST, variables.frameId],
+        [TIMETABLE_INFO_LIST, variables.timetableFrameId],
         data,
       );
       showToast('success', '강의 수정이 되었습니다.');

--- a/src/pages/TimetablePage/hooks/useEditTimetableLectureRegular.ts
+++ b/src/pages/TimetablePage/hooks/useEditTimetableLectureRegular.ts
@@ -9,17 +9,17 @@ export default function useEditTimetableLectureRegular() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ frameId, editedLecture, token }: {
-      frameId: number;
+    mutationFn: ({ timetableFrameId, editedLecture, token }: {
+      timetableFrameId: number;
       editedLecture: TimetableRegularLecture;
       token: string
     }) => editTimetableLectureRegular(
-      { timetable_frame_id: frameId, timetable_lecture: editedLecture },
+      { timetable_frame_id: timetableFrameId, timetable_lecture: editedLecture },
       token,
     ),
     onSuccess: (data, variables) => {
       queryClient.setQueryData(
-        [TIMETABLE_INFO_LIST, variables.frameId],
+        [TIMETABLE_INFO_LIST, variables.timetableFrameId],
         data,
       );
       showToast('success', '강의 수정이 되었습니다.');

--- a/src/pages/TimetablePage/hooks/useMyLectures.ts
+++ b/src/pages/TimetablePage/hooks/useMyLectures.ts
@@ -3,11 +3,11 @@ import { useLecturesState } from 'utils/zustand/myLectures';
 import { useSemester } from 'utils/zustand/semester';
 import useTimetableInfoList from './useTimetableInfoList';
 
-export default function useMyLectures(frameId: number) {
+export default function useMyLectures(timetableFrameId: number) {
   const token = useTokenState();
   const semester = useSemester();
   const { data: myLecturesFromServer } = useTimetableInfoList({
-    authorization: token, timetableFrameId: frameId,
+    authorization: token, timetableFrameId,
   });
   const myLecturesFromLocalStorageValue = useLecturesState(`${semester?.year}${semester?.term}`);
 

--- a/src/pages/TimetablePage/hooks/useRollbackLecture.ts
+++ b/src/pages/TimetablePage/hooks/useRollbackLecture.ts
@@ -5,7 +5,7 @@ import { RollbackTimetableLectureRequest } from 'api/timetable/entity';
 import showToast from 'utils/ts/showToast';
 import { TIMETABLE_INFO_LIST } from './useTimetableInfoList';
 
-export default function useRollbackLecture(token: string, frameId: number) {
+export default function useRollbackLecture(token: string, timetableFrameId: number) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -15,7 +15,7 @@ export default function useRollbackLecture(token: string, frameId: number) {
 
     onSuccess: () => {
       queryClient.invalidateQueries(
-        { queryKey: [TIMETABLE_INFO_LIST, frameId] },
+        { queryKey: [TIMETABLE_INFO_LIST, timetableFrameId] },
       );
     },
 

--- a/src/pages/TimetablePage/hooks/useRollbackTimetableFrame.ts
+++ b/src/pages/TimetablePage/hooks/useRollbackTimetableFrame.ts
@@ -10,7 +10,9 @@ export default function useRollbackTimetableFrame(token: string) {
   const semester = useSemester();
 
   return useMutation({
-    mutationFn: (frameId: number) => timetable.rollbackTimetableFrame(token, frameId),
+    mutationFn: (
+      timetableFrameId: number,
+    ) => timetable.rollbackTimetableFrame(token, timetableFrameId),
 
     onSuccess: () => {
       queryClient.invalidateQueries(

--- a/src/pages/TimetablePage/hooks/useTimetableMutation.ts
+++ b/src/pages/TimetablePage/hooks/useTimetableMutation.ts
@@ -23,7 +23,7 @@ type RemoveMyLectureProps = {
   id: number
 };
 
-export default function useTimetableMutation(frameId: number) {
+export default function useTimetableMutation(timetableFrameId: number) {
   const token = useTokenState();
   const semester = useSemester();
   const toast = useToast();
@@ -34,7 +34,7 @@ export default function useTimetableMutation(frameId: number) {
   const { mutate: mutateEditWithServerCustom } = useEditTimetableLectureCustom();
   const { mutate: mutateEditWithServerRegular } = useEditTimetableLectureRegular();
 
-  const { mutate: rollbackLecture } = useRollbackLecture(token, frameId);
+  const { mutate: rollbackLecture } = useRollbackLecture(token, timetableFrameId);
 
   const {
     addLecture: addLectureFromLocalStorage,
@@ -49,12 +49,12 @@ export default function useTimetableMutation(frameId: number) {
     if (token) {
       if ('name' in clickedLecture) {
         mutateAddWithServerRegular({
-          timetable_frame_id: frameId,
+          timetable_frame_id: timetableFrameId,
           lecture_id: clickedLecture.id,
         });
       } else {
         mutateAddWithServerCustom({
-          timetable_frame_id: frameId,
+          timetable_frame_id: timetableFrameId,
           timetable_lecture:
             {
               class_title: clickedLecture.class_title,
@@ -84,7 +84,7 @@ export default function useTimetableMutation(frameId: number) {
   const editMyLecture = (editedLecture: TimetableRegularLecture | TimetableCustomLecture) => {
     if ('lecture_id' in editedLecture) {
       mutateEditWithServerRegular({
-        frameId,
+        timetableFrameId,
         editedLecture:
             {
               id: editedLecture.id,
@@ -96,7 +96,7 @@ export default function useTimetableMutation(frameId: number) {
       });
     } else {
       mutateEditWithServerCustom({
-        frameId,
+        timetableFrameId,
         editedLecture:
             {
               id: editedLecture.id,

--- a/src/static/timetable.ts
+++ b/src/static/timetable.ts
@@ -3,7 +3,7 @@ export const BACKGROUND_COLOR = ['#E7CCCC', '#FFDADA', '#FFEBD8', '#FAF7D4', '#F
 export const BORDER_TOP_COLOR = ['#890000', '#FF4444', '#FF993B', '#E8D52A', '#D0AE00', '#513A00', '#0C9D61', '#7ABA78', '#366718', '#80C4E9', '#1679AB', '#074173', '#523AE2', '#6F6F6F', '#CBCBCB'];
 export const MINUTE = [{ label: '00분', value: '00분' },
   { label: '30분', value: '30분' },
-];
+] as const;
 export const HOUR = [{ label: '09시', value: '09시' },
   { label: '10시', value: '10시' },
   { label: '11시', value: '11시' },
@@ -18,7 +18,7 @@ export const HOUR = [{ label: '09시', value: '09시' },
   { label: '20시', value: '20시' },
   { label: '21시', value: '21시' },
   { label: '22시', value: '22시' },
-  { label: '23시', value: '23시' }];
+  { label: '23시', value: '23시' }] as const;
 
 export const START_TIME = {
   '09시': 0,

--- a/src/utils/zustand/myCustomTempLecture.ts
+++ b/src/utils/zustand/myCustomTempLecture.ts
@@ -1,8 +1,19 @@
-import { AddTimetableCustomLecture } from 'api/timetable/entity';
 import { create } from 'zustand';
 
 type State = {
-  customTempLecture: AddTimetableCustomLecture | null;
+  customTempLecture: {
+    class_title: string,
+    professor: string,
+    lecture_infos: {
+      id: string,
+      days: string[],
+      start_time: number,
+      end_time: number,
+      place: string,
+    }[],
+    grades?: string,
+    memo?: string,
+  } | null;
 };
 
 type Action = {
@@ -16,6 +27,8 @@ const useCustomTempLectureStore = create<State & Action>((set, get) => ({
     class_title: '',
     lecture_infos: [
       {
+        id: '',
+        days: [],
         start_time: 0,
         end_time: 0,
         place: '',


### PR DESCRIPTION
- Close #650 
  
## What is this PR? 🔍

- 기능 : 커스텀 시간표 페이지를 리팩터링했습니다.
- issue : #650 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
@ChoiWonBeen 님의 피드백을 받고 정리한 [관련 노션](https://chatter-afternoon-e41.notion.site/CustomLecture-646643b63d78448c88130e4febb2c690)입니다.
[관련 스레드](https://bcsdlab.slack.com/archives/CGQM7A3S8/p1738594121084649)입니다.

아무래도 **노션에서 정리한 5번**과 **6번**을 중점적으로 리뷰해주시면 될 것 같습니다.

**5번 내용**은 지금까지 `CustomLecture`라는 폼 컨테이너에 모든 state를 넣고 관리했는데 시간과 장소를 묶는 컨테이너를 컴포넌트화할 필요가 있다하여 `TimeSpaceInput`이라는 이름으로 컴포넌트화했습니다.

~~**6번 내용**은 useEffect를 줄일 수 있으면 줄여라 였는데, 결과적으로는 더 늘리는 꼴이 되었습니다. 그 이유는 아래와 같습니다.
customTempLecture라는 현재 커스텀 일정의 정보를 담고 있는 객체를 전역 상태로 관리하고 있습니다. 이 객체가 하는 역할은 그 강의 정보를 시간표에 미리보기볼 수 있도록 하는 것입니다. 따라서 form을 업데이트 할 때마다 customTempLecture도 즉각 업데이트를 해줘야 하는데, 컴포넌트를 분리하다 보니 자식, 부모, 컴포넌트에서 updateCustomLecture를 해야 하는 상황이 있었습니다. 
**"한 줄 요약"**
컴포넌트화해서~~ -> 해결했습니다.

솔직히 잘 리팩터링한 건 지는 모르겠습니다... 코드 길이도 이전보다 100줄 정도 늘어나기도 해서..

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
