### PR TITLE
Feat/#819/update signup api UI

### DIFF
--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -184,7 +184,7 @@ export class CheckPhone<R extends CheckPhoneResponse> implements APIRequest<R> {
 export class SmsSend<R extends SmsSendResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
 
-  path = '/user/sms/send';
+  path = '/user/verification/sms/send';
 
   response!: R;
 
@@ -196,7 +196,7 @@ export class SmsSend<R extends SmsSendResponse> implements APIRequest<R> {
 export class SmsVerify<R extends SmsVerifyResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
 
-  path = '/user/sms/verify';
+  path = '/user/verification/sms/verify';
 
   response!: R;
 

--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -5,7 +5,6 @@ import {
   NicknameDuplicateCheckResponse,
   RefreshRequest,
   RefreshResponse,
-  SignupResponse,
   UserResponse,
   UserAcademicInfoResponse,
   FindPasswordRequest,
@@ -21,6 +20,10 @@ import {
   SmsSendResponse,
   SmsVerifyResponse,
   SmsVerifyRequest,
+  SignupGeneralResponse,
+  LoginGeneralRequest,
+  SignupStudentResponse,
+  LoginStudentRequest,
 } from './entity';
 
 export class Login<R extends LoginResponse> implements APIRequest<R> {
@@ -50,7 +53,7 @@ export class NicknameDuplicateCheck<R extends NicknameDuplicateCheckResponse> im
   }
 }
 
-export class SignupStudent<R extends SignupResponse> implements APIRequest<R> {
+export class SignupStudent<R extends SignupStudentResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
 
   path = 'v2/user/student/register';
@@ -59,7 +62,19 @@ export class SignupStudent<R extends SignupResponse> implements APIRequest<R> {
 
   auth = false;
 
-  constructor(public data: LoginRequest) { }
+  constructor(public data: LoginStudentRequest) { }
+}
+
+export class SignupGeneral<R extends SignupGeneralResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.POST;
+
+  path = 'v2/user/general/register';
+
+  response!: R;
+
+  auth = false;
+
+  constructor(public data: LoginGeneralRequest) { }
 }
 
 export class Refresh<R extends RefreshResponse> implements APIRequest<R> {

--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -50,10 +50,10 @@ export class NicknameDuplicateCheck<R extends NicknameDuplicateCheckResponse> im
   }
 }
 
-export class Signup<R extends SignupResponse> implements APIRequest<R> {
+export class SignupStudent<R extends SignupResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
 
-  path = '/user/student/register';
+  path = 'v2/user/student/register';
 
   response!: R;
 

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -1,6 +1,11 @@
 import { APIResponse } from 'interfaces/APIResponse';
 
 export type LoginRequest = {
+  email: string;
+  password: string;
+};
+
+export type LoginStudentRequest = {
   name: string;
   phone_number: string;
   user_id: string;
@@ -9,6 +14,16 @@ export type LoginRequest = {
   student_number: string;
   gender: string;
   email?: string;
+  nickname: string;
+};
+
+export type LoginGeneralRequest = {
+  name: string;
+  phone_number: string;
+  user_id: string;
+  password: string;
+  gender: string;
+  email: string;
   nickname: string;
 };
 
@@ -43,7 +58,9 @@ export interface CheckPasswordRequest {
   password: string;
 }
 
-export interface SignupResponse extends APIResponse { }
+export interface SignupStudentResponse extends APIResponse { }
+
+export interface SignupGeneralResponse extends APIResponse { }
 
 export interface RefreshRequest {
   refresh_token: string;

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -106,7 +106,12 @@ export interface UpdateAcademicInfoResponse extends APIResponse {
 }
 
 export interface CheckPhoneResponse extends APIResponse { }
-export interface SmsSendResponse extends APIResponse { }
+export interface SmsSendResponse extends APIResponse {
+  target: string;
+  total_count: number;
+  remaining_count: number;
+  current_count: number;
+}
 export interface SmsVerifyResponse extends APIResponse { }
 
 export interface SmsSendRequest {
@@ -115,5 +120,5 @@ export interface SmsSendRequest {
 
 export interface SmsVerifyRequest {
   phone_number: string;
-  certification_code: string;
+  verification_code: string;
 }

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -1,8 +1,15 @@
 import { APIResponse } from 'interfaces/APIResponse';
 
 export type LoginRequest = {
-  email: string;
+  name: string;
+  phone_number: string;
+  user_id: string;
   password: string;
+  department: string;
+  student_number: string;
+  gender: string;
+  email?: string;
+  nickname: string;
 };
 
 export interface LoginResponse extends APIResponse {

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -4,6 +4,7 @@ import {
   NicknameDuplicateCheck,
   Refresh,
   SignupStudent,
+  SignupGeneral,
   User,
   UserAcademicInfo,
   UpdateUser,
@@ -21,6 +22,8 @@ export const login = APIClient.of(Login);
 export const nicknameDuplicateCheck = APIClient.of(NicknameDuplicateCheck);
 
 export const signupStudent = APIClient.of(SignupStudent);
+
+export const signupGeneral = APIClient.of(SignupGeneral);
 
 export const refresh = APIClient.of(Refresh);
 

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -3,7 +3,7 @@ import {
   Login,
   NicknameDuplicateCheck,
   Refresh,
-  Signup,
+  SignupStudent,
   User,
   UserAcademicInfo,
   UpdateUser,
@@ -20,7 +20,7 @@ export const login = APIClient.of(Login);
 
 export const nicknameDuplicateCheck = APIClient.of(NicknameDuplicateCheck);
 
-export const signup = APIClient.of(Signup);
+export const signupStudent = APIClient.of(SignupStudent);
 
 export const refresh = APIClient.of(Refresh);
 

--- a/src/pages/Auth/SignupPage/Steps/CompleteStep/CompleteStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/CompleteStep/CompleteStep.module.scss
@@ -1,0 +1,74 @@
+@use "src/utils/scss/media" as media;
+
+.container {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: calc(100% - 40px);
+    font-family: Pretendard, sans-serif;
+    align-items: center;
+  }
+}
+
+.logo {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    width: 96px;
+    height: 56px;
+    margin: 100px auto 24px auto;
+  }
+}
+
+.title {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 160%;
+    margin-bottom: 57px; 
+  }
+}
+
+.button-container {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+    align-items: center;
+  }
+
+  &__button {
+    @include media.media-breakpoint(mobile) {
+      display: flex;
+      width: calc(100% - 48px);
+      height: 48px;
+      padding: 12px;
+      justify-content: center;
+      align-items: center;
+      border-radius: 8px;
+      
+      color: #FFF;
+      font-size: 16px;
+      font-weight: 500;
+      line-height: 160%;
+    }
+
+    &--orange{
+      @include media.media-breakpoint(mobile) {
+        background-color: #f7941e;
+      }
+    }
+
+    &--blue{
+      @include media.media-breakpoint(mobile) {
+        background-color: #175c8e;
+      }
+    }
+  }
+}

--- a/src/pages/Auth/SignupPage/Steps/CompleteStep/CompleteStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/CompleteStep/CompleteStep.module.scss
@@ -16,7 +16,7 @@
     display: flex;
     width: 96px;
     height: 56px;
-    margin: 100px auto 24px auto;
+    margin: 100px auto 24px;
   }
 }
 
@@ -26,11 +26,10 @@
     width: 100%;
     align-items: center;
     justify-content: center;
-
     font-size: 18px;
     font-weight: 500;
     line-height: 160%;
-    margin-bottom: 57px; 
+    margin-bottom: 57px;
   }
 }
 
@@ -52,20 +51,19 @@
       justify-content: center;
       align-items: center;
       border-radius: 8px;
-      
-      color: #FFF;
+      color: #fff;
       font-size: 16px;
       font-weight: 500;
       line-height: 160%;
     }
 
