### PR TITLE
[hotfix] 분실물 사진 올리기 위치 문제

### DIFF
--- a/src/pages/Articles/LostItemWritePage/components/FormImage/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/FormImage/index.tsx
@@ -12,15 +12,17 @@ interface FormImageProps {
   images: Array<string>;
   setImages: (images: Array<string>) => void;
   type: 'FOUND' | 'LOST';
+  formIndex: number;
 }
 
 export default function FormImage({
-  images, setImages, type,
+  images, setImages, type, formIndex,
 }: FormImageProps) {
   const isMobile = useMediaQuery();
   const { imgRef, saveImgFile } = useImageUpload({ uploadFn: uploadLostItemFile });
 
   const imageCounter = `${images.length}/${MAX_IMAGES_LENGTH}`;
+  const inputId = `image-file-${formIndex}`;
 
   const saveImage = async () => {
     if (images.length >= MAX_IMAGES_LENGTH) {
@@ -71,14 +73,14 @@ export default function FormImage({
           ))}
         </ul>
       )}
-      <label htmlFor="image-file" className={styles.images__upload}>
+      <label htmlFor={inputId} className={styles.images__upload}>
         <PhotoIcon />
         사진 등록하기
         <input
           type="file"
           ref={imgRef}
           accept="image/*"
-          id="image-file"
+          id={inputId}
           multiple
           onChange={saveImage}
           aria-label="사진 등록하기"

--- a/src/pages/Articles/LostItemWritePage/components/LostItemForm/index.tsx
+++ b/src/pages/Articles/LostItemWritePage/components/LostItemForm/index.tsx
@@ -88,10 +88,19 @@ export default function LostItemForm({
           />
         </div>
         <div className={`${styles.template__right}`}>
-          <FormImage images={images} setImages={setImages} type={type} />
+          <FormImage
+            images={images}
+            setImages={setImages}
+            type={type}
+            formIndex={count}
+          />
         </div>
         <div className={styles.template__bottom}>
-          <FormContent content={content} setContent={setContent} type={type} />
+          <FormContent
+            content={content}
+            setContent={setContent}
+            type={type}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

분실물 올리기 기능에서 여러 개의 분실물을 동시에 등록하고자 할 때,
사진을 업로드 함에 있어서, 첫 번째 분실물 폼에만 사진이 올라가는 문제가 있었습니다.

원인은 고정 문자열로 들어간 ref 때문이었으며,
각각의 폼 마다 인덱스를 프롭스로 받은 뒤 ref에 사용할 수 있도록 수정하는 방식으로 해결했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
