### PR TITLE
[Hotfix] 자동 로그인 후 access token이 유효하지 않을 때 빈 화면이 보이는 에러

### DIFF
--- a/src/utils/ts/auth.ts
+++ b/src/utils/ts/auth.ts
@@ -19,3 +19,9 @@ export function redirectToLogin(currentPath?: string) {
   setRedirectPath(pathToSave);
   window.location.href = ROUTES.Auth();
 }
+
+export function redirectToMain(currentPath?: string) {
+  const pathToSave = currentPath || window.location.pathname;
+  setRedirectPath(pathToSave);
+  window.location.href = ROUTES.Main();
+}


### PR DESCRIPTION
  ## What is this PR? 🔍

- 기능 : 자동 로그인 후 access token이 유효하지 않을 때 빈 화면이 보이는 에러 해결
- issue : #

## Changes 📝
- 자동 로그인 후 access token이 유효하지 않을 때 리다이렉트하는 로직이 없어 메인 페이지로 리다이렉트 하는 `redirectMain()` 함수 추가
- `refresh` 요청이 불필요하게 여러 번 요청하는 문제 해결
<!-- 이번 PR에서의 변경점 -->


## ScreenShot 📷
자동 로그인 후 auth token 강제 변경 후 refreshToken을 통해 다시 auth token을 받고 메인 페이지로 리다이렉트 함

https://github.com/user-attachments/assets/e639cb60-bb79-4c3f-98ac-72059add809d


## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