-    &--orange{
+    &--orange {
       @include media.media-breakpoint(mobile) {
         background-color: #f7941e;
       }
     }
 
-    &--blue{
+    &--blue {
       @include media.media-breakpoint(mobile) {
         background-color: #175c8e;
       }

--- a/src/pages/Auth/SignupPage/Steps/CompleteStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/CompleteStep/index.tsx
@@ -1,0 +1,35 @@
+import LogoIcon from 'assets/svg/Login/logo.svg';
+import { useNavigate } from 'react-router-dom';
+import styles from './CompleteStep.module.scss';
+
+function CompleteStep() {
+  const navigate = useNavigate();
+  return (
+    <div className={styles.container}>
+      <div className={styles.logo}>
+        <LogoIcon />
+      </div>
+      <span className={styles.title}>회원가입이 완료되었습니다.</span>
+      <div className={styles['button-container']}>
+        <button
+          className={`${styles['button-container__button']} ${styles['button-container__button--orange']}`}
+          type="button"
+          onClick={() => {
+            navigate('/auth');
+          }}
+        >
+          로그인 바로가기
+        </button>
+        <button
+          className={`${styles['button-container__button']} ${styles['button-container__button--blue']}`}
+          type="button"
+          onClick={() => navigate('/')}
+        >
+          홈화면 바로가기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CompleteStep;

--- a/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/MobileExternalDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/MobileExternalDetailStep.module.scss
@@ -1,0 +1,90 @@
+@use "src/utils/scss/media" as media;
+
+.container {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: calc(100% - 40px);
+    margin: 64px auto 0 auto;
+    font-family: Pretendard, sans-serif;
+    justify-content: space-between;
+  }
+}
+
+.form-container {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    flex-direction: column;
+    gap: 48px;
+  }
+}
+
+
+.wrapper {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    text-align: start;
+    gap: 16px;
+  }
+
+  &__header {
+    @include media.media-breakpoint(mobile) {
+      display: flex;
+      font-size: 18px;
+      font-weight: 500;
+      line-height: 160%;
+    }
+  }
+}
+
+.next-button {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    width: 100%;
+    padding: 12px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 8px;
+    background: #175c8e;
+
+    color: #fff;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 160%;
+
+    &:disabled {
+      background: #e1e1e1;
+      color: #4b4b4b;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.input-wrapper {
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    gap: 16px;
+  }
+
+    &__button {
+      @include media.media-breakpoint(mobile) {
+        display: flex;
+        height: 32px;
+        width: 86px;
+        padding: 6px 12px;
+        justify-content: center;
+        align-items: center;
+        border-radius: 4px;
+        background: #e1e1e1;
+        white-space: nowrap;
+        color: #4b4b4b;
+        font-size: 10px;
+        font-weight: 400;
+        line-height: 160%; 
+        margin-top: 4px;
+      }
+    }
+  }

--- a/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/MobileExternalDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/MobileExternalDetailStep.module.scss
@@ -6,7 +6,7 @@
     flex-direction: column;
     width: 100%;
     height: calc(100% - 40px);
-    margin: 64px auto 0 auto;
+    margin: 64px auto 0;
     font-family: Pretendard, sans-serif;
     justify-content: space-between;
   }
@@ -19,7 +19,6 @@
     gap: 48px;
   }
 }
