### PR TITLE
[hotfix, 유저] 닉네임 중복확인 조건 추가

### DIFF
--- a/src/pages/Articles/components/ArticleContent/ArticleContent.module.scss
+++ b/src/pages/Articles/components/ArticleContent/ArticleContent.module.scss
@@ -14,6 +14,7 @@
   min-height: 230px;
   overflow: scroll;
   user-select: text;
+
   &::-webkit-scrollbar {
     display: none;
   }

--- a/src/pages/Auth/SignupPage/hooks/useNicknameDuplicateCheck.ts
+++ b/src/pages/Auth/SignupPage/hooks/useNicknameDuplicateCheck.ts
@@ -2,15 +2,21 @@ import React from 'react';
 import showToast from 'utils/ts/showToast';
 import useNicknameCheckServer from './useNicknameCheckServer';
 
-const NICKNAME_REGEX = /admin|관리자/;
+const ADMIN_NICKNAME_REGEX = /admin|관리자/;
+
+const INVALID_NICKNAME_REGEX = /^[A-Za-z가-힣\d]+$/;
 
 const useNicknameDuplicateCheck = () => {
   const [nickname, setNickname] = React.useState('');
   const { data, mutate, status } = useNicknameCheckServer();
 
   const changeTargetNickname = (targetNickname: string) => {
-    if (NICKNAME_REGEX.test(targetNickname)) {
+    if (ADMIN_NICKNAME_REGEX.test(targetNickname)) {
       showToast('warning', '사용할 수 없는 닉네임입니다.');
+      return;
+    }
+    if (!INVALID_NICKNAME_REGEX.test(targetNickname)) {
+      showToast('warning', '닉네임은 한글, 영문 및 숫자만 사용할 수 있습니다.');
       return;
     }
     if (!targetNickname) {


### PR DESCRIPTION
- Close #709 
  
## What is this PR? 🔍

- 기능 : 회원가입, 정보수정 페이지에서 닉네임 중복확인 시 영문, 한글, 숫자 외 입력 불가 조건을 추가했습니다.
- issue : #709 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 회원가입, 정보수정 페이지에서 닉네임 중복확인 시 영문, 한글, 숫자 외 입력 불가 조건을 추가했습니다.
