### PR TITLE
[유저] 정보 수정 시 성별 미선택하면 "null"로 요청값 보내는 이슈 해결

### DIFF
--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -353,11 +353,10 @@ const GenderSelectorWithRef = React.forwardRef((
   const { data: userInfo } = useUser();
   const [
     selectedValue, setSelectedValue,
-  ] = React.useState<string | null>(String(userInfo?.gender) || null);
+  ] = React.useState<string | null>(userInfo ? String(userInfo?.gender) : null);
 
   useImperativeHandle(ref, () => ({
     value: selectedValue,
-    valid: selectedValue !== null ? true : '성별을 선택해주세요.',
   }));
 
   return (


### PR DESCRIPTION
- Close #721 
  
## What is this PR? 🔍

- 기능 : 성별이 있는지 없는지를 구분하여 요청값을 보냅니다.
- issue : #721 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 성별이 있는지 없는지를 구분하여 요청값을 보냅니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