-
 
 .wrapper {
   @include media.media-breakpoint(mobile) {
@@ -49,7 +48,6 @@
     align-items: center;
     border-radius: 8px;
     background: #175c8e;
-
     color: #fff;
     font-size: 16px;
     font-weight: 500;
@@ -69,22 +67,22 @@
     gap: 16px;
   }
 
-    &__button {
-      @include media.media-breakpoint(mobile) {
-        display: flex;
-        height: 32px;
-        width: 86px;
-        padding: 6px 12px;
-        justify-content: center;
-        align-items: center;
-        border-radius: 4px;
-        background: #e1e1e1;
-        white-space: nowrap;
-        color: #4b4b4b;
-        font-size: 10px;
-        font-weight: 400;
-        line-height: 160%; 
-        margin-top: 4px;
-      }
+  &__button {
+    @include media.media-breakpoint(mobile) {
+      display: flex;
+      height: 32px;
+      width: 86px;
+      padding: 6px 12px;
+      justify-content: center;
+      align-items: center;
+      border-radius: 4px;
+      background: #e1e1e1;
+      white-space: nowrap;
+      color: #4b4b4b;
+      font-size: 10px;
+      font-weight: 400;
+      line-height: 160%;
+      margin-top: 4px;
     }
   }
+}

--- a/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
@@ -1,5 +1,188 @@
-function MobileExternalDetailStep() {
-  return <div>Mobile Guest Detail Step</div>;
+/* eslint-disable no-restricted-imports */
+import { isKoinError } from '@bcsdlab/koin';
+import { useMutation } from '@tanstack/react-query';
+import { nicknameDuplicateCheck, signupGeneral } from 'api/auth';
+import { useState } from 'react';
+import {
+  Controller, useFormContext, useFormState, useWatch,
+} from 'react-hook-form';
+import CustomInput, { type InputMessage } from '../../components/CustomInput';
+import styles from './MobileExternalDetailStep.module.scss';
+
+const MESSAGES = {
+  PASSWORD_FORMAT: '올바른 비밀번호 양식이 아닙니다. 다시 입력해 주세요.',
+  PASSWORD_MISMATCH: '비밀번호가 일치하지 않습니다.',
+  PASSWORD_MATCH: '비밀번호가 일치합니다.',
+
+  NICKNAME_DUPLICATED: '중복된 닉네임입니다. 다시 입력해 주세요.',
+  NICKNAME_AVAILABLE: '사용 가능한 닉네임입니다.',
+  NICKNAME_FORMAT: '한글, 영문 및 숫자 포함하여 10자 내로 입력해 주세요.',
+};
+
+const REGEX = {
+  PASSWORD: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/])[A-Za-z\d!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/]{6,18}$/,
+  NICKNAME: /^[가-힣a-zA-Z0-9]{1,10}$/,
+};
+
+interface MobileExternalDetailStepProps {
+  onNext: () => void;
+}
+
+function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
+  const { control, getValues, handleSubmit } = useFormContext();
+  const phoneNumber = getValues('phone_number');
+  const nickname = (useWatch({ control, name: 'nickname' }) ?? '') as string;
+
+  const password = useWatch({ control, name: 'password' });
+  const passwordCheck = useWatch({ control, name: 'password_check' });
+  const { errors } = useFormState({ control });
+
+  const isPasswordValid = password && !errors.password;
+  const isPasswordCheckValid = passwordCheck && !errors.password_check;
+  const isPasswordAllValid = isPasswordValid && isPasswordCheckValid;
+
+  const [phoneMessage, setPhoneMessage] = useState<InputMessage | null>(null);
+  const isFormFilled = isPasswordAllValid && nickname;
+
+  const { mutate: checkNickname } = useMutation({
+    mutationFn: nicknameDuplicateCheck,
+    onSuccess: () => {
+      setPhoneMessage({ type: 'success', content: MESSAGES.NICKNAME_AVAILABLE });
+    },
+    onError: (err) => {
+      if (isKoinError(err)) {
+        if (err.status === 400) {
+          setPhoneMessage({ type: 'warning', content: MESSAGES.NICKNAME_FORMAT });
+        }
+
+        if (err.status === 409) {
+          setPhoneMessage({ type: 'error', content: MESSAGES.NICKNAME_DUPLICATED });
+        }
+      }
+    },
+  });
+
+  const { mutate: signup } = useMutation({
+    mutationFn: (variables: {
+      name: string;
+      phone_number: string;
+      user_id: string;
+      password: string;
+      gender: string;
+      email: string;
+      nickname: string;
+    }) => signupGeneral(variables),
+    onSuccess: () => {
+      onNext();
+    },
+  });
+
+  const onSubmit = (formData: any) => {
+    signup(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.container}>
+      <div className={styles['form-container']}>
+        <div className={styles.wrapper}>
+          <h1 className={styles.wrapper__header}>아이디 (전화번호)</h1>
+          <Controller
+            name="number"
+            control={control}
+            defaultValue={phoneNumber}
+            render={({ field }) => (
+              <CustomInput {...field} disabled />
+            )}
+          />
+          <div className={styles['input-wrapper']}>
+            <Controller
+              name="nickname"
+              control={control}
+              defaultValue=""
+              rules={{
+                required: true,
+                value: REGEX.NICKNAME,
+              }}
+              render={({ field }) => (
+                <CustomInput
+                  {...field}
+                  placeholder="닉네임을 입력해 주세요. (선택)"
+                  isDelete
+                  isButton
+                  message={phoneMessage}
+                  buttonText="중복 확인"
+                  buttonOnClick={() => checkNickname(nickname)}
+                  buttonDisabled={!nickname}
+                />
+              )}
+            />
+          </div>
+        </div>
+        <div className={styles['form-container']}>
+          <div className={styles.wrapper}>
+            <h1 className={styles.wrapper__header}>사용하실 비밀번호를 입력해 주세요.</h1>
+            <Controller
+              name="password"
+              control={control}
+              defaultValue=""
+              rules={{
+                required: true,
+                pattern: {
+                  value: REGEX.PASSWORD,
+                  message: MESSAGES.PASSWORD_FORMAT,
+                },
+              }}
+              render={({ field, fieldState }) => (
+                <CustomInput
+                  {...field}
+                  placeholder="특수문자 포함 영어와 숫자 6~18자리로 입력해주세요."
+                  type="password"
+                  isVisibleButton
+                  message={fieldState.error ? { type: 'warning', content: MESSAGES.PASSWORD_FORMAT } : null}
+                />
+              )}
+            />
+            {isPasswordValid && (
+              <Controller
+                name="password_check"
+                control={control}
+                defaultValue=""
+                rules={{
+                  required: true,
+                  validate: (value) => value === getValues('password'),
+                }}
+                render={({ field, fieldState }) => (
+                  <CustomInput
+                    {...field}
+                    placeholder="비밀번호를 다시 입력해 주세요."
+                    type="password"
+                    isVisibleButton
+                    message={fieldState.error
+                      ? { type: 'warning', content: MESSAGES.PASSWORD_MISMATCH }
+                      : { type: 'success', content: MESSAGES.PASSWORD_MATCH }}
+                  />
+                )}
+              />
+            )}
+
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        onClick={() => {
+          // onSubmit(getValues());
+          onNext();
+        }}
+        className={styles['next-button']}
+        disabled={!isFormFilled}
+      >
+        다음
+      </button>
+    </form>
+
+  );
 }
 
 export default MobileExternalDetailStep;

--- a/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
@@ -7,23 +7,9 @@ import { useState } from 'react';
 import {
   Controller, useFormContext, useFormState, useWatch,
 } from 'react-hook-form';
+import { REGEX, MESSAGES } from 'static/auth';
 import CustomInput, { type InputMessage } from '../../components/CustomInput';
 import styles from './MobileExternalDetailStep.module.scss';
