### PR TITLE
[유저] 학생 정보기입 페이지 기능 추가

### DIFF
--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -25,6 +25,7 @@ import {
   SignupStudentResponse,
   LoginStudentRequest,
   CheckIdResponse,
+  EmailDuplicateCheckResponse,
 } from './entity';
 
 export class Login<R extends LoginResponse> implements APIRequest<R> {
@@ -233,4 +234,18 @@ export class SmsVerify<R extends SmsVerifyResponse> implements APIRequest<R> {
   auth = false;
 
   constructor(public data: SmsVerifyRequest) { }
+}
+
+export class EmailDuplicateCheck<R extends EmailDuplicateCheckResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path = 'user/check/email';
+
+  response!: R;
+
+  auth = false;
+
+  constructor(email: string) {
+    this.path = `/user/check/email?email=${email}`;
+  }
 }

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -13,8 +13,8 @@ export type LoginStudentRequest = {
   department: string;
   student_number: string;
   gender: string;
-  email?: string;
-  nickname: string;
+  email: string | null;
+  nickname: string | null;
 };
 
 export type LoginGeneralRequest = {
@@ -34,6 +34,10 @@ export interface LoginResponse extends APIResponse {
 }
 
 export interface NicknameDuplicateCheckResponse extends APIResponse {
+  success: string;
+}
+
+export interface EmailDuplicateCheckResponse extends APIResponse {
   success: string;
 }
 

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -16,6 +16,7 @@ import {
   SmsSend,
   SmsVerify,
   CheckId,
+  EmailDuplicateCheck,
 } from './APIDetail';
 
 export const login = APIClient.of(Login);
@@ -49,3 +50,5 @@ export const smsSend = APIClient.of(SmsSend);
 export const smsVerify = APIClient.of(SmsVerify);
 
 export const checkId = APIClient.of(CheckId);
+
+export const emailDuplicateCheck = APIClient.of(EmailDuplicateCheck);

--- a/src/assets/svg/arrow-back.svg
+++ b/src/assets/svg/arrow-back.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M17.5098 3.86961L15.7298 2.09961L5.83984 11.9996L15.7398 21.8996L17.5098 20.1296L9.37984 11.9996L17.5098 3.86961Z" fill="black"/>
+</svg>

--- a/src/pages/Auth/SignupPage/Steps/CompleteStep/CompleteStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/CompleteStep/CompleteStep.module.scss
@@ -43,7 +43,7 @@
     font-size: 18px;
     font-weight: 500;
     line-height: 160%;
-    margin-top: 0px;
+    margin-top: 0;
     margin-bottom: 57px;
     color: #000;
   }

--- a/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/ExternalDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/ExternalDetailStep.module.scss
@@ -12,6 +12,23 @@
     align-items: center;
   }
 
+  &__title-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &--title {
+      text-align: center;
+      font-size: 30px;
+      font-weight: 700;
+    }
+
+    &--icon {
+      visibility: hidden;
+    }
+  }
+
   &__title {
     text-align: center;
     font-size: 30px;

--- a/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/ExternalDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/ExternalDetailStep.module.scss
@@ -48,7 +48,7 @@
       line-height: 160%;
 
       .required {
-        color: #EC2D30;
+        color: #ec2d30;
       }
     }
   }
