### PR TITLE
[비지니스] 가게 이미지 리사이징 이슈 해결

### DIFF
--- a/src/pages/Store/StoreDetailPage/StoreDetailPage.module.scss
+++ b/src/pages/Store/StoreDetailPage/StoreDetailPage.module.scss
@@ -270,11 +270,12 @@
   }
 
   &__poster {
-    width: 330px;
-    height: 330px;
-    object-fit: fill;
+    width: 320px;
+    height: 360px;
+    object-fit: scale-down;
     image-orientation: from-image;
-
+    background-color: #EEEEEE;
+    
     &:nth-child(n + 2) {
       display: none;
     }

--- a/src/pages/Store/StoreDetailPage/StoreDetailPage.module.scss
+++ b/src/pages/Store/StoreDetailPage/StoreDetailPage.module.scss
@@ -274,8 +274,8 @@
     height: 360px;
     object-fit: scale-down;
     image-orientation: from-image;
-    background-color: #EEEEEE;
-    
+    background-color: #eee;
+
     &:nth-child(n + 2) {
       display: none;
     }


### PR DESCRIPTION
- Close #756 
  
## What is this PR? 🔍

- 기능 : 가게 이미지의 비율을 그대로 살리고 뒤에 배경을 둠
- issue : #756

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
가게 이미지의 비율을 그대로 살리고 뒤에 배경을 둠


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
![image](https://github.com/user-attachments/assets/d718b407-136a-45f3-9714-5c00646ee532)


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
