### PR TITLE
[졸업학점계산기] 2차 qa 이슈 수정

### DIFF
--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -7,6 +7,7 @@ import {
   RefreshResponse,
   SignupResponse,
   UserResponse,
+  UserAcademicInfoResponse,
   FindPasswordRequest,
   FindPasswordResponse,
   UserUpdateRequest,
@@ -76,6 +77,19 @@ export class User<R extends UserResponse> implements APIRequest<R> {
   response!: R;
 
   auth = false;
+
+  constructor(public authorization: string) { }
+}
+
+// 추후 User 클래스명으로 아래 API로 통일할 것
+export class UserAcademicInfo<R extends UserAcademicInfoResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path = '/user/student/me/academic-info';
+
+  response! : R;
+
+  auth = true;
 
   constructor(public authorization: string) { }
 }

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -59,6 +59,19 @@ export interface UserResponse extends APIResponse {
   student_number: string;
 }
 
+export interface UserAcademicInfoResponse extends APIResponse {
+  id: number;
+  anonymous_nickname: string;
+  email: string;
+  gender: 0 | 1;
+  department: string;
+  major: string;
+  name: string;
+  nickname: string;
+  phone_number: string;
+  student_number: string;
+}
+
 export interface UserUpdateRequest {
   password?: string;
   identity?: number;

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -52,7 +52,7 @@ export interface UserResponse extends APIResponse {
   anonymous_nickname: string;
   email: string;
   gender: 0 | 1;
-  major: string;
+  major: string; // 학부
   name: string;
   nickname: string;
   phone_number: string;
@@ -64,8 +64,8 @@ export interface UserAcademicInfoResponse extends APIResponse {
   anonymous_nickname: string;
   email: string;
   gender: 0 | 1;
-  department: string;
-  major: string;
+  department: string; // 학부
+  major: string; // 세부 전공
   name: string;
   nickname: string;
   phone_number: string;

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -5,6 +5,7 @@ import {
   Refresh,
   Signup,
   User,
+  UserAcademicInfo,
   UpdateUser,
   FindPassword,
   DeleteUser,
@@ -21,6 +22,8 @@ export const signup = APIClient.of(Signup);
 export const refresh = APIClient.of(Refresh);
 
 export const getUser = APIClient.of(User);
+
+export const getUserAcademicInfo = APIClient.of(UserAcademicInfo);
 
 export const updateUser = APIClient.of(UpdateUser);
 

--- a/src/api/graduationCalculator/entity.ts
+++ b/src/api/graduationCalculator/entity.ts
@@ -22,6 +22,7 @@ export interface LectureInfo {
   id: number;
   code: string;
   name: string;
+  professor?: string;
   grades: string;
   department: string;
 }

--- a/src/pages/GraduationCalculatorPage/CalculatorHelpModal/CalculatorHelpModal.module.scss
+++ b/src/pages/GraduationCalculatorPage/CalculatorHelpModal/CalculatorHelpModal.module.scss
@@ -20,6 +20,7 @@
   border-radius: 16px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 36px;
   background-color: #fff;
 
@@ -39,7 +40,6 @@
     font-size: 20px;
     font-weight: 500;
     line-height: normal;
-    margin-left: 63px;
 
     & > strong {
       font-weight: 700;

--- a/src/pages/GraduationCalculatorPage/components/CreditChart/CreditChart.module.scss
+++ b/src/pages/GraduationCalculatorPage/components/CreditChart/CreditChart.module.scss
@@ -55,6 +55,7 @@
       font-style: normal;
       font-weight: 400;
       line-height: 160%;
+      white-space: nowrap;
     }
   }
 

--- a/src/pages/GraduationCalculatorPage/components/CreditChart/CreditChart.module.scss
+++ b/src/pages/GraduationCalculatorPage/components/CreditChart/CreditChart.module.scss
@@ -3,6 +3,7 @@
 .credit-chart {
   position: relative;
   display: flex;
+  gap: 36px;
   border: none;
   border-radius: 16px;
   background-color: #fff;
@@ -40,10 +41,11 @@
   }
 
   &__x-axis {
-    position: absolute;
-    display: flex;
-    bottom: 42px;
-    left: 66px;
+    display: grid;
+    width: 800px;
+    gap: 20px;
+    position: relative;
+    bottom: -30px;
     align-items: end;
 
     &--name {
@@ -76,6 +78,7 @@
 
   &__earned-credit {
     position: absolute;
+    width: 100%;
     background: rgba(122 186 120 / 70%);
     bottom: 0;
 

--- a/src/pages/GraduationCalculatorPage/components/CreditChart/SemesterLectureListModal/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/CreditChart/SemesterLectureListModal/index.tsx
@@ -10,6 +10,7 @@ import useUserAcademicInfo from 'utils/hooks/state/useUserAcademicInfo';
 import useAllMyLectures from 'pages/TimetablePage/hooks/useAllMyLectures';
 import { LectureInfo } from 'api/graduationCalculator/entity';
 import { Selector } from 'components/common/Selector';
+import _ from 'lodash';
 import styles from './SemesterLectureListModal.module.scss';
 
 const lectureStatusOptions = [
@@ -70,12 +71,8 @@ export default function SemesterLectureListModal({
   const allMyLecturesInfo = allMyLectures
     .filter((myLecture) => myLecture.course_type === course)
     .map((lecture) => ({
-      id: lecture.id,
-      code: lecture.code,
+      ..._.pick(lecture, ['id', 'code', 'professor', 'grades', 'department']),
       name: lecture.class_title,
-      professor: lecture.professor,
-      grades: lecture.grades,
-      department: lecture.department,
     }));
 
   const lecturesInfo = lectureStatus === '수강한 강의'

--- a/src/pages/GraduationCalculatorPage/components/CreditChart/SemesterLectureListModal/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/CreditChart/SemesterLectureListModal/index.tsx
@@ -6,8 +6,8 @@ import CloseIcon from 'assets/svg/close-icon-grey.svg';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useCourseType from 'pages/GraduationCalculatorPage/hooks/useCourseType';
 import { startTransition, useState } from 'react';
-import { useUser } from 'utils/hooks/state/useUser';
-import useTakenLectureCode from 'pages/TimetablePage/hooks/useTakenLectureCode';
+import useUserAcademicInfo from 'utils/hooks/state/useUserAcademicInfo';
+import useAllMyLectures from 'pages/TimetablePage/hooks/useAllMyLectures';
 import { LectureInfo } from 'api/graduationCalculator/entity';
 import { Selector } from 'components/common/Selector';
 import styles from './SemesterLectureListModal.module.scss';
@@ -44,8 +44,8 @@ export default function SemesterLectureListModal({
 }) {
   const semesters = useSemester();
   const token = useTokenState();
-  const { data: takenLectureCode } = useTakenLectureCode(token);
-  const { data: userInfo } = useUser();
+  const allMyLectures = useAllMyLectures(token);
+  const { data: academicInfo } = useUserAcademicInfo();
   const semesterOptionList = (semesters ?? []).map(
     (semesterInfo) => ({
       label: `${semesterInfo.year}년 ${semesterInfo.term}`,
@@ -60,13 +60,31 @@ export default function SemesterLectureListModal({
   const {
     value: lectureStatus, onChangeSelect: onChangeLectureStatus,
   } = useSelect(lectureStatusOptions[0].value);
-  const { value: department, onChangeSelect: onChangeDepartment } = useSelect(userInfo?.major);
+  const {
+    value: department,
+    onChangeSelect: onChangeDepartment,
+  } = useSelect(academicInfo?.department);
   const { value: course, onChangeSelect: onChangeCourse } = useSelect(initialCourse);
   const { data: generalCourses } = useCourseType(token, semester, course!);
 
+  const allMyLecturesInfo = allMyLectures
+    .filter((myLecture) => myLecture.course_type === course)
+    .map((lecture) => ({
+      id: lecture.id,
+      code: lecture.code,
+      name: lecture.class_title,
+      professor: lecture.professor,
+      grades: lecture.grades,
+      department: lecture.department,
+    }));
+
+  const lecturesInfo = lectureStatus === '수강한 강의'
+    ? allMyLecturesInfo
+    : generalCourses.lectures;
+
   const filteredLecturesByDept = department === '전체'
-    ? generalCourses.lectures
-    : generalCourses.lectures.filter(
+    ? lecturesInfo
+    : lecturesInfo.filter(
       (lecture) => lecture.department === department,
     );
 
@@ -84,12 +102,18 @@ export default function SemesterLectureListModal({
   }
 
   const filteredLectureByLectureStatus = lectureStatus === '수강한 강의'
-    ? separateByMatchingCodes(filteredLecturesByDept, takenLectureCode).matched
-    : separateByMatchingCodes(filteredLecturesByDept, takenLectureCode).unmatched;
+    ? separateByMatchingCodes(
+      filteredLecturesByDept,
+      allMyLectures.map((item) => item.code),
+    ).matched
+    : separateByMatchingCodes(
+      filteredLecturesByDept,
+      allMyLectures.map((item) => item.code),
+    ).unmatched;
 
   const tableData = filteredLectureByLectureStatus.map((lecture) => [
     <span>{lecture.name}</span>,
-    <span>{ }</span>,
+    <span>{lecture.professor ? lecture.professor : ''}</span>,
     <span>{lecture.grades}</span>,
     <span>{course}</span>,
     <span>{ }</span>,
@@ -108,7 +132,7 @@ export default function SemesterLectureListModal({
           <div className={styles['dropdowns__first-row']}>
             <Selector
               options={semesterOptionList}
-              value={`${semester.year}년 ${semester.term}`}
+              value={lectureStatus === '수강한 강의' ? '' : `${semester.year}년 ${semester.term}`}
               onChange={({ target }) => startTransition(() => {
                 setSemester({
                   year: Number(target.value.slice(0, 4)),
@@ -116,6 +140,8 @@ export default function SemesterLectureListModal({
                 });
               })}
               dropDownMaxHeight={384}
+              placeholder="-"
+              disabled={lectureStatus === '수강한 강의'}
             />
           </div>
           <div className={styles['dropdowns__first-row']}>

--- a/src/pages/GraduationCalculatorPage/components/CreditChart/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/CreditChart/index.tsx
@@ -10,13 +10,13 @@ import useGetMultiMajorLecture from 'pages/TimetablePage/hooks/useGetMultiMajorL
 import styles from './CreditChart.module.scss';
 import SemesterLectureListModal from './SemesterLectureListModal';
 
-const barStyles = (barsNumber: number) => {
-  if (barsNumber === 7) return { width: '75px', gap: '45px' };
-  if (barsNumber === 8) return { width: '70px', gap: '33.57px' };
-  if (barsNumber === 9) return { width: '65px', gap: '26.25px' };
-  if (barsNumber === 10) return { width: '60px', gap: '21.67px' };
-  return { width: '70px', gap: '33.57px' };
-};
+// const barStyles = (barsNumber: number) => {
+//   if (barsNumber === 7) return { width: '75px', gap: '45px' };
+//   if (barsNumber === 8) return { width: '70px', gap: '33.57px' };
+//   if (barsNumber === 9) return { width: '65px', gap: '26.25px' };
+//   if (barsNumber === 10) return { width: '60px', gap: '21.67px' };
+//   return { width: '70px', gap: '33.57px' };
+// };
 
 function CreditChart() {
   const portalManger = useModalPortal();
@@ -70,7 +70,7 @@ function CreditChart() {
       <motion.div
         layout
         className={styles['credit-chart__x-axis']}
-        style={{ gap: barStyles(barsNumber).gap }}
+        style={{ gridTemplateColumns: `repeat(${barsNumber}, 1fr)` }}
       >
         <AnimatePresence>
           {creditState.map((credit) => (
@@ -85,14 +85,12 @@ function CreditChart() {
             >
               <div
                 style={{
-                  width: barStyles(barsNumber).width,
                   height: `${Number(credit.requiredGrades) * 5}px`,
                 }}
                 className={styles['credit-chart__total-credit']}
               >
                 <motion.div
                   style={{
-                    width: barStyles(barsNumber).width,
                     height: `${Number(credit.grades) * 5}px`,
                   }}
                   className={cn({

--- a/src/pages/GraduationCalculatorPage/components/CreditChart/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/CreditChart/index.tsx
@@ -10,14 +10,6 @@ import useGetMultiMajorLecture from 'pages/TimetablePage/hooks/useGetMultiMajorL
 import styles from './CreditChart.module.scss';
 import SemesterLectureListModal from './SemesterLectureListModal';
 
-// const barStyles = (barsNumber: number) => {
-//   if (barsNumber === 7) return { width: '75px', gap: '45px' };
-//   if (barsNumber === 8) return { width: '70px', gap: '33.57px' };
-//   if (barsNumber === 9) return { width: '65px', gap: '26.25px' };
-//   if (barsNumber === 10) return { width: '60px', gap: '21.67px' };
-//   return { width: '70px', gap: '33.57px' };
-// };
-
 function CreditChart() {
   const portalManger = useModalPortal();
   const token = useTokenState();

--- a/src/pages/GraduationCalculatorPage/components/ExcelUploader/ExcelUploader.module.scss
+++ b/src/pages/GraduationCalculatorPage/components/ExcelUploader/ExcelUploader.module.scss
@@ -93,8 +93,7 @@
     &-asset {
       position: absolute;
       bottom: -13px;
-      right: -148px;
-      width: 100%;
+      right: 130px;
       margin: 0 auto;
     }
   }

--- a/src/pages/GraduationCalculatorPage/components/ExcelUploader/ExcelUploader.module.scss
+++ b/src/pages/GraduationCalculatorPage/components/ExcelUploader/ExcelUploader.module.scss
@@ -57,9 +57,10 @@
     z-index: 10;
     position: absolute;
     top: -90.5px;
-    right: -102px;
+    right: -112px;
     display: flex;
-    width: fit-content;
+    justify-content: space-between;
+    width: 264px;
     gap: 8px;
     border-radius: 8px;
     background: #fafafa;
@@ -92,7 +93,7 @@
     &-asset {
       position: absolute;
       bottom: -13px;
-      right: -124px;
+      right: -148px;
       width: 100%;
       margin: 0 auto;
     }

--- a/src/pages/GraduationCalculatorPage/components/GeneralCourse/GeneralCourse.module.scss
+++ b/src/pages/GraduationCalculatorPage/components/GeneralCourse/GeneralCourse.module.scss
@@ -106,9 +106,9 @@
   z-index: 10;
   position: absolute;
   top: -58px;
-  right: -120px;
+  right: -101px;
   display: flex;
-  width: fit-content;
+  width: 264px;
   gap: 8px;
   border-radius: 8px;
   background: #fafafa;
@@ -142,7 +142,7 @@
   &-asset {
     position: absolute;
     bottom: -13px;
-    right: -124px;
+    right: -148px;
     width: 100%;
     margin: 0 auto;
   }

--- a/src/pages/GraduationCalculatorPage/components/GeneralCourse/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/GeneralCourse/index.tsx
@@ -70,7 +70,6 @@ function GeneralCourse() {
           <div className={styles['tooltip-content']}>
             교양 영역을 클릭해서
             <strong> 학기 교양 개설 목록</strong>
-            <br />
             을 확인할 수 있어요.
           </div>
           <button

--- a/src/pages/GraduationCalculatorPage/components/StudentForm/StudentForm.module.scss
+++ b/src/pages/GraduationCalculatorPage/components/StudentForm/StudentForm.module.scss
@@ -36,11 +36,15 @@
     gap: 16px;
     justify-content: space-between;
     align-items: center;
-    font-family: Pretendard, sans-serif;
-    font-weight: 500;
-    font-size: 22px;
-    line-height: 26.25px;
-    letter-spacing: 0%;
+
+    &--text {
+      font-family: Pretendard, sans-serif;
+      font-weight: 500;
+      font-size: 22px;
+      line-height: 26.25px;
+      letter-spacing: 0%;
+      white-space: nowrap;
+    }
   }
 
   &__department,
@@ -56,7 +60,7 @@
   }
 
   &__student-number {
-    width: 261px;
+    flex: 1;
     border: 1px solid #e1e1e1;
     border-radius: 5px;
     padding: 11px 16px;

--- a/src/pages/GraduationCalculatorPage/components/StudentForm/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/StudentForm/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useUser } from 'utils/hooks/state/useUser';
+import useUserAcademicInfo from 'utils/hooks/state/useUserAcademicInfo';
 import useDepartmentMajorList from 'pages/GraduationCalculatorPage/hooks/useDepartmentMajorList';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useUpdateAcademicInfo from 'pages/GraduationCalculatorPage/hooks/useUpdateAcademicInfo';
@@ -8,16 +8,16 @@ import styles from './StudentForm.module.scss';
 
 function StudentForm() {
   const token = useTokenState();
-  const { data: userInfo } = useUser();
+  const { data: academicInfo } = useUserAcademicInfo();
   const { data: deptMajorList } = useDepartmentMajorList();
 
   const [
     studentNumber, setStudentNumber,
-  ] = useState<string>(userInfo?.student_number ?? '');
+  ] = useState<string>(academicInfo?.student_number ?? '');
   const [
     department, setDepartment,
-  ] = useState<string>(userInfo?.major ?? '');
-  const [major, setMajor] = useState<string>();
+  ] = useState<string>(academicInfo?.department ?? '');
+  const [major, setMajor] = useState<string>(academicInfo?.major ?? '');
   const [majorOptionList, setMajorOptionList] = useState<{ label: string, value: string }[]>([{ label: '', value: '' }]);
 
   const departmentOptionList = deptMajorList.map(
@@ -41,7 +41,7 @@ function StudentForm() {
   const handleDepartment = ({ target }: { target: { value: string } }) => {
     setDepartment(target.value);
     handleMajor(target.value);
-    setMajor(undefined);
+    setMajor('');
   };
 
   const { mutate: updateAcademicInfo } = useUpdateAcademicInfo(token);
@@ -52,7 +52,7 @@ function StudentForm() {
     updateAcademicInfo({
       student_number: studentNumber,
       department,
-      major,
+      major: major || undefined,
     });
   };
 

--- a/src/pages/GraduationCalculatorPage/components/StudentForm/index.tsx
+++ b/src/pages/GraduationCalculatorPage/components/StudentForm/index.tsx
@@ -66,11 +66,11 @@ function StudentForm() {
   return (
     <form onSubmit={onSubmitForm} className={styles['student-form']}>
       <div className={styles['student-form__input']}>
-        <div>내 정보</div>
+        <div className={styles['student-form__input--text']}>내 정보</div>
         <button type="submit" className={styles['student-form__button']}>저장하기</button>
       </div>
       <div className={styles['student-form__input']}>
-        <div>학번</div>
+        <div className={styles['student-form__input--text']}>학번</div>
         <input
           name="student-number"
           className={styles['student-form__student-number']}
@@ -79,7 +79,7 @@ function StudentForm() {
         />
       </div>
       <div className={styles['student-form__input']}>
-        <div>학과</div>
+        <div className={styles['student-form__input--text']}>학과</div>
         <div className={styles['student-form__department']}>
           <Selector
             options={departmentOptionList}
@@ -90,7 +90,7 @@ function StudentForm() {
         </div>
       </div>
       <div className={styles['student-form__input']}>
-        <div>전공</div>
+        <div className={styles['student-form__input--text']}>전공</div>
         <div className={styles['student-form__major']}>
           <Selector
             options={majorOptionList}

--- a/src/pages/GraduationCalculatorPage/hooks/useUpdateAcademicInfo.ts
+++ b/src/pages/GraduationCalculatorPage/hooks/useUpdateAcademicInfo.ts
@@ -16,6 +16,7 @@ export default function useUpdateAcademicInfo(token: string) {
       agreeGraduationCredits();
       queryClient.invalidateQueries({ queryKey: ['generalEducation'] });
       queryClient.invalidateQueries({ queryKey: ['creditsByCourseType'] });
+      queryClient.invalidateQueries({ queryKey: ['userAcademicinfo'] });
 
       showToast('success', '수정하신 정보가 적용되었습니다.');
     },

--- a/src/pages/TimetablePage/components/Curriculum/Curriculum.module.scss
+++ b/src/pages/TimetablePage/components/Curriculum/Curriculum.module.scss
@@ -57,6 +57,7 @@
     font-size: 18px;
     line-height: 28.8px;
     letter-spacing: 0%;
+    white-space: nowrap;
   }
 
   &__icon {

--- a/src/pages/TimetablePage/hooks/useAllMyLectures.ts
+++ b/src/pages/TimetablePage/hooks/useAllMyLectures.ts
@@ -1,12 +1,12 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { timetable } from 'api';
 
-export default function useTakenLectureCode(token: string) {
-  return useSuspenseQuery({
+export default function useAllMyLectures(token: string) {
+  const { data } = useSuspenseQuery({
     queryKey: ['allLectures'],
 
     queryFn: () => timetable.getTimetableAllLectureInfo(token),
-
-    select: (data) => data.timetable.map((item) => item.code),
   });
+
+  return data.timetable;
 }

--- a/src/utils/hooks/state/useUserAcademicInfo.ts
+++ b/src/utils/hooks/state/useUserAcademicInfo.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { auth } from 'api';
+import useTokenState from './useTokenState';
+
+export default function useUserAcademicInfo() {
+  const token = useTokenState();
+
+  return useQuery({
+    queryKey: ['userAcademicinfo'],
+
+    queryFn: () => (token ? auth.getUserAcademicInfo(token) : null),
+  });
+}

--- a/src/utils/hooks/state/useUserAcademicInfo.ts
+++ b/src/utils/hooks/state/useUserAcademicInfo.ts
@@ -1,11 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { auth } from 'api';
 import useTokenState from './useTokenState';
 
 export default function useUserAcademicInfo() {
   const token = useTokenState();
 
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['userAcademicinfo'],
 
     queryFn: () => (token ? auth.getUserAcademicInfo(token) : null),


### PR DESCRIPTION
- Close #720 
  
## What is this PR? 🔍

- 기능 : 졸업학점계산기 기능 2차 qa 이슈를 수정했습니다.
- issue : #720 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 기존 `useUser` 훅으로 사용자 정보를 받아왔는데, `useUserAcademicInfo`라는 훅을 새로 만들어 졸학계 쪽에만 대체했습니다.
 두 훅의 차이점으로 `useUser`는 **major**로 학부(예: 전기전자통신공학부)를 받고 있고, `useUserAcademicInfo`는 **department**로 학부(예: 전기전자통신공학부)를 **major**로 전공(예: 전기공학전공)을 받고 있습니다.
- `Pretendard` 폰트 설치되어 있지 않아 `sans-serif`로 적용되어 글자가 깨지는 경우를 대비하여 해당 텍스트가 줄바꿈되지 않도록 했습니다.
- 툴팁들의 너비를 고정시켰습니다.
- 학기 강의 개설 목록을 조회할 때 수강한 강의만을 조회 시 학기와 상관없이 전체 강의를 조회할 수 있도록 수정했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