@@ -59,7 +59,7 @@
   border: 2px solid #175c8e;
 
   &--top {
-    margin: 0 0 48px 0;
+    margin: 0 0 48px;
   }
 
   &--bottom {
@@ -109,7 +109,7 @@
 .checkbox-wrapper {
   display: flex;
   gap: 32px;
-  
+
   &__checkbox {
     display: flex;
   }
@@ -135,16 +135,16 @@
   gap: 10px;
   color: #4b4b4b;
   background-color: #e1e1e1;
-  font-family: Pretendard,sans-serif;
+  font-family: Pretendard, sans-serif;
   font-size: 16px;
   font-style: normal;
   font-weight: 500;
   line-height: 160%;
 
-    &--active {
-      color: #fff;
-      background-color: #175c8e;
-    }
+  &--active {
+    color: #fff;
+    background-color: #175c8e;
+  }
 }
 
 .email-input-wrapper {

--- a/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/ExternalDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/ExternalDetailStep.module.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   align-items: center;
   font-family: Pretendard, sans-serif;
-  height: 1100px;
+  margin: 120px 0 200px;
 
   &__wrapper {
     display: flex;

--- a/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/index.tsx
@@ -7,11 +7,13 @@ import {
 } from 'react-hook-form';
 import { REGEX, MESSAGES } from 'static/auth';
 import CustomInput, { type InputMessage } from 'pages/Auth/SignupPage/components/CustomInput';
+import BackIcon from 'assets/svg/arrow-back.svg';
 import { cn } from '@bcsdlab/utils';
 import styles from './ExternalDetailStep.module.scss';
 
 interface ExternalDetailStepProps {
   onNext: () => void;
+  onBack: () => void;
 }
 
 interface GeneralFormValues {
@@ -25,7 +27,7 @@ interface GeneralFormValues {
   nickname: string | null;
 }
 
-function ExternalDetail({ onNext }: ExternalDetailStepProps) {
+function ExternalDetail({ onNext, onBack }: ExternalDetailStepProps) {
   const {
     control, getValues, handleSubmit, trigger,
   } = useFormContext<GeneralFormValues>();
@@ -131,7 +133,15 @@ function ExternalDetail({ onNext }: ExternalDetailStepProps) {
   return (
     <div className={styles.container}>
       <div className={styles.container__wrapper}>
-        <h1 className={styles.container__title}>회원가입</h1>
+        <div className={styles['container__title-wrapper']}>
+          <button type="button" onClick={onBack} aria-label="뒤로가기">
+            <BackIcon />
+          </button>
+          <h1 className={styles['container__title-wrapper--title']}>회원가입</h1>
+          <div className={styles['container__title-wrapper--icon']}>
+            <BackIcon />
+          </div>
+        </div>
         <div className={styles.container__subTitleWrapper}>
           <span className={styles['container__subTitleWrapper-subTitle']}>
             <span className={styles.required}>*</span>

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
@@ -12,10 +12,21 @@
     align-items: center;
   }
 
-  &__title {
-    text-align: center;
-    font-size: 30px;
-    font-weight: 700;
+  &__title-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &--title {
+      text-align: center;
+      font-size: 30px;
+      font-weight: 700;
+    }
+
+    &--icon {
+      visibility: hidden;
+    }
   }
 
   &__subTitleWrapper {
@@ -31,7 +42,7 @@
       line-height: 160%;
 
       .required {
-        color: #EC2D30;
+        color: #Ec2d30;
       }
     }
   }

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
@@ -13,20 +13,22 @@
   }
 
   &__title-wrapper {
+    position: relative;
     width: 100%;
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
+  }
 
-    &--title {
-      text-align: center;
-      font-size: 30px;
-      font-weight: 700;
-    }
+  &__back-button {
+    position: absolute;
+    left: 0;
+  }
 
-    &--icon {
-      visibility: hidden;
-    }
+  &__title {
+    text-align: center;
+    font-size: 30px;
+    font-weight: 700;
   }
 
   &__subTitleWrapper {

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
@@ -42,7 +42,7 @@
       line-height: 160%;
 
       .required {
-        color: #Ec2d30;
+        color: #ec2d30;
       }
     }
   }
@@ -53,7 +53,7 @@
   border: 2px solid #175c8e;
 
   &--top {
-    margin: 0 0 48px 0;
+    margin: 0 0 48px;
   }
 
   &--bottom {
@@ -103,7 +103,7 @@
 .checkbox-wrapper {
   display: flex;
   gap: 32px;
-  
+
   &__checkbox {
     display: flex;
   }
@@ -129,16 +129,16 @@
   gap: 10px;
   color: #4b4b4b;
   background-color: #e1e1e1;
-  font-family: Pretendard,sans-serif;
+  font-family: Pretendard, sans-serif;
   font-size: 16px;
   font-style: normal;
   font-weight: 500;
   line-height: 160%;
 
-    &--active {
-      color: #fff;
-      background-color: #175c8e;
-    }
+  &--active {
+    color: #fff;
+    background-color: #175c8e;
+  }
 }
 
 .email-input-wrapper {

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/StudentDetailStep.module.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   align-items: center;
   font-family: Pretendard, sans-serif;
-  height: 1100px;
+  margin: 120px 0 70px;
 
   &__wrapper {
     display: flex;

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -369,7 +369,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
                 control={control}
                 defaultValue=""
                 rules={{
-                  required: true,
                   pattern: {
                     value: REGEX.STUDENTEMAIL,
                     message: '',
@@ -463,10 +462,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
         <button
           type="button"
           onClick={checkAndSubmit}
-          // onClick={() => {
-          //   checkEmail(emailControl);
-          //   // onNext();
-          // }}
           className={cn({
             [styles['next-button']]: true,
             [styles['next-button--active']]: Boolean(isFormFilled),

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -100,7 +100,7 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
       if (isKoinError(err)) {
         if (err.status === 400) setNicknameMessage({ type: 'warning', content: MESSAGES.NICKNAME.FORMAT });
 
-        if (err.status === 409)setNicknameMessage({ type: 'error', content: MESSAGES.NICKNAME.DUPLICATED });
+        if (err.status === 409) setNicknameMessage({ type: 'error', content: MESSAGES.NICKNAME.DUPLICATED });
       }
     },
   });
@@ -199,13 +199,15 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
       <div className={styles.container__wrapper}>
 
         <div className={styles['container__title-wrapper']}>
-          <button type="button" onClick={onBack} aria-label="뒤로가기">
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="뒤로가기"
+            className={styles['container__back-button']}
+          >
             <BackIcon />
           </button>
-          <h1 className={styles['container__title-wrapper--title']}>회원가입</h1>
-          <div className={styles['container__title-wrapper--icon']}>
-            <BackIcon />
-          </div>
+          <h1 className={styles.container__title}>회원가입</h1>
         </div>
         <div className={styles.container__subTitleWrapper}>
           <span className={styles['container__subTitleWrapper-subTitle']}>

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -391,7 +391,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
                   />
                 )}
               />
-              <span className={styles.email}>@koreatech.ac.kr</span>
             </div>
           </div>
         </div>

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -13,12 +13,14 @@ import CustomInput, { type InputMessage } from 'pages/Auth/SignupPage/components
 import CustomSelector from 'pages/Auth/SignupPage/components/CustomSelector';
 import useDeptList from 'pages/Auth/SignupPage/hooks/useDeptList';
 import { cn } from '@bcsdlab/utils';
+import BackIcon from 'assets/svg/arrow-back.svg';
 import showToast from 'utils/ts/showToast';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
 import styles from './StudentDetailStep.module.scss';
 
 interface VerificationProps {
   onNext: () => void;
+  onBack: () => void;
 }
 
 interface StudentFormValues {
@@ -34,7 +36,7 @@ interface StudentFormValues {
   nickname: string | null,
 }
 
-function StudentDetail({ onNext }: VerificationProps) {
+function StudentDetail({ onNext, onBack }: VerificationProps) {
   const {
     control, getValues, handleSubmit, trigger,
   } = useFormContext<StudentFormValues>();
@@ -145,8 +147,6 @@ function StudentDetail({ onNext }: VerificationProps) {
       email: completeEmail,
       nickname: completeNickname,
     });
-
-    console.log(formData);
   };
 
   const checkAndSubmit = () => {
@@ -197,7 +197,16 @@ function StudentDetail({ onNext }: VerificationProps) {
   return (
     <div className={styles.container}>
       <div className={styles.container__wrapper}>
-        <h1 className={styles.container__title}>회원가입</h1>
+
+        <div className={styles['container__title-wrapper']}>
+          <button type="button" onClick={onBack} aria-label="뒤로가기">
+            <BackIcon />
+          </button>
+          <h1 className={styles['container__title-wrapper--title']}>회원가입</h1>
+          <div className={styles['container__title-wrapper--icon']}>
+            <BackIcon />
+          </div>
+        </div>
         <div className={styles.container__subTitleWrapper}>
           <span className={styles['container__subTitleWrapper-subTitle']}>
             <span className={styles.required}>*</span>

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line @typescript-eslint/naming-convention */
 import { isKoinError } from '@bcsdlab/koin';
 import { useMutation } from '@tanstack/react-query';
 import {
@@ -137,6 +136,7 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
 
   const onSubmit = async (formData: StudentFormValues) => {
     const {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       password_check, email, nickname, ...signupData
     } = formData;
     const completeEmail = email ? `${email}@koreatech.ac.kr` : null;

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import {
   Controller, FieldError, useFormContext, useFormState, useWatch,
 } from 'react-hook-form';
-import { REGEX, MESSAGES } from 'static/auth';
+import { REGEX, MESSAGES, UserType } from 'static/auth';
 import CustomInput, { type InputMessage } from 'pages/Auth/SignupPage/components/CustomInput';
 import CustomSelector from 'pages/Auth/SignupPage/components/CustomSelector';
 import useDeptList from 'pages/Auth/SignupPage/hooks/useDeptList';
@@ -387,6 +387,7 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
                         setEmailMessage(null);
                       }
                     }}
+                    userType="학생"
                     value={field.value ?? ''}
                   />
                 )}

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import {
   Controller, FieldError, useFormContext, useFormState, useWatch,
 } from 'react-hook-form';
-import { REGEX, MESSAGES, UserType } from 'static/auth';
+import { REGEX, MESSAGES } from 'static/auth';
 import CustomInput, { type InputMessage } from 'pages/Auth/SignupPage/components/CustomInput';
 import CustomSelector from 'pages/Auth/SignupPage/components/CustomSelector';
 import useDeptList from 'pages/Auth/SignupPage/hooks/useDeptList';

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
@@ -10,10 +10,21 @@
     max-width: 640px;
   }
 
-  &__title {
-    text-align: center;
-    font-size: 30px;
-    font-weight: 700;
+  &__title-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &--title {
+      text-align: center;
+      font-size: 30px;
+      font-weight: 700;
+    }
+
+    &--icon {
+      visibility: hidden;
+    }
   }
 
   &__subTitleWrapper {

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
@@ -160,3 +160,37 @@
     background-color: #f7941e;
   }
 }
+
+.label-link {
+  display: flex;
+  position: relative;
+  top: 17px;
+  right: 213px;
+  align-items: flex-start;
+
+  &__text {
+    font-family: Pretendard, sans-serif;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 160%;
+    color: #727272;
+  }
+
+  &__button {
+    margin-left: 8px;
+    font-family: Pretendard, sans-serif;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 160%;
+    color: #175c8e;
+  }
+}
+
+.label-link-button {
+  margin-left: 8px;
+  font-family: Pretendard, sans-serif;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 160%;
+  color: #175c8e;
+}

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   align-items: center;
   font-family: Pretendard, sans-serif;
-  height: 1100px;
+  margin: 120px 0 300px;
 
   &__wrappe {
     max-width: 640px;

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
@@ -40,7 +40,7 @@
       line-height: 160%;
 
       .required {
-        color: #EC2D30;
+        color: #ec2d30;
       }
     }
   }
@@ -51,7 +51,7 @@
   border: 2px solid #175c8e;
 
   &--top {
-    margin: 0 0 48px 0;
+    margin: 0 0 48px;
   }
 
   &--bottom {
@@ -94,7 +94,7 @@
 .checkbox-wrapper {
   display: flex;
   gap: 32px;
-  
+
   &__checkbox {
     display: flex;
     gap: 8px;
@@ -123,10 +123,9 @@
     align-items: center;
     border-radius: 16px;
     background: #cacaca;
-    color: #FFF;
-
+    color: #fff;
     text-align: center;
-    font-family: Pretendard ,sans-serif;
+    font-family: Pretendard, sans-serif;
     font-size: 16px;
     font-weight: 500;
     line-height: 160%;
@@ -145,7 +144,7 @@
     align-items: center;
     border-radius: 16px;
     background: #cacaca;
-    color: #FFF;
+    color: #fff;
     text-align: center;
     font-family: Pretendard, sans-serif;
     font-size: 16px;

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -9,16 +9,18 @@ import { useNavigate } from 'react-router-dom';
 import type { SmsSendResponse } from 'api/auth/entity';
 import { UserType, GENDER_OPTIONS, MESSAGES } from 'static/auth';
 import { cn } from '@bcsdlab/utils';
+import BackIcon from 'assets/svg/arrow-back.svg';
 import useCountdownTimer from '../../hooks/useCountdownTimer';
 import CustomInput, { type InputMessage } from '../../components/CustomInput';
 import styles from './VerificationStep.module.scss';
 
 interface VerificationProps {
   onNext: () => void;
+  onBack: () => void;
   setUserType: (type: UserType) => void;
 }
 
-function Verification({ onNext, setUserType }: VerificationProps) {
+function Verification({ onNext, onBack, setUserType }: VerificationProps) {
   const navigate = useNavigate();
   const { control, register } = useFormContext();
   const name = useWatch({ control, name: 'name' });
@@ -127,7 +129,15 @@ function Verification({ onNext, setUserType }: VerificationProps) {
     <div className={styles.container}>
 
       <div className={styles.container__wrapper}>
-        <h1 className={styles.container__title}>회원가입</h1>
+        <div className={styles['container__title-wrapper']}>
+          <button type="button" onClick={onBack} aria-label="뒤로가기">
+            <BackIcon />
+          </button>
+          <h1 className={styles['container__title-wrapper--title']}>회원가입</h1>
+          <div className={styles['container__title-wrapper--icon']}>
+            <BackIcon />
+          </div>
+        </div>
         <div className={styles.container__subTitleWrapper}>
           <span className={styles['container__subTitleWrapper-subTitle']}>
             <span className={styles.required}>*</span>

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -34,7 +34,7 @@ function Verification({ onNext, setUserType }: VerificationProps) {
   const [buttonText, setButtonText] = useState('인증번호 발송');
 
   const { isRunning: isTimer, secondsLeft: timerValue, start: runTimer } = useCountdownTimer({
-    duration: 20,
+    duration: 180,
     onExpire: () => {
       if (!isCodeCorrect) {
         setVerificationMessage({ type: 'warning', content: MESSAGES.VERIFICATION.TIMEOUT });

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -219,13 +219,30 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                       /5)
                     </div>
                   )}
-                  {
-                    phoneMessage?.type === 'error' && (
-                    <button onClick={() => goToLogin()} type="button" className={styles['label-link-button']}>
+                  {phoneMessage?.type === 'error' && (
+                  <>
+                    <button
+                      onClick={goToLogin}
+                      type="button"
+                      className={styles['label-link-button']}
+                    >
                       로그인하기
                     </button>
-                    )
-                  }
+
+                    <div className={styles['label-link']}>
+                      <div className={styles['label-link__text']}>
+                        해당 전화번호로 가입하신 적 없으신가요?
+                      </div>
+                      <button
+                        onClick={goToLogin}
+                        type="button"
+                        className={styles['label-link__button']}
+                      >
+                        문의하기
+                      </button>
+                    </div>
+                  </>
+                  )}
                 </CustomInput>
               )}
             />

--- a/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
@@ -78,6 +78,16 @@
     }
   }
 
+  &__email {
+    position: absolute;
+    right: 12px;
+    color: #000;
+    font-weight: 400;
+    font-size: 14px;
+    z-index: 1;
+    pointer-events: none;
+  }
+
   &__optionButton {
     position: absolute;
     right: 12px;

--- a/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
@@ -72,6 +72,7 @@
     line-height: 160%;
 
     &::placeholder {
+      font-family: Pretendard, sans-serif;
       color: #cacaca;
       font-size: 12px;
     }

--- a/src/pages/Auth/SignupPage/components/CustomInput/index.tsx
+++ b/src/pages/Auth/SignupPage/components/CustomInput/index.tsx
@@ -11,6 +11,7 @@ import { useFormContext } from 'react-hook-form';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
 import FormatTime from 'pages/Auth/SignupPage/hooks/useFormatTime';
 import { cn } from '@bcsdlab/utils';
+import { UserType } from 'static/auth';
 import styles from './CustomInput.module.scss';
 
 export type InputMessage = {
@@ -30,6 +31,7 @@ interface CustomInputProps extends ComponentPropsWithoutRef<'input'> {
   buttonText?: string;
   buttonOnClick?: () => void;
   buttonDisabled?: boolean;
+  userType?: UserType;
   children?: React.ReactNode;
 }
 
@@ -46,6 +48,7 @@ function CustomInput({
   buttonText = '',
   buttonOnClick,
   buttonDisabled,
+  userType,
   children,
   ...args
 }: CustomInputProps) {
@@ -74,7 +77,7 @@ function CustomInput({
             {...args}
           />
 
-          {args.name === 'email' && (
+          {args.name === 'email' && userType === '학생' && (
             <span className={styles['input-wrapper__email']}>@koreatech.ac.kr</span>
           )}
 

--- a/src/pages/Auth/SignupPage/components/CustomInput/index.tsx
+++ b/src/pages/Auth/SignupPage/components/CustomInput/index.tsx
@@ -74,6 +74,10 @@ function CustomInput({
             {...args}
           />
 
+          {args.name === 'email' && (
+            <span className={styles['input-wrapper__email']}>@koreatech.ac.kr</span>
+          )}
+
           {isTimer && (
           <span
             className={cn({

--- a/src/pages/Auth/SignupPage/components/CustomSelector/CustomSelector.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomSelector/CustomSelector.module.scss
@@ -41,7 +41,7 @@
     max-width: 100%;
     font-size: 13px;
     border: none;
-    box-shadow: 0px 1px 9px 1px rgba(0, 0, 0, 0.06);
+    box-shadow: 0 1px 9px 1px rgb(0 0 0 / 6%);
   }
 
   @include inherit-text-style;
@@ -144,7 +144,6 @@
     color: #727272;
     font-size: 14px;
     font-weight: 400;
-
     cursor: pointer;
 
     &[aria-selected="true"] {

--- a/src/pages/Auth/SignupPage/components/CustomSelector/CustomSelector.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomSelector/CustomSelector.module.scss
@@ -61,17 +61,20 @@
   &__trigger {
     position: relative;
     width: 100%;
-    padding: 16px 12px;
+    height: 48px;
+    padding: 0 12px;
     border-radius: 12px;
     box-sizing: border-box;
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    @include inherit-text-style;
-
+    font-family: Pretendard, sans-serif;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 160%;
+    color: #000;
     background-color: #fff;
-    color: inherit;
     cursor: pointer;
 
     &--white-background {
@@ -80,6 +83,11 @@
       @include media.media-breakpoint(mobile) {
         border: none;
       }
+    }
+
+    &--placeholder {
+      color: #cacaca;
+      font-size: 12px;
     }
 
     &:hover {
@@ -91,7 +99,9 @@
     }
 
     @include media.media-breakpoint(mobile) {
-      padding: 16px;
+      width: 100%;
+      padding: 0 12px;
+      font-size: 13px;
     }
   }
 
@@ -132,8 +142,8 @@
     height: 40px;
     box-sizing: border-box;
     color: #727272;
-
-    @include inherit-text-style;
+    font-size: 14px;
+    font-weight: 400;
 
     cursor: pointer;
 

--- a/src/pages/Auth/SignupPage/components/CustomSelector/index.tsx
+++ b/src/pages/Auth/SignupPage/components/CustomSelector/index.tsx
@@ -43,6 +43,7 @@ function CustomSelector({
 
   const selectedOption = options.find((option) => option.value === value);
   const showedLabel = selectedOption?.label ?? placeholder;
+  const isPlaceholder = !selectedOption;
 
   return (
     <div
@@ -59,6 +60,7 @@ function CustomSelector({
           [styles.select__trigger]: true,
           [styles['select__trigger--opened']]: isOpen,
           [styles['select__trigger--white-background']]: isWhiteBackground,
+          [styles['select__trigger--placeholder']]: isPlaceholder,
         })}
         disabled={disabled}
       >

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -79,6 +79,7 @@ function SignupPage() {
             ) : (
               <Verification
                 onNext={() => nextStep('정보입력')}
+                onBack={goBack}
                 setUserType={setUserType}
               />
             )}
@@ -95,13 +96,13 @@ function SignupPage() {
             {userType === '학생' && (
               isMobile
                 ? <MobileStudentDetailStep onNext={() => nextStep('완료')} />
-                : <StudentDetail onNext={() => nextStep('완료')} />
+                : <StudentDetail onNext={() => nextStep('완료')} onBack={goBack} />
             )}
 
             {userType === '외부인' && (
               isMobile
                 ? <MobileGuestDetailStep onNext={() => nextStep('완료')} />
-                : <ExternalDetail onNext={() => nextStep('완료')} />
+                : <ExternalDetail onNext={() => nextStep('완료')} onBack={goBack} />
             )}
           </Step>
           <Step name="완료">

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -34,14 +34,14 @@ function SignupPage() {
     defaultValues: {
       name: '',
       phone_number: '',
-      user_id: '',
+      login_id: '',
       password: '',
       password_check: '',
       department: '',
       student_number: '',
       gender: '',
-      email: '',
-      nickname: '',
+      email: null,
+      nickname: null,
       verification_code: '',
     },
   });

--- a/src/static/auth.ts
+++ b/src/static/auth.ts
@@ -1,9 +1,10 @@
 export const REGEX = {
   PASSWORD: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/])[A-Za-z\d!@#$%^&*()_\-+=~`[\]{}|\\:;"'<>,.?/]{6,18}$/,
-  NICKNAME: /^[가-힣a-zA-Z0-9]{1,10}$/,
-  EMAIL: /^[\w.-]+@[a-zA-Z\d.-]+\.[a-zA-Z]{2,}$/,
-  USERID: /^.{1,13}$/,
+  NICKNAME: /^[가-힣a-zA-Z0-9]{0,10}$/,
+  USERID: /^[a-z0-9_.-]{5,13}$/,
   STUDENT_NUMBER: /^\d{8,10}$/,
+  EMAIL: /^[\w.-]+@[a-zA-Z\d.-]+\.[a-zA-Z]{2,}$/,
+  STUDENT_EMAIL_ID: /^[a-zA-Z0-9._%+-]{2,30}$/,
 };
 
 export const MESSAGES = {
@@ -33,12 +34,15 @@ export const MESSAGES = {
     AVAILABLE: '사용 가능한 아이디입니다.',
     DUPLICATED: '이미 사용 중인 아이디입니다.',
     INVALID: '올바른 아이디 양식이 아닙니다. 다시 입력해 주세요.',
+    REQUIRED: '5~13자의 영소문자, 숫자와 특수문자( -, _ , .)만 사용 가능합니다.',
   },
   STUDENT_NUMBER: {
     FORMAT: '올바른 학번 양식이 아닙니다. 다시 입력해 주세요.',
   },
   EMAIL: {
+    AVAILABLE: '사용 가능한 이메일입니다.',
     FORMAT: '올바른 이메일 형식이 아닙니다. 다시 입력해 주세요.',
+    DUPLICATED: '이미 사용 중인 이메일입니다.',
   },
 };
 


### PR DESCRIPTION
- Close #843 
  
## What is this PR? 🔍

- 기능 : 회원가입 학생 정보기입 페이지 추가
- issue : #843 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
학생 정보기입 페이지에 다음과 같은 기능이 추가되었습니다. (UI는 [지난 PR](https://github.com/BCSDLab/KOIN_WEB_RECODE/pull/827)에서 다루었습니다)

1. 아이디 중복 체크
2. 닉네임 중복 체크
3. 이메일 중복 체크
4. 학번 유효성 검사
5. 회원가입 완료

추가로 이메일 중복 체크는 '회원가입 완료' 버튼을 누를 때 진행됩니다.
중복된 이메일은 가입처리 되지 않고, 이미 존재하는 이메일이라는 경고 메시지를 띄웁니다.
  
  

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

https://github.com/user-attachments/assets/c2cab8ae-f895-438a-87f9-a4d2b16d10a9



## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

#### 아이디
- [x] 아이디 중복 체크가 잘 되는지 확인한다.
- [x] 아이디 중복 체크를 하지 않으면 회원가입 버튼이 활성화 되지 않는 것을 확인한다.
#### 비밀번호
- [x] 비밀번호 일치, 불일치 여부가 잘 되는지 확인한다.
#### 닉네임
- [x] 닉네임 중복 체크가 잘 되는지 확인한다.
- [x] 닉네임이 적혀있을 때, 중복 체크를 하지 않으면 버튼이 활성화 되지 않는지 확인한다.
- [x] 닉네임이 없어도 회원가입이 잘 되는지 확인한다.
#### 이메일
- [x] 이메일이 없어도 회원가입이 잘 되는지 확인한다.
- [x] 이메일이 적혀있을 때, 중복 체크를 하지 않으면 버튼이 활성화 되지 않는 것을 확인한다.
- [x] 중복된 이메일이면 회원가입이 되지 않는 것을 확인한다.
#### 학부, 학번
- [x] 입력되지 않으면 가입 버튼이 활성화 되지 않는 것을 확인한다.
- [x] 학번이 이상하면 경고 메시지를 띄워주는 것을 확인한다.
#### 가입
- [x] 회원가입 완료시, 회원가입 완료 페이지로 넘어가는지 확인한다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
