### PR TITLE
fix: 페이지 이동시 title태그와 og:title meta태그가 제대로 업데이트 되도록 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable */
-import { useEffect, ReactNode, Suspense } from 'react';
+import { ReactNode, Suspense } from 'react';
 import {
   Routes,
   Route,
-  useLocation,
   Navigate,
 } from 'react-router-dom';
 import AuthPage from 'pages/Auth/AuthPage';
@@ -53,12 +52,7 @@ function Wrapper({
   element,
   needAuth = false, // 로그인이 필요한 라우트
 }: WrapperProps) {
-  const location = useLocation();
   const token = useTokenState();
-
-  useEffect(() => {
-    document.title = `코인 - ${title}`;
-  }, [title, location]);
 
   if (needAuth && !token) {
     return <Navigate replace to={ROUTES.Main()} />;
@@ -66,9 +60,9 @@ function Wrapper({
 
   return (
     <>
-      <MetaHelmet title={title} />
-      {element}
+      <MetaHelmet title={`코인 - ${title}`} />
       <Suspense fallback={null}>
+        {element}
         <LogPage />
       </Suspense>
     </>

--- a/src/pages/BoardPage/index.tsx
+++ b/src/pages/BoardPage/index.tsx
@@ -9,9 +9,7 @@ function BoardPage() {
       <Suspense fallback={null}>
         <Header />
       </Suspense>
-      <Suspense fallback={null}>
-        <Outlet />
-      </Suspense>
+      <Outlet />
       <Footer />
     </>
   );


### PR DESCRIPTION
- Close #738
  
## What is this PR? 🔍
- 기능 : 
- issue : #738

## Changes 📝
현재 사용중인 `react-helmet`이 `Suspense 블록 안에 있을시 제대로 변경이 반영되지 않습니다.
따라서 `MetaHelmet` 컴포넌트를 `Suspense`블록 밖으로 옮깁니다.

아래는 현재 유지보수 되고 있는 포크 라이브러리 `react-helmet-async`의 동일 이슈입니다,
- staylor/react-helmet-async#226

## ScreenShot 📷

## Test CheckList ✅
- [x] 기존 존재하는 테스트 pass 확인

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
