### PR TITLE
[캠퍼스] 분실물 QA 수정

### DIFF
--- a/src/pages/Articles/LostItemDetailPage/LostItemDetailPage.module.scss
+++ b/src/pages/Articles/LostItemDetailPage/LostItemDetailPage.module.scss
@@ -214,45 +214,32 @@
 }
 
 .button-container {
+  display: flex;
   gap: 12px;
   margin-top: 64px;
   width: 100%;
-  justify-content: space-between;
 
-  @include media.media-breakpoint(mobile) {
+  &__list-button {
     display: flex;
-  }
-
-  &__left {
-    display: flex;
-  }
-
-  &__right {
-    display: flex;
-    gap: 12px;
-    justify-content: flex-end;
-
-    @include media.media-breakpoint(mobile) {
-      display: flex;
-      gap: 8px;
-    }
-  }
-
-  &__message,
-  &__report {
-    display: flex;
-    padding: 6px 10px;
-    justify-content: center;
     align-items: center;
-    gap: 4px;
+    margin-right: auto;
     border-radius: 4px;
-    color: #4b4b4b;
+    padding: 10px 16px;
     background-color: #e1e1e1;
+    color: #4b4b4b;
     font-family: Pretendard, sans-serif;
     font-size: 16px;
-    font-style: normal;
     font-weight: 500;
-    line-height: 160%;
+    line-height: 1.6;
+
+    & path {
+      fill: #4b4b4b;
+    }
+
+    & svg {
+      width: 24px;
+      height: 24px;
+    }
 
     @include media.media-breakpoint(mobile) {
       font-size: 12px;
@@ -265,9 +252,10 @@
     }
   }
 
-  &__delete {
+  &__delete-button {
     display: flex;
     align-items: center;
+    margin-left: auto;
     border-radius: 4px;
     gap: 2px;
     padding: 10px 16px;
@@ -286,6 +274,39 @@
       width: 24px;
       height: 24px;
     }
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 12px;
+      padding: 6px 12px;
+
+      & svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+
+  &__buttons {
+    display: flex;
+    gap: 12px;
+    margin-left: auto;
+  }
+
+  &__message-button,
+  &__report-button {
+    display: flex;
+    padding: 6px 10px;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    border-radius: 4px;
+    color: #4b4b4b;
+    background-color: #e1e1e1;
+    font-family: Pretendard, sans-serif;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 160%;
 
     @include media.media-breakpoint(mobile) {
       font-size: 12px;

--- a/src/pages/Articles/LostItemDetailPage/LostItemDetailPage.module.scss
+++ b/src/pages/Articles/LostItemDetailPage/LostItemDetailPage.module.scss
@@ -267,10 +267,9 @@
 
   &__delete {
     display: flex;
-    justify-content: center;
     align-items: center;
     border-radius: 4px;
-    gap: 1px;
+    gap: 2px;
     padding: 10px 16px;
     background-color: #e1e1e1;
     color: #4b4b4b;

--- a/src/pages/Articles/LostItemDetailPage/index.tsx
+++ b/src/pages/Articles/LostItemDetailPage/index.tsx
@@ -87,15 +87,16 @@ export default function LostItemDetailPage() {
             images={images}
           />
           <div className={styles.contents__content}>{content}</div>
-          <div className={styles.contents__guide}>
-            <p>분실물 수령을 희망하시는 분은 재실 시간 내에</p>
-            <p>
-              <strong>학생회관 320호 총학생회 사무실</strong>
-              로 방문해 주시기 바랍니다.
-            </p>
-            <p>재실 시간은 공지 사항을 참고해 주시기 바랍니다.</p>
-          </div>
-
+          {article?.author === '총학생회' && (
+            <div className={styles.contents__guide}>
+              <p>분실물 수령을 희망하시는 분은 재실 시간 내에</p>
+              <p>
+                <strong>학생회관 320호 총학생회 사무실</strong>
+                로 방문해 주시기 바랍니다.
+              </p>
+              <p>재실 시간은 공지 사항을 참고해 주시기 바랍니다.</p>
+            </div>
+          )}
           <div className={styles['button-container']}>
             {isMobile && (
             <div className={styles['button-container__left']}>

--- a/src/pages/Articles/LostItemDetailPage/index.tsx
+++ b/src/pages/Articles/LostItemDetailPage/index.tsx
@@ -109,17 +109,18 @@ export default function LostItemDetailPage() {
               </button>
             </div>
             )}
-            {isMyArticle && (
-              <button
-                className={styles.contents__button}
-                onClick={handleDeleteButtonClick}
-                type="button"
-              >
-                삭제
-                <GarbageCanIcon />
-              </button>
-            )}
-            {!isMyArticle && (
+            {isMyArticle ? (
+              <div className={styles['button-container__right']}>
+                <button
+                  className={styles['button-container__delete']}
+                  onClick={handleDeleteButtonClick}
+                  type="button"
+                >
+                  삭제
+                  <GarbageCanIcon />
+                </button>
+              </div>
+            ) : (
               <div className={styles['button-container__right']}>
                 <button
                   type="button"
@@ -142,6 +143,7 @@ export default function LostItemDetailPage() {
                 </button>
               </div>
             )}
+
             {isReportModalOpen
                 && <ReportModal articleId={articleId} closeReportModal={closeReportModal} />}
           </div>

--- a/src/pages/Articles/LostItemDetailPage/index.tsx
+++ b/src/pages/Articles/LostItemDetailPage/index.tsx
@@ -99,32 +99,28 @@ export default function LostItemDetailPage() {
           )}
           <div className={styles['button-container']}>
             {isMobile && (
-            <div className={styles['button-container__left']}>
               <button
-                className={styles.contents__button}
+                className={styles['button-container__list-button']}
                 onClick={() => navigate(ROUTES.Articles())}
                 type="button"
               >
                 목록
               </button>
-            </div>
             )}
             {isMyArticle ? (
-              <div className={styles['button-container__right']}>
-                <button
-                  className={styles['button-container__delete']}
-                  onClick={handleDeleteButtonClick}
-                  type="button"
-                >
-                  삭제
-                  <GarbageCanIcon />
-                </button>
-              </div>
+              <button
+                className={styles['button-container__delete-button']}
+                onClick={handleDeleteButtonClick}
+                type="button"
+              >
+                삭제
+                <GarbageCanIcon />
+              </button>
             ) : (
-              <div className={styles['button-container__right']}>
+              <div className={styles['button-container__buttons']}>
                 <button
                   type="button"
-                  className={styles.contents__button}
+                  className={styles['button-container__message-button']}
                   onClick={async () => {
                     const chatroomInfo = await searchChatroom(articleId);
                     navigate(`${ROUTES.LostItemChat()}?chatroomId=${chatroomInfo.chat_room_id}&articleId=${articleId}`);
@@ -134,7 +130,7 @@ export default function LostItemDetailPage() {
                   <div>쪽지 보내기</div>
                 </button>
                 <button
-                  className={styles['button-container__report']}
+                  className={styles['button-container__report-button']}
                   type="button"
                   onClick={handleReportClick}
                 >

--- a/src/pages/Articles/LostItemWritePage/components/FormCategory/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/FormCategory/index.tsx
@@ -14,10 +14,10 @@ interface FormCategoryProps {
 export default function FormCategory({
   category, setCategory, isCategorySelected,
 }: FormCategoryProps) {
-  const { logFindUserCategory } = useArticlesLogger();
+  const { logLostItemCategory } = useArticlesLogger();
 
   const handleCategoryClick = (item: FindUserCategory) => {
-    logFindUserCategory(item);
+    logLostItemCategory(item);
     setCategory(item);
   };
 

--- a/src/pages/Articles/LostItemWritePage/components/FormDate/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/FormDate/index.tsx
@@ -38,6 +38,7 @@ export default function FormDate({
   useEscapeKeyDown({ onEscape: closeCalendar });
 
   const getDate = type === 'FOUND' ? '습득 일자' : '분실 일자';
+  const placeholderText = type === 'FOUND' ? '습득 일자를 선택해주세요.' : '분실 일자를 선택해주세요.';
   const warningText = type === 'FOUND' ? '습득 일자가 입력되지 않았습니다.' : '분실 일자가 입력되지 않았습니다.';
 
   return (
@@ -56,7 +57,7 @@ export default function FormDate({
                 [styles['date__description--has-been-selected']]: hasDateBeenSelected,
               })}
             >
-              {hasDateBeenSelected ? getyyyyMMdd(foundDate) : `${getDate}를 선택해주세요.`}
+              {hasDateBeenSelected ? getyyyyMMdd(foundDate) : placeholderText}
             </span>
             <span className={cn({
               [styles.icon]: true,

--- a/src/pages/Articles/LostItemWritePage/components/FormDate/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/FormDate/index.tsx
@@ -56,7 +56,7 @@ export default function FormDate({
                 [styles['date__description--has-been-selected']]: hasDateBeenSelected,
               })}
             >
-              {hasDateBeenSelected ? getyyyyMMdd(foundDate) : '분실 일자를 선택해주세요.'}
+              {hasDateBeenSelected ? getyyyyMMdd(foundDate) : `${getDate}를 선택해주세요.`}
             </span>
             <span className={cn({
               [styles.icon]: true,

--- a/src/pages/Articles/LostItemWritePage/components/LostItemForm/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/LostItemForm/index.tsx
@@ -43,7 +43,6 @@ export default function LostItemForm({
     setHasDateBeenSelected,
   } = lostItemHandler;
 
-  // const itemTag = `${MAX_LOST_ITEM_TYPE[type]} ${count + 1}`;
   const itemTag = `${MAX_LOST_ITEM_TYPE[type]} ${count + 1}`;
 
   return (

--- a/src/pages/Articles/LostItemWritePage/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/index.tsx
@@ -11,6 +11,7 @@ import ROUTES from 'static/routes';
 import { useArticlesLogger } from 'pages/Articles/hooks/useArticlesLogger';
 import { useUser } from 'utils/hooks/state/useUser';
 import { useEffect } from 'react';
+import showToast from 'utils/ts/showToast';
 import styles from './LostItemWritePage.module.scss';
 
 const getyyyyMMdd = (date: Date) => {
@@ -74,6 +75,11 @@ export default function LostItemWritePage() {
   const handleCompleteClick = async () => {
     logFindUserWriteConfirmClick();
     validateAndUpdateItems();
+
+    if (lostItems.length === 0) {
+      showToast('error', '물품을 추가해주세요.');
+      return;
+    }
 
     if (!checkArticleFormFull()) return;
 

--- a/src/pages/Articles/LostItemWritePage/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/index.tsx
@@ -65,15 +65,15 @@ export default function LostItemWritePage() {
   }, [user?.name, lostItems, lostItemHandler]);
 
   const { status, mutateAsync: postLostItem } = usePostLostItemArticles();
-  const { logFindUserAddItemClick, logFindUserWriteConfirmClick } = useArticlesLogger();
+  const { logLostItemAddItemClick, logLostItemWriteConfirmClick } = useArticlesLogger();
 
   const handleItemAddClick = () => {
-    logFindUserAddItemClick();
+    logLostItemAddItemClick();
     addLostItem();
   };
 
   const handleCompleteClick = async () => {
-    logFindUserWriteConfirmClick();
+    logLostItemWriteConfirmClick();
     validateAndUpdateItems();
 
     if (lostItems.length === 0) {

--- a/src/pages/Articles/hooks/useArticlesLogger.ts
+++ b/src/pages/Articles/hooks/useArticlesLogger.ts
@@ -10,7 +10,19 @@ const CLICK_EVENTS = [
     value: '물품 추가',
   },
   {
+    label: 'lost_item_add_item',
+    value: '물품 추가',
+  },
+  {
+    label: 'lost_item_category', // 11-9. 분실물신고_품목선택_클릭
+    value: '', // {”카드”, ”신분증”, ”지갑”, ”전자제품”, ”기타”}
+  },
+  {
     label: 'find_user_write_confirm',
+    value: '작성완료',
+  },
+  {
+    label: 'lost_item_write_confirm',
     value: '작성완료',
   },
   {
@@ -48,15 +60,21 @@ export const useArticlesLogger = () => {
 
   const logItemWriteClick = () => logEvent('item_write');
   const logFindUserAddItemClick = () => logEvent('find_user_add_item');
+  const logLostItemAddItemClick = () => logEvent('lost_item_add_item');
   const logFindUserWriteConfirmClick = () => logEvent('find_user_write_confirm');
+  const logLostItemWriteConfirmClick = () => logEvent('lost_item_write_confirm');
   const logFindUserDeleteClick = () => logEvent('find_user_delete');
   const logFindUserDeleteConfirmClick = () => logEvent('find_user_delete_confirm');
   const logFindUserCategory = (category: FindUserCategory) => logEvent('find_user_category', category);
+  const logLostItemCategory = (category: FindUserCategory) => logEvent('lost_item_category', category);
 
   return {
     logItemWriteClick,
     logFindUserAddItemClick,
+    logLostItemAddItemClick,
+    logLostItemCategory,
     logFindUserWriteConfirmClick,
+    logLostItemWriteConfirmClick,
     logFindUserDeleteClick,
     logFindUserDeleteConfirmClick,
     logFindUserCategory,


### PR DESCRIPTION
- Close #676
  
## What is this PR? 🔍

- 기능 : 분실물 QA 이슈 수정
- issue : #676 

## Changes 📝
* 분실물 또는 습득물이 0개일 때 작성 완료 버튼을 누르면 에러가 발생하던 현상을 수정했습니다.
* 총학생회 이외의 사람이 작성한 글에서 분실물 수령 문구가 뜨는 현상을 수정했습니다.
* 삭제 버튼을 디자인과 동일하게 우측 정렬로 수정했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/4402c183-2c4a-4083-995b-f50d77e78221" />
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/835f9aff-409a-48d3-af5f-c2a7cd7c932e" />
분실물 또는 습득물이 0개일 때는 api를 호출하지 않고 토스트 메시지를 띄웁니다.  


<br><img width="644" alt="image" src="https://github.com/user-attachments/assets/0e85d872-5574-4749-87c8-442763ad7abb" />
<br>총학생회 이외의 사람이 작성한 글에서 분실물 수령 문구가 뜨지 않습니다.

<br><img width="641" alt="image" src="https://github.com/user-attachments/assets/bbcd306d-0406-4710-b9c2-71bec0165fce" />
<br> 삭제 버튼이 우측 정렬 되었습니다.<br>


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