-
-const MESSAGES = {
-  PASSWORD_FORMAT: '올바른 비밀번호 양식이 아닙니다. 다시 입력해 주세요.',
-  PASSWORD_MISMATCH: '비밀번호가 일치하지 않습니다.',
-  PASSWORD_MATCH: '비밀번호가 일치합니다.',
-
-  NICKNAME_DUPLICATED: '중복된 닉네임입니다. 다시 입력해 주세요.',
-  NICKNAME_AVAILABLE: '사용 가능한 닉네임입니다.',
-  NICKNAME_FORMAT: '한글, 영문 및 숫자 포함하여 10자 내로 입력해 주세요.',
-};
-
-const REGEX = {
-  PASSWORD: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/])[A-Za-z\d!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/]{6,18}$/,
-  NICKNAME: /^[가-힣a-zA-Z0-9]{1,10}$/,
-};
 
 interface MobileExternalDetailStepProps {
   onNext: () => void;
@@ -59,16 +45,16 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
   const { mutate: checkNickname } = useMutation({
     mutationFn: nicknameDuplicateCheck,
     onSuccess: () => {
-      setPhoneMessage({ type: 'success', content: MESSAGES.NICKNAME_AVAILABLE });
+      setPhoneMessage({ type: 'success', content: MESSAGES.NICKNAME.AVAILABLE });
     },
     onError: (err) => {
       if (isKoinError(err)) {
         if (err.status === 400) {
-          setPhoneMessage({ type: 'warning', content: MESSAGES.NICKNAME_FORMAT });
+          setPhoneMessage({ type: 'warning', content: MESSAGES.NICKNAME.FORMAT });
         }
 
         if (err.status === 409) {
-          setPhoneMessage({ type: 'error', content: MESSAGES.NICKNAME_DUPLICATED });
+          setPhoneMessage({ type: 'error', content: MESSAGES.NICKNAME.DUPLICATED });
         }
       }
     },
@@ -137,7 +123,7 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
                 required: true,
                 pattern: {
                   value: REGEX.PASSWORD,
-                  message: MESSAGES.PASSWORD_FORMAT,
+                  message: MESSAGES.PASSWORD.FORMAT,
                 },
               }}
               render={({ field, fieldState }) => (
@@ -146,7 +132,7 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
                   placeholder="특수문자 포함 영어와 숫자 6~18자리로 입력해주세요."
                   type="password"
                   isVisibleButton
-                  message={fieldState.error ? { type: 'warning', content: MESSAGES.PASSWORD_FORMAT } : null}
+                  message={fieldState.error ? { type: 'warning', content: MESSAGES.PASSWORD.FORMAT } : null}
                 />
               )}
             />
@@ -166,8 +152,8 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
                     type="password"
                     isVisibleButton
                     message={fieldState.error
-                      ? { type: 'warning', content: MESSAGES.PASSWORD_MISMATCH }
-                      : { type: 'success', content: MESSAGES.PASSWORD_MATCH }}
+                      ? { type: 'warning', content: MESSAGES.PASSWORD.MISMATCH }
+                      : { type: 'success', content: MESSAGES.PASSWORD.MATCH }}
                   />
                 )}
               />

--- a/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable no-restricted-imports */
 import { isKoinError } from '@bcsdlab/koin';
 import { useMutation } from '@tanstack/react-query';
@@ -28,8 +29,19 @@ interface MobileExternalDetailStepProps {
   onNext: () => void;
 }
 
+interface GeneralFormValues {
+  name: string;
+  phone_number: string;
+  user_id: string;
+  password: string;
+  gender: string;
+  email: string;
+  nickname: string;
+  password_check?: string;
+}
+
 function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
-  const { control, getValues, handleSubmit } = useFormContext();
+  const { control, getValues, handleSubmit } = useFormContext<GeneralFormValues>();
   const phoneNumber = getValues('phone_number');
   const nickname = (useWatch({ control, name: 'nickname' }) ?? '') as string;
 
@@ -63,22 +75,15 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
   });
 
   const { mutate: signup } = useMutation({
-    mutationFn: (variables: {
-      name: string;
-      phone_number: string;
-      user_id: string;
-      password: string;
-      gender: string;
-      email: string;
-      nickname: string;
-    }) => signupGeneral(variables),
+    mutationFn: (variables: GeneralFormValues) => signupGeneral(variables),
     onSuccess: () => {
       onNext();
     },
   });
 
-  const onSubmit = (formData: any) => {
-    signup(formData);
+  const onSubmit = (formData: GeneralFormValues) => {
+    const { password_check, ...signupData } = formData;
+    signup(signupData);
   };
 
   return (
@@ -87,7 +92,7 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
         <div className={styles.wrapper}>
           <h1 className={styles.wrapper__header}>아이디 (전화번호)</h1>
           <Controller
-            name="number"
+            name="phone_number"
             control={control}
             defaultValue={phoneNumber}
             render={({ field }) => (
@@ -101,7 +106,10 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
               defaultValue=""
               rules={{
                 required: true,
-                value: REGEX.NICKNAME,
+                pattern: {
+                  value: REGEX.NICKNAME,
+                  message: '',
+                },
               }}
               render={({ field }) => (
                 <CustomInput

--- a/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
@@ -27,7 +27,9 @@ interface GeneralFormValues {
 }
 
 function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
-  const { control, getValues, handleSubmit } = useFormContext<GeneralFormValues>();
+  const {
+    control, getValues, handleSubmit, trigger,
+  } = useFormContext<GeneralFormValues>();
   const phoneNumber = getValues('phone_number');
   const nickname = (useWatch({ control, name: 'nickname' }) ?? '') as string;
 
@@ -35,7 +37,8 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
   const passwordCheck = useWatch({ control, name: 'password_check' });
   const { errors } = useFormState({ control });
 
-  const isPasswordValid = password && !errors.password;
+  const isPasswordPatternValid = REGEX.PASSWORD.test(password || '');
+  const isPasswordValid = isPasswordPatternValid && !errors.password;
   const isPasswordCheckValid = passwordCheck && !errors.password_check;
   const isPasswordAllValid = isPasswordValid && isPasswordCheckValid;
 
@@ -131,6 +134,10 @@ function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {
                   {...field}
                   placeholder="특수문자 포함 영어와 숫자 6~18자리로 입력해주세요."
                   type="password"
+                  onChange={(e) => {
+                    field.onChange(e);
+                    trigger('password_check');
+                  }}
                   isVisibleButton
                   message={fieldState.error ? { type: 'warning', content: MESSAGES.PASSWORD.FORMAT } : null}
                 />

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/MobileStudentDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/MobileStudentDetailStep.module.scss
@@ -49,12 +49,18 @@
     justify-content: center;
     align-items: center;
     border-radius: 8px;
-    background: #e1e1e1;
+    background: #175c8e;
 
-    color: #4b4b4b;
+    color: #fff;
     font-size: 16px;
     font-weight: 500;
     line-height: 160%;
+
+    &:disabled {
+      background: #e1e1e1;
+      color: #4b4b4b;
+      cursor: not-allowed;
+    }
   }
 }
 

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/MobileStudentDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/MobileStudentDetailStep.module.scss
@@ -6,7 +6,7 @@
     flex-direction: column;
     width: 100%;
     height: calc(100% - 40px);
-    margin: 32px auto 0 auto;
+    margin: 32px auto 0;
     font-family: Pretendard, sans-serif;
     justify-content: space-between;
   }
@@ -20,7 +20,6 @@
   }
 }
 
-
 .wrapper {
   @include media.media-breakpoint(mobile) {
     display: flex;
@@ -28,7 +27,6 @@
     width: 100%;
     text-align: start;
     gap: 16px;
-    // margin-bottom: 32px;
   }
 
   &__header {
@@ -50,7 +48,6 @@
     align-items: center;
     border-radius: 8px;
     background: #175c8e;
-
     color: #fff;
     font-size: 16px;
     font-weight: 500;
@@ -70,22 +67,22 @@
     gap: 16px;
   }
 
-    &__button {
-      @include media.media-breakpoint(mobile) {
-        display: flex;
-        height: 32px;
-        width: 86px;
-        padding: 6px 12px;
-        justify-content: center;
-        align-items: center;
-        border-radius: 4px;
-        background: #e1e1e1;
-        white-space: nowrap;
-        color: #4b4b4b;
-        font-size: 10px;
-        font-weight: 400;
-        line-height: 160%; 
-        margin-top: 4px;
-      }
+  &__button {
+    @include media.media-breakpoint(mobile) {
+      display: flex;
+      height: 32px;
+      width: 86px;
+      padding: 6px 12px;
+      justify-content: center;
+      align-items: center;
+      border-radius: 4px;
+      background: #e1e1e1;
+      white-space: nowrap;
+      color: #4b4b4b;
+      font-size: 10px;
+      font-weight: 400;
+      line-height: 160%;
+      margin-top: 4px;
     }
   }
+}

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/MobileStudentDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/MobileStudentDetailStep.module.scss
@@ -6,7 +6,7 @@
     flex-direction: column;
     width: 100%;
     height: calc(100% - 40px);
-    margin: 32px auto 40px auto;
+    margin: 32px auto 0 auto;
     font-family: Pretendard, sans-serif;
     justify-content: space-between;
   }
@@ -28,7 +28,7 @@
     width: 100%;
     text-align: start;
     gap: 16px;
-    margin-bottom: 32px;
+    // margin-bottom: 32px;
   }
 
   &__header {

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
@@ -31,7 +31,9 @@ interface StudentFormValues {
 }
 
 function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
-  const { control, getValues, handleSubmit } = useFormContext<StudentFormValues>();
+  const {
+    control, getValues, handleSubmit, trigger,
+  } = useFormContext<StudentFormValues>();
   const phoneNumber = getValues('phone_number');
   const nickname = (useWatch({ control, name: 'nickname' }) ?? '') as string;
 
@@ -39,7 +41,8 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
   const passwordCheck = useWatch({ control, name: 'password_check' });
   const { errors } = useFormState({ control });
 
-  const isPasswordValid = password && !errors.password;
+  const isPasswordPatternValid = REGEX.PASSWORD.test(password || '');
+  const isPasswordValid = isPasswordPatternValid && !errors.password;
   const isPasswordCheckValid = passwordCheck && !errors.password_check;
   const isPasswordAllValid = isPasswordValid && isPasswordCheckValid;
 
@@ -116,6 +119,10 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
                   {...field}
                   placeholder="특수문자 포함 영어와 숫자 6~18자리로 입력해주세요."
                   type="password"
+                  onChange={(e) => {
+                    field.onChange(e);
+                    trigger('password_check');
+                  }}
                   isVisibleButton
                   message={fieldState.error ? { type: 'warning', content: MESSAGES.PASSWORD.FORMAT } : null}
                 />
@@ -166,12 +173,6 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
                 />
               )}
             />
