### PR TITLE
[hotfix, 주변상점] 엔터 키 무한 입력으로 인한 무한 검색 이슈 해결

### DIFF
--- a/src/pages/Store/StorePage/components/SearchBar/index.tsx
+++ b/src/pages/Store/StorePage/components/SearchBar/index.tsx
@@ -12,7 +12,7 @@ import styles from './SearchBar.module.scss';
 
 export default function SearchBar() {
   const { data: categories } = useStoreCategories();
-  const { params } = useParamsHandler();
+  const { params, searchParams } = useParamsHandler();
   const logger = useLogger();
   const isMobile = useMediaQuery();
   const [isModalOpen, openModal, closeModal] = useBooleanState(false);
@@ -31,7 +31,7 @@ export default function SearchBar() {
           openModal();
         }}
       >
-        검색어를 입력해주세요
+        {searchParams.get('storeName') || '검색어를 입력하세요'}
       </button>
       )}
       {/* <input

--- a/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
+++ b/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
@@ -41,10 +41,8 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
     }, 200);
   }, []);
 
-  const handleSearch = async () => {
+  const handleSearch = () => {
     const value = storeRef.current?.value ?? '';
-    const data = await getRelateSearch(value);
-    setRelateSearchItems(data);
     setParams('storeName', value, {
       deleteBeforeParam: searchParams.get('storeName') === undefined,
       replacePage: true,
@@ -66,7 +64,7 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
             placeholder="검색어를 입력하세요"
             autoComplete="off"
             onChange={handleInputChange}
-            onKeyUp={(async (e) => {
+            onKeyUp={((e) => {
               if (e.key === 'Enter') {
                 handleSearch();
               }
@@ -79,7 +77,7 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
           <button
             className={styles['search-bar-modal__icon']}
             type="button"
-            onClick={async () => handleSearch()}
+            onClick={handleSearch}
           >
             {
           isMobile ? (

--- a/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
+++ b/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
@@ -40,6 +40,17 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
       setRelateSearchItems(data);
     }, 200);
   }, []);
+
+  const handleSearch = async () => {
+    const value = storeRef.current?.value ?? '';
+    const data = await getRelateSearch(value);
+    setRelateSearchItems(data);
+    setParams('storeName', value, {
+      deleteBeforeParam: searchParams.get('storeName') === undefined,
+      replacePage: true,
+    });
+  };
+
   return (
     <div className={styles['search-bar-modal__background']} ref={backgroundRef}>
       <div className={styles['search-bar-modal__container']}>
@@ -55,14 +66,9 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
             placeholder="검색어를 입력하세요"
             autoComplete="off"
             onChange={handleInputChange}
-            onKeyDown={(async (e) => {
+            onKeyUp={(async (e) => {
               if (e.key === 'Enter') {
-                const data = await getRelateSearch(e.currentTarget.value) || '';
-                setRelateSearchItems(data);
-              // setParams('storeName', e.currentTarget.value, {
-              //   deleteBeforeParam: searchParams.get('storeName') === undefined,
-              //   replacePage: true,
-              // });
+                handleSearch();
               }
             })}
             onFocus={() => {
@@ -73,15 +79,7 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
           <button
             className={styles['search-bar-modal__icon']}
             type="button"
-            onClick={async () => {
-              const value = storeRef.current?.value ?? '';
-              const data = await getRelateSearch(value);
-              setRelateSearchItems(data);
-              // setParams('storeName', storeRef.current?.value ?? '', {
-              //   deleteBeforeParam: searchParams.get('storeName') === undefined,
-              //   replacePage: true,
-              // });
-            }}
+            onClick={async () => handleSearch()}
           >
             {
           isMobile ? (

--- a/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
+++ b/src/pages/Store/StorePage/components/SearchBarModal/index.tsx
@@ -47,6 +47,7 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
       deleteBeforeParam: searchParams.get('storeName') === undefined,
       replacePage: true,
     });
+    onClose();
   };
 
   return (
@@ -57,8 +58,8 @@ export default function SearchBarModal({ onClose }:SearchBarModalProps) {
             ref={storeRef}
             className={styles['search-bar-modal__input']}
             defaultValue={
-          searchParams.get('storeName') === undefined ? '' : searchParams.get('storeName') ?? ''
-        }
+              searchParams.get('storeName') === undefined ? '' : searchParams.get('storeName') ?? ''
+            }
             type="text"
             name="search"
             placeholder="검색어를 입력하세요"

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -88,7 +88,7 @@ const useStoreList = (
 ) => {
   const { data: storeList } = useQuery(
     {
-      queryKey: ['storeListV2', sorter, filter],
+      queryKey: ['storeListV2', sorter, filter, params.storeName],
       queryFn: () => api.store.getStoreListV2(
         sorter,
         filter,
@@ -105,21 +105,10 @@ const useStoreList = (
     return [];
   }
 
-  return storeList.shops.filter((store) => {
-    const matchCategory = params.category === undefined
-      || store.category_ids.some((id) => id === selectedCategory);
-
-    if (!params.shopIds && params.storeName) return store.name.includes(params.storeName ? params.storeName : '');
-    // 메뉴검색시 메뉴를 가진 가게를 반환
-    if (params.shopIds) {
-      const shopIdsArr = params.shopIds.split(',').map(Number);
-      return shopIdsArr.includes(store.id);
-    }
-    return (
-      matchCategory
-      && store.name.includes(params.storeName ? params.storeName : '')
-    );
-  });
+  return storeList.shops.filter(
+    (store) => params.category === undefined
+    || store.category_ids.some((id) => id === selectedCategory),
+  );
 };
 
 function StorePage() {

--- a/src/pages/Store/StorePage/index.tsx
+++ b/src/pages/Store/StorePage/index.tsx
@@ -266,17 +266,11 @@ function StorePage() {
       </div>
       {!isMobile && <SearchBarModal onClose={() => {}} />}
       <div className={styles.option}>
-        {params.searchWord ? (
+        {params.storeName ? (
           <div className={styles.option__count}>
             <strong>
-              {params.searchWord}
+              {`"${params.storeName}" 관련 가게가 총 ${storeList.length}개 있습니다.`}
             </strong>
-            메뉴를 가진 가게가
-            <strong>
-              {storeList.length}
-              개
-            </strong>
-            있습니다.
           </div>
         ) : (
           <div className={styles.option__count}>


### PR DESCRIPTION
- Close #816 
  
## What is this PR? 🔍

- 기능 : 검색창 무한 엔터로 인한 무한 검색 방지
- issue : #816 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- onKeyDown으로 'Enter'키를 받고 있어서 'Enter'키를 꾹 누를 시 계속 onKeyDown 이벤트 핸들러가 호출되는 현상을 onKeyUp 이벤트 핸들러로 해결했습니다.
- 주변상점 **검색 완료 시** 상점에 대한 정보만 나타냈던 것을 검색어와 관련된 메뉴를 가진 상점도 나타내게 수정했습니다.(앱과 ux 일치)
- 모바일뷰에서 검색 완료 시 모달이 닫히지 않는 현상을 수정했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
