### PR TITLE
[졸업학점계산기] 컴포넌트 높이 수정 및 queryKey 추가

### DIFF
--- a/src/pages/GraduationCalculatorPage/components/GeneralCourse/GeneralCourse.module.scss
+++ b/src/pages/GraduationCalculatorPage/components/GeneralCourse/GeneralCourse.module.scss
@@ -2,6 +2,7 @@
 
 .general-course {
   display: flex;
+  height: 224px;
   flex-direction: column;
   gap: 16px;
   border: none;

--- a/src/pages/GraduationCalculatorPage/components/GeneralCourse/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/GeneralCourse/index.tsx
@@ -16,7 +16,7 @@ function GeneralCourse() {
   const [isModalOpen, openModal, closeModal] = useBooleanState(false);
   const token = useTokenState();
   const { generalEducation } = useGeneralEducation(token);
-  const requiredEducationArea = generalEducation.general_education_area;
+  const requiredEducationArea = generalEducation?.general_education_area || [];
   const [selectedCourseType, setSelectedCourseType] = useState<string | null>(null);
 
   const handleOpenModal = (courseType: string) => {

--- a/src/pages/GraduationCalculatorPage/hooks/useGeneralEducation.ts
+++ b/src/pages/GraduationCalculatorPage/hooks/useGeneralEducation.ts
@@ -1,11 +1,12 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { graduationCalculator } from 'api';
 
 const useGeneralEducation = (token: string) => {
-  const { data } = useSuspenseQuery(
+  const { data } = useQuery(
     {
       queryKey: ['generalEducation'],
       queryFn: () => (graduationCalculator.getGeneralEducation(token)),
+      enabled: !!token,
     },
   );
 

--- a/src/pages/TimetablePage/hooks/useDeleteTimetableLecture.ts
+++ b/src/pages/TimetablePage/hooks/useDeleteTimetableLecture.ts
@@ -13,6 +13,9 @@ export default function useDeleteTimetableLecture(authorization: string) {
       queryClient.invalidateQueries(
         { queryKey: [TIMETABLE_INFO_LIST] },
       );
+      queryClient.invalidateQueries(
+        { queryKey: ['generalEducation'] },
+      );
     },
     onError: (error) => {
       if (isKoinError(error)) {


### PR DESCRIPTION
- Close #699 
  
## What is this PR? 🔍

- 기능 : 컴포넌트 높이를 고정하여 배치를 조정합니다.
- issue : #699 

## Changes 📝

- 교양 영역이 두 줄일 경우와 세 줄일 경우 컴포넌트 높이가 동일합니다.
- queryKey를 추가하여 새로고침 없이 값이 바로 반영되도록 합니다.

## ScreenShot 📷
<img width="918" alt="스크린샷 2025-02-26 20 33 28" src="https://github.com/user-attachments/assets/5fc97b21-1b6c-44ab-94b5-8aa53ad829a7" />

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