-            {/* <CustomSelector
-              options={deptOptionList}
-              value={major}
-              onChange={(event) => setMajor(event.target.value)}
-              placeholder="학부를 선택해주세요."
-            /> */}
             <Controller
               name="student_number"
               control={control}

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable no-restricted-imports */
 import { isKoinError } from '@bcsdlab/koin';
 import { useMutation } from '@tanstack/react-query';
@@ -30,8 +31,21 @@ interface MobileVerificationProps {
   onNext: () => void;
 }
 
+interface StudentFormValues {
+  name: string,
+  phone_number: string,
+  user_id: string,
+  password: string,
+  password_check?: string,
+  department: string,
+  student_number: string,
+  gender: string,
+  email: string,
+  nickname: string,
+}
+
 function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
-  const { control, getValues, handleSubmit } = useFormContext();
+  const { control, getValues, handleSubmit } = useFormContext<StudentFormValues>();
   const phoneNumber = getValues('phone_number');
   const nickname = (useWatch({ control, name: 'nickname' }) ?? '') as string;
 
@@ -72,24 +86,15 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
   });
 
   const { mutate: signup } = useMutation({
-    mutationFn: (variables: {
-      name: string;
-      phone_number: string;
-      user_id: string;
-      password: string;
-      department: string;
-      student_number: string;
-      gender: string;
-      email: string;
-      nickname: string;
-    }) => signupStudent(variables),
+    mutationFn: (variables: StudentFormValues) => signupStudent(variables),
     onSuccess: () => {
       onNext();
     },
   });
 
