### PR TITLE
[캠퍼스] 분실물 로깅 수정

### DIFF
--- a/src/pages/Articles/LostItemDetailPage/components/ReportModal/index.tsx
+++ b/src/pages/Articles/LostItemDetailPage/components/ReportModal/index.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import useReportLostItemArticle from 'pages/Articles/hooks/useReportLostItemArticle';
 import showToast from 'utils/ts/showToast';
 import { useNavigate } from 'react-router-dom';
+import { ReportCategory, useArticlesLogger } from 'pages/Articles/hooks/useArticlesLogger';
 import styles from './ReportModal.module.scss';
 
 interface ReportModalProps {
@@ -32,6 +33,8 @@ export default function ReportModal({ articleId, closeReportModal }: ReportModal
   const [selectedReason, setSelectedReason] = useState('');
   const { mutate: reportArticle } = useReportLostItemArticle();
 
+  const { logItemPostReportConfirm } = useArticlesLogger();
+
   const handleReportClick = () => {
     const selectedOption = options.find((option) => option.value === selectedReason);
 
@@ -47,6 +50,7 @@ export default function ReportModal({ articleId, closeReportModal }: ReportModal
       },
     );
 
+    logItemPostReportConfirm(selectedOption.label as ReportCategory);
     closeReportModal();
     navigate('/articles');
   };
@@ -76,7 +80,11 @@ export default function ReportModal({ articleId, closeReportModal }: ReportModal
         />
 
         <div className={styles.modal__buttons}>
-          <button className={styles.buttons__report} type="button" onClick={handleReportClick}>
+          <button
+            className={styles.buttons__report}
+            type="button"
+            onClick={() => handleReportClick()}
+          >
             신고하기
           </button>
           <button className={styles.buttons__close} type="button" onClick={closeReportModal}>

--- a/src/pages/Articles/LostItemDetailPage/index.tsx
+++ b/src/pages/Articles/LostItemDetailPage/index.tsx
@@ -47,7 +47,7 @@ export default function LostItemDetailPage() {
     registeredAt,
   } = article;
 
-  const { logFindUserDeleteClick } = useArticlesLogger();
+  const { logFindUserDeleteClick, logItemPostReportClick } = useArticlesLogger();
 
   const handleDeleteButtonClick = () => {
     logFindUserDeleteClick();
@@ -56,6 +56,7 @@ export default function LostItemDetailPage() {
 
   const handleReportClick = () => {
     if (token) {
+      logItemPostReportClick();
       openReportModal();
     } else {
       portalManager.open((portalOption) => (

--- a/src/pages/Articles/LostItemWritePage/components/FormCategory/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/FormCategory/index.tsx
@@ -9,15 +9,20 @@ interface FormCategoryProps {
   category: FindUserCategory | '';
   setCategory: (category: FindUserCategory) => void;
   isCategorySelected: boolean;
+  type: 'FOUND' | 'LOST';
 }
 
 export default function FormCategory({
-  category, setCategory, isCategorySelected,
+  category, setCategory, isCategorySelected, type,
 }: FormCategoryProps) {
-  const { logLostItemCategory } = useArticlesLogger();
+  const { logFindUserCategory, logLostItemCategory } = useArticlesLogger();
 
   const handleCategoryClick = (item: FindUserCategory) => {
-    logLostItemCategory(item);
+    if (type === 'FOUND') {
+      logFindUserCategory(item);
+    } else {
+      logLostItemCategory(item);
+    }
     setCategory(item);
   };
 

--- a/src/pages/Articles/LostItemWritePage/components/LostItemForm/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/LostItemForm/index.tsx
@@ -66,6 +66,7 @@ export default function LostItemForm({
             category={category}
             setCategory={setCategory}
             isCategorySelected={isCategorySelected}
+            type={type}
           />
           <FormDate
             foundDate={foundDate}

--- a/src/pages/Articles/LostItemWritePage/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/index.tsx
@@ -65,15 +65,28 @@ export default function LostItemWritePage() {
   }, [user?.name, lostItems, lostItemHandler]);
 
   const { status, mutateAsync: postLostItem } = usePostLostItemArticles();
-  const { logLostItemAddItemClick, logLostItemWriteConfirmClick } = useArticlesLogger();
+  const {
+    logFindUserAddItemClick,
+    logLostItemAddItemClick,
+    logFindUserWriteConfirmClick,
+    logLostItemWriteConfirmClick,
+  } = useArticlesLogger();
 
   const handleItemAddClick = () => {
-    logLostItemAddItemClick();
+    if (type === 'FOUND') {
+      logFindUserAddItemClick();
+    } else {
+      logLostItemAddItemClick();
+    }
     addLostItem();
   };
 
   const handleCompleteClick = async () => {
-    logLostItemWriteConfirmClick();
+    if (type === 'FOUND') {
+      logFindUserWriteConfirmClick();
+    } else {
+      logLostItemWriteConfirmClick();
+    }
     validateAndUpdateItems();
 
     if (lostItems.length === 0) {

--- a/src/pages/Articles/components/LostItemRouteButton/index.tsx
+++ b/src/pages/Articles/components/LostItemRouteButton/index.tsx
@@ -9,9 +9,16 @@ import ROUTES from 'static/routes';
 import styles from './LostItemRouteButton.module.scss';
 
 export default function LostItemRouteButton() {
-  const { logItemWriteClick } = useArticlesLogger();
+  const { logItemWriteClick, logFindUserWriteClick, logLostItemWriteClick } = useArticlesLogger();
   const [isWriting, setIsWriting] = useState(false);
   const { pathname } = useLocation();
+
+  const handleWritingButtonClick = () => {
+    setIsWriting((prev) => !prev);
+    if (!isWriting) {
+      logItemWriteClick();
+    }
+  };
 
   return (
     <>
@@ -35,8 +42,7 @@ export default function LostItemRouteButton() {
             <Link
               className={styles['links__option-button']}
               to={ROUTES.LostItemFound()}
-              onClick={() => logItemWriteClick()}
-
+              onClick={() => logFindUserWriteClick()}
             >
               <FoundIcon />
               <div className={styles['links__option-text']}>주인을 찾아요</div>
@@ -45,8 +51,7 @@ export default function LostItemRouteButton() {
             <Link
               className={styles['links__option-button']}
               to={ROUTES.LostItemLost()}
-              onClick={() => logItemWriteClick()}
-
+              onClick={() => logLostItemWriteClick()}
             >
               <LostIcon />
               <div className={styles['links__option-text']}>잃어버렸어요</div>
@@ -58,7 +63,7 @@ export default function LostItemRouteButton() {
           <button
             className={styles.links__write}
             type="button"
-            onClick={() => setIsWriting((prev) => !prev)}
+            onClick={handleWritingButtonClick}
           >
             {isWriting ? <CloseIcon /> : <PencilIcon />}
             글쓰기

--- a/src/pages/Articles/hooks/useArticlesLogger.ts
+++ b/src/pages/Articles/hooks/useArticlesLogger.ts
@@ -6,6 +6,14 @@ const CLICK_EVENTS = [
     value: '글쓰기',
   },
   {
+    label: 'find_user_write',
+    value: '주인을 찾아요',
+  },
+  {
+    label: 'lost_item_write',
+    value: '잃어버렸어요',
+  },
+  {
     label: 'find_user_add_item',
     value: '물품 추가',
   },
@@ -37,11 +45,21 @@ const CLICK_EVENTS = [
     label: 'find_user_category',
     value: '', // {”카드”, ”신분증”, ”지갑”, ”전자제품”, ”기타”}
   },
+  {
+    label: 'item_post_report',
+    value: '신고하기',
+  },
+  {
+    label: 'item_post_report_confirm',
+    value: '', // {"주제에 맞지 않음", "스팸", "욕설", "개인정보", "기타"}
+  },
 ] as const;
 
 export type ClickEventLabel = typeof CLICK_EVENTS[number]['label'];
 
 export type FindUserCategory = '카드' | '신분증' | '지갑' | '전자제품' | '기타';
+
+export type ReportCategory = '주제에 맞지 않음' | '스팸' | '욕설' | '개인정보' | '기타';
 
 export const useArticlesLogger = () => {
   const logger = useLogger();
@@ -59,6 +77,8 @@ export const useArticlesLogger = () => {
   };
 
   const logItemWriteClick = () => logEvent('item_write');
+  const logFindUserWriteClick = () => logEvent('find_user_write');
+  const logLostItemWriteClick = () => logEvent('lost_item_write');
   const logFindUserAddItemClick = () => logEvent('find_user_add_item');
   const logLostItemAddItemClick = () => logEvent('lost_item_add_item');
   const logFindUserWriteConfirmClick = () => logEvent('find_user_write_confirm');
@@ -67,9 +87,13 @@ export const useArticlesLogger = () => {
   const logFindUserDeleteConfirmClick = () => logEvent('find_user_delete_confirm');
   const logFindUserCategory = (category: FindUserCategory) => logEvent('find_user_category', category);
   const logLostItemCategory = (category: FindUserCategory) => logEvent('lost_item_category', category);
+  const logItemPostReportClick = () => logEvent('item_post_report');
+  const logItemPostReportConfirm = (category: ReportCategory) => logEvent('item_post_report_confirm', category);
 
   return {
     logItemWriteClick,
+    logFindUserWriteClick,
+    logLostItemWriteClick,
     logFindUserAddItemClick,
     logLostItemAddItemClick,
     logLostItemCategory,
@@ -78,5 +102,7 @@ export const useArticlesLogger = () => {
     logFindUserDeleteClick,
     logFindUserDeleteConfirmClick,
     logFindUserCategory,
+    logItemPostReportClick,
+    logItemPostReportConfirm,
   };
 };


### PR DESCRIPTION
- Close #691 
  
## What is this PR? 🔍

- 기능 : 분실물 로깅 수정입니다.
- issue : #691 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
분실물 로깅이 추가, 수정되었습니다.
* 추가: 주인을 찾아요, 잃어버렸어요, 신고, 신고하기 버튼에 대한 로깅
* 수정: 습득물 페이지 로깅

## ScreenShot 📷

#### 로깅 추가
* 주인을 찾아요(습득물 글쓰기), 잃어버렸어요(분실물 글쓰기) 버튼의 로깅을 추가하였습니다.
<img width="341" alt="image" src="https://github.com/user-attachments/assets/701aa8cf-169d-46e9-a520-2f7544829fef" />
<img width="256" alt="image" src="https://github.com/user-attachments/assets/7f43319b-7170-4a25-8d53-7aa03f0d17c3" />  
  
* 신고와 신고하기 버튼의 로깅을 추가하였습니다.

<img width="257" alt="image" src="https://github.com/user-attachments/assets/5153ffba-d818-4045-80e2-47ad450bfb98" />
<img width="262" alt="image" src="https://github.com/user-attachments/assets/2cbe474c-77f4-4920-9fce-3861cc78dd51" />


#### 로깅 수정
* 습득물 페이지에 분실물 로깅이 들어가 있던 현상을 수정하였습니다.
<img width="257" alt="image" src="https://github.com/user-attachments/assets/f4861891-776e-4cac-b450-8cb57de6b164" />
<img width="257" alt="image" src="https://github.com/user-attachments/assets/2ade4d09-b0a3-4fd0-ba81-710ad4490054" />
<img width="256" alt="image" src="https://github.com/user-attachments/assets/e4268914-8eaf-43d9-b553-ed60fea5f997" />



## Test CheckList ✅

- [x] 주인을 찾아요(`find_user_write`)와 잃어버렸어요(`lost_item_write`)의 로깅이 나오는지 확인합니다.
- [x] 습득물 페이지에서 `lost`로 시작하는 분실물 로깅이 나오지 않는지 확인합니다.
- [x] 신고 버튼을 누를 시 `item_post_report` 로깅이 나오는지 확인합니다.
- [x] 신고하기 버튼을 누를 시 `item_post_report_confirm` 로깅이 나오는지 확인합니다.


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
