### PR TITLE
[졸업학점계산기] 학적 정보 수정 추가

### DIFF
--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -13,6 +13,8 @@ import {
   DeleteResponse,
   CheckPasswordResponse,
   CheckPasswordRequest,
+  UpdateAcademicInfoResponse,
+  UpdateAcademicInfoRequest,
 } from './entity';
 
 export class Login<R extends LoginResponse> implements APIRequest<R> {
@@ -132,4 +134,16 @@ export class CheckPassword<R extends CheckPasswordResponse> implements APIReques
   constructor(public authorization: string, data: CheckPasswordRequest) {
     this.data = data;
   }
+}
+
+export class UpdateAcademicInfo<R extends UpdateAcademicInfoResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.PUT;
+
+  path = 'user/student/academic-info';
+
+  response!: R;
+
+  auth = true;
+
+  constructor(public authorization: string, public data: UpdateAcademicInfoRequest) { }
 }

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -78,3 +78,15 @@ export interface FindPasswordResponse extends APIResponse {
 }
 
 export interface CheckPasswordResponse extends APIResponse { }
+
+export interface UpdateAcademicInfoRequest extends APIResponse {
+  student_number: string;
+  department: string;
+  major?: string;
+}
+
+export interface UpdateAcademicInfoResponse extends APIResponse {
+  student_number: string;
+  department: string;
+  major: string | null;
+}

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -48,6 +48,7 @@ export interface RefreshResponse extends APIResponse {
 }
 
 export interface UserResponse extends APIResponse {
+  id: number;
   anonymous_nickname: string;
   email: string;
   gender: 0 | 1;

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -9,6 +9,7 @@ import {
   FindPassword,
   DeleteUser,
   CheckPassword,
+  UpdateAcademicInfo,
 } from './APIDetail';
 
 export const login = APIClient.of(Login);
@@ -28,3 +29,5 @@ export const deleteUser = APIClient.of(DeleteUser);
 export const findPassword = APIClient.of(FindPassword);
 
 export const checkPassword = APIClient.of(CheckPassword);
+
+export const updateAcademicInfo = APIClient.of(UpdateAcademicInfo);

--- a/src/api/graduationCalculator/index.ts
+++ b/src/api/graduationCalculator/index.ts
@@ -4,6 +4,6 @@ import {
   GraduationExcelUpload,
 } from './APIDetail';
 
-export const calculateGraduationCredits = APIClient.of(GraduationAgreement);
+export const agreegraduationCredits = APIClient.of(GraduationAgreement);
 
 export const uploadGraduationExcel = APIClient.of(GraduationExcelUpload);

--- a/src/pages/GraduationCalculatorPage/components/StudentForm/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/StudentForm/index.tsx
@@ -1,17 +1,15 @@
 import Listbox, { ListboxRef } from 'components/TimetablePage/Listbox';
 import { useEffect, useState } from 'react';
 import { useUser } from 'utils/hooks/state/useUser';
-import useUserInfoUpdate from 'utils/hooks/auth/useUserInfoUpdate';
 import useDepartmentMajorList from 'pages/GraduationCalculatorPage/hooks/useDepartmentMajorList';
-import useRemainingCredits from 'pages/GraduationCalculatorPage/hooks/useRemainingCredits';
 import useTokenState from 'utils/hooks/state/useTokenState';
+import useUpdateAcademicInfo from 'pages/GraduationCalculatorPage/hooks/useUpdateAcademicInfo';
 import styles from './StudentForm.module.scss';
 
 function StudentForm() {
   const token = useTokenState();
   const { data: userInfo } = useUser();
   const { data: deptMajorList } = useDepartmentMajorList();
-  const { mutate: calculateRemainingCredits } = useRemainingCredits(token);
 
   const [
     studentNumber, setStudentNumber,
@@ -19,7 +17,7 @@ function StudentForm() {
   const [
     department, setDepartment,
   ] = useState<string>(userInfo?.major ?? '');
-  const [major, setMajor] = useState<string | null>(null);
+  const [major, setMajor] = useState<string>();
   const [majorOptionList, setMajorOptionList] = useState<{ label: string, value: string }[]>([{ label: '', value: '' }]);
 
   const departmentOptionList = deptMajorList.map(
@@ -45,21 +43,15 @@ function StudentForm() {
     handleMajor(target.value);
   };
 
-  const onSuccess = () => {
-    calculateRemainingCredits();
-    // 그래프 학점 이수 구분 변경
-    // 이수 교양 영역 변경
-  };
-
-  const { mutate: updateUserInfo } = useUserInfoUpdate({ onSuccess });
+  const { mutate: updateAcademicInfo } = useUpdateAcademicInfo(token);
 
   const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    updateUserInfo({
-      ...userInfo,
-      major: department,
+    updateAcademicInfo({
       student_number: studentNumber,
+      department,
+      major,
     });
   };
 
@@ -101,7 +93,7 @@ function StudentForm() {
         <div className={styles['student-form__major']}>
           <Listbox
             list={majorOptionList}
-            value={major}
+            value={major ?? null}
             onChange={({ target }) => setMajor(target.value)}
             version="new"
           />

--- a/src/pages/GraduationCalculatorPage/hooks/useAgreeGraduationCreidts.ts
+++ b/src/pages/GraduationCalculatorPage/hooks/useAgreeGraduationCreidts.ts
@@ -3,14 +3,15 @@ import { useMutation } from '@tanstack/react-query';
 import { graduationCalculator } from 'api';
 import showToast from 'utils/ts/showToast';
 
-export default function useRemainingCredits(token: string) {
+export default function useAgreeGraduationCreidts(token: string) {
   return useMutation({
-    mutationFn: () => graduationCalculator.calculateGraduationCredits(token),
+    mutationFn: () => graduationCalculator.agreegraduationCredits(token),
 
     onSuccess: () => {},
 
     onError: (error) => {
       if (isKoinError(error)) {
+        if (error.status === 409) return;
         showToast('error', error.message || '학점 계산에 실패했습니다.');
       } else {
         sendClientError(error);

--- a/src/pages/GraduationCalculatorPage/hooks/useAgreeGraduationCreidts.ts
+++ b/src/pages/GraduationCalculatorPage/hooks/useAgreeGraduationCreidts.ts
@@ -3,17 +3,18 @@ import { useMutation } from '@tanstack/react-query';
 import { graduationCalculator } from 'api';
 import showToast from 'utils/ts/showToast';
 
-export default function useAgreeGraduationCreidts(token: string) {
+export default function useAgreeGraduationCreidts(token: string, userId: string) {
+  const agreeGraduationCredits = localStorage.getItem('agreeGraduationCredits');
   return useMutation({
     mutationFn: () => graduationCalculator.agreegraduationCredits(token),
 
     onSuccess: () => {
-      // 이수 교양 강의 조회 api 추가
-      // 이수구분별 학점 조회 api 추가
+      localStorage.setItem('agreeGraduationCredits', userId);
     },
 
     onError: (error) => {
       if (isKoinError(error)) {
+        if (!agreeGraduationCredits) return;
         if (error.status === 409) return;
         showToast('error', error.message || '학점 계산에 실패했습니다.');
       } else {

--- a/src/pages/GraduationCalculatorPage/hooks/useAgreeGraduationCreidts.ts
+++ b/src/pages/GraduationCalculatorPage/hooks/useAgreeGraduationCreidts.ts
@@ -7,7 +7,10 @@ export default function useAgreeGraduationCreidts(token: string) {
   return useMutation({
     mutationFn: () => graduationCalculator.agreegraduationCredits(token),
 
-    onSuccess: () => {},
+    onSuccess: () => {
+      // 이수 교양 강의 조회 api 추가
+      // 이수구분별 학점 조회 api 추가
+    },
 
     onError: (error) => {
       if (isKoinError(error)) {

--- a/src/pages/GraduationCalculatorPage/hooks/useUpdateAcademicInfo.ts
+++ b/src/pages/GraduationCalculatorPage/hooks/useUpdateAcademicInfo.ts
@@ -1,0 +1,20 @@
+import { isKoinError, sendClientError } from '@bcsdlab/koin';
+import { useMutation } from '@tanstack/react-query';
+import { auth } from 'api';
+import { UpdateAcademicInfoRequest } from 'api/auth/entity';
+import showToast from 'utils/ts/showToast';
+
+export default function useUpdateAcademicInfo(token: string) {
+  return useMutation({
+    mutationFn: (data: UpdateAcademicInfoRequest) => auth.updateAcademicInfo(token, data),
+
+    onError: (error) => {
+      if (isKoinError(error)) {
+        showToast('error', error.message || '학적 정보 수정에 실패했습니다.');
+      } else {
+        sendClientError(error);
+        showToast('error', '학적 정보 수정에 실패했습니다.');
+      }
+    },
+  });
+}

--- a/src/pages/GraduationCalculatorPage/index.tsx
+++ b/src/pages/GraduationCalculatorPage/index.tsx
@@ -6,6 +6,7 @@ import useTimetableFrameList from 'pages/TimetablePage/hooks/useTimetableFrameLi
 import AcademicCapIcon from 'assets/svg/academic-cap-icon.svg';
 import QuestionMarkIcon from 'assets/svg/question-mark-icon.svg';
 import useModalPortal from 'utils/hooks/layout/useModalPortal';
+import { useUser } from 'utils/hooks/state/useUser';
 import styles from './GraduationCalculatorPage.module.scss';
 import StudentForm from './components/StudentForm';
 import CourseTable from './components/CourseTable';
@@ -17,12 +18,13 @@ import useAgreeGraduationCreidts from './hooks/useAgreeGraduationCreidts';
 
 function GraduationCalculatorPage() {
   const token = useTokenState();
+  const { data: userInfo } = useUser();
   const semester = useSemester();
   const { data: timetableFrameList } = useTimetableFrameList(token, semester);
   const mainFrame = timetableFrameList.find(
     (frame) => frame.is_main === true,
   );
-  const { mutate: agreeGraduationCreidts } = useAgreeGraduationCreidts(token);
+  const { mutate: agreeGraduationCreidts } = useAgreeGraduationCreidts(token, String(userInfo?.id));
   const currentFrameIndex = mainFrame?.id ? mainFrame.id : 0;
   const portalManager = useModalPortal();
   const handleInformationClick = () => {
@@ -34,9 +36,8 @@ function GraduationCalculatorPage() {
   useEffect(() => {
     const isFirstAgree = localStorage.getItem('agreeGraduationCredits');
 
-    if (isFirstAgree) return;
+    if (Number(isFirstAgree) === userInfo?.id) return;
 
-    localStorage.setItem('agreeGraduationCredits', 'true');
     agreeGraduationCreidts();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/pages/GraduationCalculatorPage/index.tsx
+++ b/src/pages/GraduationCalculatorPage/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSemester } from 'utils/zustand/semester';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useTimetableFrameList from 'pages/TimetablePage/hooks/useTimetableFrameList';
@@ -13,6 +13,7 @@ import ExcelUploader from './components/ExcelUploader';
 import GeneralCourse from './components/GeneralCourse';
 import CreditChart from './components/CreditChart';
 import CalculatorHelpModal from './CalculatorHelpModal';
+import useAgreeGraduationCreidts from './hooks/useAgreeGraduationCreidts';
 
 function GraduationCalculatorPage() {
   const token = useTokenState();
@@ -21,6 +22,7 @@ function GraduationCalculatorPage() {
   const mainFrame = timetableFrameList.find(
     (frame) => frame.is_main === true,
   );
+  const { mutate: agreeGraduationCreidts } = useAgreeGraduationCreidts(token);
   const currentFrameIndex = mainFrame?.id ? mainFrame.id : 0;
   const portalManager = useModalPortal();
   const handleInformationClick = () => {
@@ -28,6 +30,16 @@ function GraduationCalculatorPage() {
       <CalculatorHelpModal closeInfo={portalManager.close} />
     ));
   };
+
+  useEffect(() => {
+    const isFirstAgree = localStorage.getItem('agreeGraduationCredits');
+
+    if (isFirstAgree) return;
+
+    localStorage.setItem('agreeGraduationCredits', 'true');
+    agreeGraduationCreidts();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className={styles.page}>


### PR DESCRIPTION
- Close #679 
  
## What is this PR? 🔍

- 기능 :  학적 정보 수정 api를 추가했습니다.
- issue : #679 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 기존 정보 수정 api 대신 세부 전공이 추가된 학적 정보 수정 api를 추가했습니다.
- 졸업학점 계산 동의 api를 졸업학점 계산기 페이지 최초 이동 시에만 호출하는 것으로 변경했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
