### PR TITLE
[hotfix] 탈퇴한 사용자 쪽지보내기 버튼 비활성화

### DIFF
--- a/src/pages/Articles/LostItemDetailPage/index.tsx
+++ b/src/pages/Articles/LostItemDetailPage/index.tsx
@@ -130,14 +130,16 @@ export default function LostItemDetailPage() {
               </button>
             ) : (
               <div className={styles['button-container__buttons']}>
-                <button
-                  type="button"
-                  className={styles['button-container__message-button']}
-                  onClick={handleChatroomButtonClick}
-                >
-                  <ChatIcon />
-                  <div>쪽지 보내기</div>
-                </button>
+                {article.author !== '탈퇴한 사용자' && (
+                  <button
+                    type="button"
+                    className={styles['button-container__message-button']}
+                    onClick={handleChatroomButtonClick}
+                  >
+                    <ChatIcon />
+                    <div>쪽지 보내기</div>
+                  </button>
+                )}
                 {article.author !== '총학생회' && (
                   <button
                     className={styles['button-container__report-button']}


### PR DESCRIPTION
- Close #771 
  
## What is this PR? 🔍

- 기능 : 탈퇴한 사용자의 경우 쪽지 보내기 버튼을 비활성화 하였습니다.
- issue : #771 

## ScreenShot 📷
<img width="855" alt="스크린샷 2025-03-24 10 12 55" src="https://github.com/user-attachments/assets/10b22b49-cc08-4350-987c-2c2047ea6c2d" />
<img width="859" alt="스크린샷 2025-03-24 10 13 13" src="https://github.com/user-attachments/assets/d58169d2-5756-4e32-8716-a89003085d41" />

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
