### PR TITLE
[커스텀시간표] 드롭다운 메뉴 위로 올라가는 이슈 수정

### DIFF
--- a/src/pages/TimetablePage/components/CustomLecture/index.tsx
+++ b/src/pages/TimetablePage/components/CustomLecture/index.tsx
@@ -275,7 +275,7 @@ function TimeSpaceInput({
           <div
             className={cn({
               [styles['form-group-time__time']]: true,
-              [styles['form-group-time__time--reverse']]: isReverseDropdown,
+              [styles['form-group-time__time--reverse']]: isReverseDropdown && !isSingleTimeSpaceComponent,
             })}
           >
             <Listbox list={HOUR} value={time.startHour} onChange={handleLectureTimeByTime('startHour')} version="addLecture" disabled={isEditStandardLecture} />
@@ -542,8 +542,8 @@ function CustomLecture({ timetableFrameId }: { timetableFrameId: number }) {
         behavior: 'smooth',
         top: 999,
       });
-      handleScroll();
     }
+    handleScroll();
 
     prevLengthRef.current = timeSpaceComponents.length;
   }, [timeSpaceComponents]);


### PR DESCRIPTION
- Close #693 
  
## What is this PR? 🔍

- 기능 : 드롭다운 메뉴 위로 올라가는 이슈를 수정합니다.
- issue : #693 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 시간, 장소 컴포넌트가 하나인 경우 reverse가 되지 않도록 조정했습니다.
- 또한, 시간,장소 컴포넌트 삭제 시 `handleScroll()`을 하여 botton position을 변경해야 하는데 컴포넌트 추가 시에만 `handleScroll()`을 호출하던 것을 수정했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
![image](https://github.com/user-attachments/assets/565900b8-a39b-438f-ad5a-fd55463e303e)


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