-  const onSubmit = (formData: any) => {
-    signup(formData);
+  const onSubmit = (formData: StudentFormValues) => {
+    const { password_check, ...signupData } = formData;
+    signup(signupData);
   };
 
   return (
@@ -98,7 +103,7 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
         <div className={styles.wrapper}>
           <h1 className={styles.wrapper__header}>아이디 (전화번호)</h1>
           <Controller
-            name="number"
+            name="phone_number"
             control={control}
             defaultValue={phoneNumber}
             render={({ field }) => (
@@ -196,7 +201,10 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
                 defaultValue=""
                 rules={{
                   required: true,
-                  value: REGEX.NICKNAME,
+                  pattern: {
+                    value: REGEX.NICKNAME,
+                    message: '',
+                  },
                 }}
                 render={({ field }) => (
                   <CustomInput

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
@@ -7,25 +7,11 @@ import { useState } from 'react';
 import {
   Controller, useFormContext, useFormState, useWatch,
 } from 'react-hook-form';
+import { REGEX, MESSAGES } from 'static/auth';
 import CustomInput, { type InputMessage } from '../../components/CustomInput';
 import CustomSelector from '../../components/CustomSelector';
 import useDeptList from '../../hooks/useDeptList';
 import styles from './MobileStudentDetailStep.module.scss';
-
-const MESSAGES = {
-  PASSWORD_FORMAT: '올바른 비밀번호 양식이 아닙니다. 다시 입력해 주세요.',
-  PASSWORD_MISMATCH: '비밀번호가 일치하지 않습니다.',
-  PASSWORD_MATCH: '비밀번호가 일치합니다.',
-
-  NICKNAME_DUPLICATED: '중복된 닉네임입니다. 다시 입력해 주세요.',
-  NICKNAME_AVAILABLE: '사용 가능한 닉네임입니다.',
-  NICKNAME_FORMAT: '한글, 영문 및 숫자 포함하여 10자 내로 입력해 주세요.',
-};
-
-const REGEX = {
-  PASSWORD: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/])[A-Za-z\d!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/]{6,18}$/,
-  NICKNAME: /^[가-힣a-zA-Z0-9]{1,10}$/,
-};
 
 interface MobileVerificationProps {
   onNext: () => void;
@@ -70,16 +56,16 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
   const { mutate: checkNickname } = useMutation({
     mutationFn: nicknameDuplicateCheck,
     onSuccess: () => {
-      setPhoneMessage({ type: 'success', content: MESSAGES.NICKNAME_AVAILABLE });
+      setPhoneMessage({ type: 'success', content: MESSAGES.NICKNAME.AVAILABLE });
     },
     onError: (err) => {
       if (isKoinError(err)) {
         if (err.status === 400) {
-          setPhoneMessage({ type: 'warning', content: MESSAGES.NICKNAME_FORMAT });
+          setPhoneMessage({ type: 'warning', content: MESSAGES.NICKNAME.FORMAT });
         }
 
         if (err.status === 409) {
-          setPhoneMessage({ type: 'error', content: MESSAGES.NICKNAME_DUPLICATED });
+          setPhoneMessage({ type: 'error', content: MESSAGES.NICKNAME.DUPLICATED });
         }
       }
     },
@@ -122,7 +108,7 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
                 required: true,
                 pattern: {
                   value: REGEX.PASSWORD,
-                  message: MESSAGES.PASSWORD_FORMAT,
+                  message: MESSAGES.PASSWORD.FORMAT,
                 },
               }}
               render={({ field, fieldState }) => (
@@ -131,7 +117,7 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
                   placeholder="특수문자 포함 영어와 숫자 6~18자리로 입력해주세요."
                   type="password"
                   isVisibleButton
-                  message={fieldState.error ? { type: 'warning', content: MESSAGES.PASSWORD_FORMAT } : null}
+                  message={fieldState.error ? { type: 'warning', content: MESSAGES.PASSWORD.FORMAT } : null}
                 />
               )}
             />
@@ -151,8 +137,8 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
                     type="password"
                     isVisibleButton
                     message={fieldState.error
-                      ? { type: 'warning', content: MESSAGES.PASSWORD_MISMATCH }
-                      : { type: 'success', content: MESSAGES.PASSWORD_MATCH }}
+                      ? { type: 'warning', content: MESSAGES.PASSWORD.MISMATCH }
+                      : { type: 'success', content: MESSAGES.PASSWORD.MATCH }}
                   />
                 )}
               />

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
@@ -218,7 +218,8 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
       <button
         type="submit"
         onClick={() => {
-          onSubmit(getValues());
+          // onSubmit(getValues());
+          onNext();
         }}
         className={styles['next-button']}
         disabled={!isFormFilled}

--- a/src/pages/Auth/SignupPage/Steps/MobileUserTypeStep/MobileUserTypeStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileUserTypeStep/MobileUserTypeStep.module.scss
@@ -16,7 +16,7 @@
     display: flex;
     width: 96px;
     height: 56px;
-    margin: 100px auto 80px auto;
+    margin: 100px auto 80px;
   }
 }
 
@@ -38,20 +38,19 @@
       justify-content: center;
       align-items: center;
       border-radius: 8px;
-      
-      color: #FFF;
+      color: #fff;
       font-size: 16px;
       font-weight: 500;
       line-height: 160%;
     }
 
-    &--orange{
+    &--orange {
       @include media.media-breakpoint(mobile) {
         background-color: #f7941e;
       }
     }
 
-    &--blue{
+    &--blue {
       @include media.media-breakpoint(mobile) {
         background-color: #175c8e;
       }

--- a/src/pages/Auth/SignupPage/Steps/MobileUserTypeStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileUserTypeStep/index.tsx
@@ -1,7 +1,6 @@
 import LogoIcon from 'assets/svg/Login/logo.svg';
+import type { UserType } from 'static/auth';
 import styles from './MobileUserTypeStep.module.scss';
-
-type UserType = '학생' | '외부인';
 
 interface MobileUserTypeStepProps {
   onSelectType: (type: UserType) => void;

--- a/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/MobileVerification.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/MobileVerification.module.scss
@@ -6,7 +6,7 @@
     flex-direction: column;
     width: 100%;
     height: calc(100% - 40px);
-    margin: 64px auto 0 auto;
+    margin: 64px auto 0;
     font-family: Pretendard, sans-serif;
     justify-content: space-between;
   }
@@ -45,38 +45,35 @@
     gap: 32px;
     height: fit-content;
     align-items: center;
+  }
 
-    &__checkbox {
+  &__checkbox {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    input[type="radio"] {
+      box-sizing: border-box;
       display: flex;
-      gap: 8px;
-      align-items: center;
+      appearance: none;
+      width: 16px;
+      height: 16px;
+      margin: 0 0 2px;
+      border-radius: 50px;
+      border: 2px solid #175c8e;
+      cursor: pointer;
+    }
 
-      input[type='radio'] {
-        box-sizing: border-box;
-        display: flex;
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        appearance: none;
+    input[type="radio"]:checked {
+      background-color: #175c8e;
+      border: 2px solid white;
+      box-shadow: 0 0 0 2px #175c8e;
+    }
 
-        width: 16px;
-        height: 16px;
-        margin: 0 0 2px;
-        border-radius: 50px;
-        border: 2px solid #175C8E;
-        cursor: pointer;
-      }
-
-      input[type='radio']:checked {
-        background-color: #175C8E;
-        border: 2px solid white;
-        box-shadow: 0 0 0 2px #175C8E;
-      }
-
-      & > div {
-        display: flex;
-        font-size: 16px;
-        line-height: 160%;
-      }
+    & > div {
+      display: flex;
+      font-size: 16px;
+      line-height: 160%;
     }
   }
 }
@@ -107,7 +104,6 @@
       align-items: center;
       border: none;
       border-bottom: 1px solid #cacaca;
-
       font-size: 14px;
       font-weight: 400;
       line-height: 160%;
@@ -132,8 +128,7 @@
 }
 
 .label-count-number {
-  color:  #727272;
-
+  color: #727272;
   font-size: 12px;
   font-weight: 400;
   line-height: 160%;
@@ -149,7 +144,6 @@
     align-items: center;
     border-radius: 8px;
     background: #175c8e;
-
     color: #fff;
     font-size: 16px;
     font-weight: 500;

--- a/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/MobileVerification.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/MobileVerification.module.scss
@@ -6,7 +6,7 @@
     flex-direction: column;
     width: 100%;
     height: calc(100% - 40px);
-    margin: 64px auto 40px auto;
+    margin: 64px auto 0 auto;
     font-family: Pretendard, sans-serif;
     justify-content: space-between;
   }
@@ -129,6 +129,15 @@
   font-size: 12px;
   font-weight: 400;
   line-height: 160%;
+}
+
+.label-count-number {
+  color:  #727272;
+
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 160%;
+  margin-left: 8px;
 }
 
 .next-button {

--- a/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
@@ -7,28 +7,10 @@ import { isKoinError } from '@bcsdlab/koin';
 import ROUTES from 'static/routes';
 import { useNavigate } from 'react-router-dom';
 import type { SmsSendResponse } from 'api/auth/entity';
+import { GENDER_OPTIONS, MESSAGES } from 'static/auth';
 import useCountdownTimer from '../../hooks/useCountdownTimer';
 import CustomInput, { type InputMessage } from '../../components/CustomInput';
 import styles from './MobileVerification.module.scss';
-
-const MESSAGES = {
-  // 전화번호 입력
-  INVALID_PHONE: '올바른 전화번호 양식이  아닙니다. 다시 입력해 주세요.',
-  ALREADY_REGISTERED: '이미 가입된 전화 번호입니다.',
-  CODE_SENT: '인증번호가 발송되었습니다.',
-
-  // 인증번호 입력
-  DEFAULT: '인증번호 발송이 안 되시나요?',
-  CODE_TIMEOUT: '유효시간이 지났습니다. 인증번호를 재발송 해주세요.',
-  CODE_INCORRECT: '인증번호가 일치하지 않습니다. 다시 입력해 주세요.',
-  CODE_CORRECT: '인증번호가 일치합니다.',
-  CODE_STOP: '1일 발송 한도를 초과했습니다. 24시간 이후 재시도 바랍니다.',
-};
-
-const GENDER_OPTIONS = [
-  { label: '남성', value: 'male' },
-  { label: '여성', value: 'female' },
-];
 
 interface MobileVerificationProps {
   onNext: () => void;
@@ -52,7 +34,7 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
     duration: 200,
     onExpire: () => {
       if (!isCodeCorrect) {
-        setVerificationMessage({ type: 'warning', content: MESSAGES.CODE_TIMEOUT });
+        setVerificationMessage({ type: 'warning', content: MESSAGES.VERIFICATION.TIMEOUT });
       }
     },
   });
