### PR TITLE
[hotfix] 모바일 시간표 학기 드롭다운 버튼 배경색 active 에러

### DIFF
--- a/src/pages/TimetablePage/components/SemesterList/SemesterList.module.scss
+++ b/src/pages/TimetablePage/components/SemesterList/SemesterList.module.scss
@@ -51,19 +51,13 @@
     border-radius: 5px;
     cursor: pointer;
 
+    &:active {
+      background-color: #e1e1e1;
+    }
+
     @media (hover: hover) {
       &:hover {
         background-color: #eee;
-      }
-
-      &:active {
-        background-color: #e1e1e1;
-      }
-    }
-
-    @media (hover: none) {
-      &:active {
-        background-color: #e1e1e1;
       }
     }
 

--- a/src/pages/TimetablePage/components/SemesterList/SemesterList.module.scss
+++ b/src/pages/TimetablePage/components/SemesterList/SemesterList.module.scss
@@ -51,12 +51,20 @@
     border-radius: 5px;
     cursor: pointer;
 
-    &:hover {
-      background-color: #eee;
+    @media (hover: hover) {
+      &:hover {
+        background-color: #eee;
+      }
+
+      &:active {
+        background-color: #e1e1e1;
+      }
     }
 
-    &:active {
-      background-color: #e1e1e1;
+    @media (hover: none) {
+      &:active {
+        background-color: #e1e1e1;
+      }
     }
 
     @include media.media-breakpoint(mobile) {


### PR DESCRIPTION
- Close #758
  
## What is this PR? 🔍

- 기능 : 모바일 시간표 학기 드롭다운 버튼 배경 active 에러 해결
- issue : #758

## Changes 📝
- 모바일 환경과 데스크톱 환경에서 `미디어 쿼리`를 나눠서 구현
`hover` 여부를 기준으로 나누어 데스크톱에 `hover` 가상 클래스를 따로 추가

## ScreenShot 📷
![semester](https://github.com/user-attachments/assets/0070c696-d1dd-400f-a266-f696f19adfa2)


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
