### PR TITLE
[유저] 회원가입 로깅 추가 

### DIFF
--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -67,6 +67,7 @@ const useLightweightForm = (submitForm: ISubmitForm) => {
       }
     },
   });
+
   const watch = (name?: string) => {
     if (name) {
       return refCollection.current[name]?.ref?.value ?? undefined;
@@ -455,6 +456,7 @@ const TermsCheckboxes = React.forwardRef<ICustomFormInput | null, ICustomFormInp
 
 const useSignupForm = () => {
   const navigate = useNavigate();
+
   const onSuccess = () => {
     navigate(ROUTES.Main());
   };
@@ -482,10 +484,36 @@ function SignupDefaultPage() {
   const { status, submitForm } = useSignupForm();
   const { register, onSubmit: onSubmitSignupForm, watch } = useLightweightForm(submitForm);
   const logger = useLogger();
-  const genderValue = watch('gender');
 
-  const studentNumberData: { major?: string; studentNumber?: string } = watch('student-number') || {};
-  const majorValue = studentNumberData.major ?? '';
+  const onClickSignupButton = () => {
+    const genderValue = watch('gender') ?? '';
+    const studentNumberData: { major?: string; studentNumber?: string } = watch('student-number') || {};
+    const majorValue = studentNumberData.major ?? '';
+
+    const genderLabel = genderValue !== undefined && genderValue !== null
+      ? GENDER_TYPE.find((item) => item.value === Number(genderValue))?.label || ''
+      : '';
+
+    const finalMajorValue = majorValue || '';
+
+    logger.actionEventClick({
+      actionTitle: 'USER',
+      event_label: 'complete_sign_up',
+      value: '회원가입 완료',
+    });
+
+    logger.actionEventClick({
+      actionTitle: 'USER',
+      event_label: 'gender',
+      value: genderLabel as string,
+    });
+
+    logger.actionEventClick({
+      actionTitle: 'USER',
+      event_label: 'major',
+      value: finalMajorValue,
+    });
+  };
 
   return (
     <>
@@ -565,27 +593,7 @@ function SignupDefaultPage() {
             [styles['signup__button--block']]: true,
             [styles['signup__button--large-font']]: true,
           })}
-          onClick={() => {
-            logger.actionEventClick({
-              actionTitle: 'USER',
-              event_label: 'complete_sign_up',
-              value: '회원가입 완료',
-            });
-            logger.actionEventClick({
-              actionTitle: 'USER',
-              event_label: 'gender',
-              value: genderValue !== undefined && genderValue !== null
-                ? GENDER_TYPE.find((item) => item.value === Number(genderValue))?.label || ''
-                : '',
-            });
-            logger.actionEventClick({
-              actionTitle: 'USER',
-              event_label: 'major',
-              value: majorValue !== undefined && majorValue !== null
-                ? majorValue || ''
-                : '',
-            });
-          }}
+          onClick={onClickSignupButton}
         >
           회원가입
         </button>

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -68,18 +68,6 @@ const useLightweightForm = (submitForm: ISubmitForm) => {
     },
   });
 
-  const watch = (name?: string) => {
-    if (name) {
-      return refCollection.current[name]?.ref?.value ?? undefined;
-    }
-    return Object.fromEntries(
-      Object.entries(refCollection.current).map(([key, refObj]) => [
-        key,
-        refObj.ref?.value ?? undefined,
-      ]),
-    );
-  };
-
   const onSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     const isCurrentValidEntries = Object.entries(refCollection.current)
@@ -107,7 +95,6 @@ const useLightweightForm = (submitForm: ISubmitForm) => {
   return {
     register,
     onSubmit,
-    watch,
   };
 };
 

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -480,8 +480,9 @@ const useSignupForm = () => {
 
 function SignupDefaultPage() {
   const { status, submitForm } = useSignupForm();
-  const { register, onSubmit: onSubmitSignupForm } = useLightweightForm(submitForm);
+  const { register, onSubmit: onSubmitSignupForm, watch } = useLightweightForm(submitForm);
   const logger = useLogger();
+  const genderValue = watch('gender');
 
   return (
     <>
@@ -566,6 +567,13 @@ function SignupDefaultPage() {
               actionTitle: 'USER',
               event_label: 'complete_sign_up',
               value: '회원가입 완료',
+            });
+            logger.actionEventClick({
+              actionTitle: 'USER',
+              event_label: 'gender',
+              value: genderValue !== undefined && genderValue !== null
+                ? GENDER_TYPE.find((item) => item.value === Number(genderValue))?.label || ''
+                : '',
             });
           }}
         >

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -603,7 +603,6 @@ function SignupDefaultPage() {
             [styles['signup__button--block']]: true,
             [styles['signup__button--large-font']]: true,
           })}
-          // onClick={onClickSignupButton}
         >
           회원가입
         </button>

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -484,6 +484,9 @@ function SignupDefaultPage() {
   const logger = useLogger();
   const genderValue = watch('gender');
 
+  const studentNumberData: { major?: string; studentNumber?: string } = watch('student-number') || {};
+  const majorValue = studentNumberData.major ?? '';
+
   return (
     <>
       <div>
@@ -573,6 +576,13 @@ function SignupDefaultPage() {
               event_label: 'gender',
               value: genderValue !== undefined && genderValue !== null
                 ? GENDER_TYPE.find((item) => item.value === Number(genderValue))?.label || ''
+                : '',
+            });
+            logger.actionEventClick({
+              actionTitle: 'USER',
+              event_label: 'major',
+              value: majorValue !== undefined && majorValue !== null
+                ? majorValue || ''
                 : '',
             });
           }}

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -67,6 +67,18 @@ const useLightweightForm = (submitForm: ISubmitForm) => {
       }
     },
   });
+  const watch = (name?: string) => {
+    if (name) {
+      return refCollection.current[name]?.ref?.value ?? undefined;
+    }
+    return Object.fromEntries(
+      Object.entries(refCollection.current).map(([key, refObj]) => [
+        key,
+        refObj.ref?.value ?? undefined,
+      ]),
+    );
+  };
+
   const onSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     const isCurrentValidEntries = Object.entries(refCollection.current)
@@ -94,6 +106,7 @@ const useLightweightForm = (submitForm: ISubmitForm) => {
   return {
     register,
     onSubmit,
+    watch,
   };
 };
 
@@ -469,6 +482,7 @@ function SignupDefaultPage() {
   const { status, submitForm } = useSignupForm();
   const { register, onSubmit: onSubmitSignupForm } = useLightweightForm(submitForm);
   const logger = useLogger();
+
   return (
     <>
       <div>


### PR DESCRIPTION
- Close #659 
  
## What is this PR? 🔍

- 기능 : 회원가입 로깅 추가
- issue : #659 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
기존에는 `회원가입 완료` 로깅이 회원가입 버튼 클릭 시점에 실행되어, 회원가입이 실패해도 `회원가입 완료` 로그가 전달되는 문제가 있었습니다. 이를 해결하기 위해 로깅 위치를 회원가입 성공 시점으로 수정하였습니다.
또한, 성별 및 학부 관련 로깅을 추가하였습니다. 



## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