@@ -60,7 +42,7 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
   const { mutate: sendSMSToUser } = useMutation({
     mutationFn: smsSend,
     onSuccess: (data : SmsSendResponse) => {
-      setPhoneMessage({ type: 'success', content: MESSAGES.CODE_SENT });
+      setPhoneMessage({ type: 'success', content: MESSAGES.PHONE.CODE_SENT });
       runTimer();
       setShowVerificationField(true);
       setSmsSendCount(data.remaining_count);
@@ -68,10 +50,10 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
     onError: (err) => {
       if (isKoinError(err)) {
         if (err.status === 400) {
-          setPhoneMessage({ type: 'warning', content: MESSAGES.INVALID_PHONE });
+          setPhoneMessage({ type: 'warning', content: MESSAGES.PHONE.INVALID });
         }
         if (err.status === 429) {
-          setPhoneMessage({ type: 'error', content: MESSAGES.CODE_STOP });
+          setPhoneMessage({ type: 'error', content: MESSAGES.VERIFICATION.STOP });
         }
       }
     },
@@ -80,16 +62,16 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
   const { mutate: checkVerificationCode } = useMutation({
     mutationFn: smsVerify,
     onSuccess: () => {
-      setVerificationMessage({ type: 'success', content: MESSAGES.CODE_CORRECT });
+      setVerificationMessage({ type: 'success', content: MESSAGES.VERIFICATION.CORRECT });
       setIsCodeCorrect(true);
     },
     onError: (err) => {
       if (isKoinError(err)) {
         if (err.status === 400) {
-          setVerificationMessage({ type: 'warning', content: MESSAGES.CODE_INCORRECT });
+          setVerificationMessage({ type: 'warning', content: MESSAGES.VERIFICATION.INCORRECT });
         }
         if (err.status === 404) {
-          setVerificationMessage({ type: 'error', content: MESSAGES.CODE_TIMEOUT });
+          setVerificationMessage({ type: 'error', content: MESSAGES.VERIFICATION.TIMEOUT });
         }
       }
     },
@@ -103,11 +85,11 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
     onError: (err) => {
       if (isKoinError(err)) {
         if (err.status === 400) {
-          setPhoneMessage({ type: 'warning', content: MESSAGES.INVALID_PHONE });
+          setPhoneMessage({ type: 'warning', content: MESSAGES.PHONE.INVALID });
         }
 
         if (err.status === 409) {
-          setPhoneMessage({ type: 'error', content: MESSAGES.ALREADY_REGISTERED });
+          setPhoneMessage({ type: 'error', content: MESSAGES.PHONE.ALREADY_REGISTERED });
         }
       }
     },

--- a/src/pages/Auth/SignupPage/Steps/Verification/Verification.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/Verification/Verification.module.scss
@@ -32,14 +32,13 @@
   border: 2px solid #175c8e;
 
   &--top {
-    margin: 0 0 48px 0;
+    margin: 0 0 48px;
   }
 
   &--bottom {
     margin: 40px 0;
   }
 }
-
 
 .field {
   display: flex;
@@ -50,7 +49,7 @@
     font-weight: bold;
 
     .required {
-      color: #EC2D30;
+      color: #ec2d30;
     }
   }
 
@@ -67,14 +66,11 @@
   }
 }
 
-
-
 .form {
   display: flex;
   flex-direction: column;
   align-items: center;
   font-family: Pretendard, sans-serif;
-
 
   &__inputWrapper {
     display: flex;
@@ -112,7 +108,6 @@
     gap: 10px;
     border-radius: 12px;
     border: 1px solid #e1e1e1;
-
     color: #cacaca;
     font-size: 13px;
     font-weight: 500;
@@ -132,10 +127,9 @@
     align-items: center;
     border-radius: 16px;
     background-color: #cacaca;
-
-    color: #FFF;
+    color: #fff;
     font-size: 16px;
     font-weight: 500;
     line-height: 160%;
-  };
+  }
 }

--- a/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
@@ -51,7 +51,7 @@
 
     &::placeholder {
       color: #cacaca;
-      font-size: 14px;
+      font-size: 13px;
     }
   }
 

--- a/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
@@ -20,7 +20,6 @@
   align-items: center;
   border-radius: 4px;
   background-color: #175c8e;
-
   color: #fff;
   font-size: 10px;
   font-weight: 400;
@@ -44,7 +43,6 @@
     padding: 8px 64px 8px 4px;
     border: none;
     border-bottom: 1px solid #e1e1e1;
-
     font-size: 14px;
     font-weight: 400;
     line-height: 160%;
@@ -69,7 +67,6 @@
     display: flex;
     background: none;
     margin-top: 2px;
-
     color: #727272;
     font-size: 14px;
     font-weight: 500;
@@ -81,7 +78,7 @@
   display: flex;
   align-items: center;
   margin-top: 8px;
-  
+
   & > svg {
     display: flex;
     width: 16px;
@@ -96,7 +93,6 @@
     font-weight: 400;
     line-height: 160%;
 
-
     &--error {
       color: #f64c4c;
     }
@@ -108,8 +104,5 @@
     &--warning {
       color: #f7941e;
     }
-
-
   }
-
 }

--- a/src/pages/Auth/SignupPage/components/CustomSelector/CustomSelector.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomSelector/CustomSelector.module.scss
@@ -124,7 +124,6 @@
     width: 100%;
     height: 40px;
     box-sizing: border-box;
-
     color: #727272;
 
     @include inherit-text-style;

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -83,7 +83,7 @@ function SignupPage() {
           </Step>
           <Step name="정보 입력">
             {userType === '학생' && <MobileStudentDetailStep onNext={() => nextStep('완료')} />}
-            {userType === '외부인' && <MobileGuestDetailStep />}
+            {userType === '외부인' && <MobileGuestDetailStep onNext={() => nextStep('완료')} />}
           </Step>
           <Step name="완료">
             <CompleteStep />

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -51,7 +51,7 @@ function SignupPage() {
             type="button"
             className={styles.container__button}
             onClick={goBack}
-            aria-label="ddd"
+            aria-label="button"
           >
             <ChevronLeftIcon />
           </button>

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -27,7 +27,7 @@ function SignupPage() {
   const isMobile = useMediaQuery();
 
   const methods = useForm({
-    mode: 'onBlur',
+    mode: 'onChange',
     defaultValues: {
       name: '',
       phone_number: '',

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -11,11 +11,12 @@ import MobileUserTypeStep from './Steps/MobileUserTypeStep';
 import MobileStudentDetailStep from './Steps/MobileStudentDetailStep';
 import MobileGuestDetailStep from './Steps/MobileExternalDetailStep';
 import styles from './SignupPage.module.scss';
+import CompleteStep from './Steps/CompleteStep';
 
-type StepTitle = '약관 동의' | '본인 인증' | '회원 유형 선택' | '정보 입력';
+type StepTitle = '약관 동의' | '본인 인증' | '회원 유형 선택' | '정보 입력' | '완료';
 type UserType = '학생' | '외부인';
 
-const stepTitles: StepTitle[] = ['약관 동의', '본인 인증', '회원 유형 선택', '정보 입력'];
+const stepTitles: StepTitle[] = ['약관 동의', '본인 인증', '회원 유형 선택', '정보 입력', '완료'];
 
 function SignupPage() {
   const {
@@ -58,10 +59,13 @@ function SignupPage() {
           <span className={styles.container__title}>회원가입</span>
         </div>
         )}
-        <ProgressBar
-          steps={stepTitles.map((title) => ({ title }))}
-          currentIndex={currentIndex}
-        />
+
+        {currentStep !== '완료' && (
+          <ProgressBar
+            steps={stepTitles.map((title) => ({ title }))}
+            currentIndex={currentIndex}
+          />
+        )}
         <FormProvider {...methods}>
           <Step name="약관 동의">
             <Terms onNext={() => nextStep('본인 인증')} />
@@ -78,8 +82,11 @@ function SignupPage() {
             />
           </Step>
           <Step name="정보 입력">
-            {userType === '학생' && <MobileStudentDetailStep onNext={() => nextStep('회원 유형 선택')} />}
+            {userType === '학생' && <MobileStudentDetailStep onNext={() => nextStep('완료')} />}
             {userType === '외부인' && <MobileGuestDetailStep />}
+          </Step>
+          <Step name="완료">
+            <CompleteStep />
           </Step>
         </FormProvider>
       </div>

--- a/src/static/auth.ts
+++ b/src/static/auth.ts
@@ -1,0 +1,36 @@
+export const REGEX = {
+  PASSWORD: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/])[A-Za-z\d!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/]{6,18}$/,
+  NICKNAME: /^[가-힣a-zA-Z0-9]{1,10}$/,
+};
+
+export const MESSAGES = {
+  PASSWORD: {
+    FORMAT: '올바른 비밀번호 양식이 아닙니다. 다시 입력해 주세요.',
+    MISMATCH: '비밀번호가 일치하지 않습니다.',
+    MATCH: '비밀번호가 일치합니다.',
+  },
+  NICKNAME: {
+    DUPLICATED: '중복된 닉네임입니다. 다시 입력해 주세요.',
+    AVAILABLE: '사용 가능한 닉네임입니다.',
+    FORMAT: '한글, 영문 및 숫자 포함하여 10자 내로 입력해 주세요.',
+  },
+  PHONE: {
+    INVALID: '올바른 전화번호 양식이 아닙니다. 다시 입력해 주세요.',
+    ALREADY_REGISTERED: '이미 가입된 전화 번호입니다.',
+    CODE_SENT: '인증번호가 발송되었습니다.',
+  },
+  VERIFICATION: {
+    DEFAULT: '인증번호 발송이 안 되시나요?',
+    TIMEOUT: '유효시간이 지났습니다. 인증번호를 재발송 해주세요.',
+    INCORRECT: '인증번호가 일치하지 않습니다. 다시 입력해 주세요.',
+    CORRECT: '인증번호가 일치합니다.',
+    STOP: '1일 발송 한도를 초과했습니다. 24시간 이후 재시도 바랍니다.',
+  },
+};
+
+export type UserType = '학생' | '외부인';
+
+export const GENDER_OPTIONS = [
+  { label: '남성', value: 'male' },
+  { label: '여성', value: 'female' },
+];


### PR DESCRIPTION
- Close #819 
  
## What is this PR? 🔍

- 기능 : 회원가입 외부인 페이지 구현 및 api 변경사항 대응
- issue : #819 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

- 회원가입 로직 중 외부인 회원가입 로직을 구현했습니다. 
- `/v2/user/general/register` , `/v2/user/student/register`, `/user/verification/sms/send`, `/user/verification/sms/verify` api 에 변경사항이 생겨 대응했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

<img width="918" alt="image" src="https://github.com/user-attachments/assets/fe1e18b8-ee86-459f-9713-8b581c97e9ec" />

## Precaution

- 모바일 페이지만 구현 완료했습니다.
- 휴대전화 인증번호의 경우 slack 에서 `코인_이벤트알림_stage` 에서 확인 가능합니다.
- 아이디 입력 부분의 경우 변경된 디자인이 아직 나오지 않아 추가하지 않았습니다. 디자인이 추가된 후 이어서 PR 올리도록 하겠습니다. 
- 아이디 입력 부분이 구현되지 않아 회원가입 완료 또한 주석 처리해놨습니다.
## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
