### PR TITLE
[유저] 회원가입 api 필드 추가 및 에러 수정

### DIFF
--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -25,6 +25,7 @@ export type LoginGeneralRequest = {
   gender: string;
   email: string | null;
   nickname: string | null;
+  marketing_notification_agreement: boolean;
 };
 
 export interface LoginResponse extends APIResponse {

--- a/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { isKoinError } from '@bcsdlab/koin';
 import { useMutation } from '@tanstack/react-query';
 import {
@@ -125,12 +126,12 @@ function ExternalDetail({ onNext, onBack }: ExternalDetailStepProps) {
   const onSubmit = (formData: GeneralFormValues) => {
     const payload = {
       name: formData.name,
+      nickname: formData.nickname === '' ? null : formData.nickname,
+      email: formData.email === '' ? null : formData.email,
       phone_number: formData.phone_number,
+      gender: formData.gender,
       login_id: formData.login_id,
       password: formData.password,
-      gender: formData.gender,
-      email: formData.email === '' ? null : formData.email,
-      nickname: formData.nickname === '' ? null : formData.nickname,
       marketing_notification_agreement: formData.marketing_notification_agreement,
     };
 

--- a/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/ExternalDetailStep/index.tsx
@@ -29,6 +29,7 @@ interface GeneralFormValues {
   gender: string;
   email: string | null;
   nickname: string | null;
+  marketing_notification_agreement: boolean;
 }
 
 function ExternalDetail({ onNext, onBack }: ExternalDetailStepProps) {
@@ -130,6 +131,7 @@ function ExternalDetail({ onNext, onBack }: ExternalDetailStepProps) {
       gender: formData.gender,
       email: formData.email === '' ? null : formData.email,
       nickname: formData.nickname === '' ? null : formData.nickname,
+      marketing_notification_agreement: formData.marketing_notification_agreement,
     };
 
     signup(payload);

--- a/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileExternalDetailStep/index.tsx
@@ -28,6 +28,7 @@ interface GeneralFormValues {
   password_check?: string;
   department?: string;
   student_number?: string;
+  marketing_notification_agreement: boolean;
 }
 
 function MobileExternalDetailStep({ onNext }: MobileExternalDetailStepProps) {

--- a/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
@@ -30,6 +30,7 @@ interface StudentFormValues {
   gender: string;
   email: string | null;
   nickname: string | null;
+  marketing_notification_agreement: boolean;
 }
 
 function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -138,18 +138,21 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
     },
   });
 
-  const onSubmit = async (formData: StudentFormValues) => {
-    const {
-      password_check, email, nickname, ...signupData
-    } = formData;
-    const completeEmail = email ? `${email}@koreatech.ac.kr` : null;
-    const completeNickname = nickname || null;
+  const onSubmit = (formData: StudentFormValues) => {
+    const payload = {
+      name: formData.name,
+      nickname: formData.nickname === '' ? null : formData.nickname,
+      email: formData.email === '' ? null : `${formData.email}@koreatech.ac.kr`,
+      phone_number: formData.phone_number,
+      student_number: formData.student_number,
+      department: formData.department,
+      gender: formData.gender,
+      login_id: formData.login_id,
+      password: formData.password,
+      marketing_notification_agreement: formData.marketing_notification_agreement,
+    };
 
-    signup({
-      ...signupData,
-      email: completeEmail,
-      nickname: completeNickname,
-    });
+    signup(payload);
   };
 
   const checkAndSubmit = () => {
@@ -186,16 +189,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
     if (fieldError) return { type: 'warning', content: MESSAGES.EMAIL.FORMAT };
     return emailMessage;
   };
-
-  // useEffect(() => {
-  //   setIdMessage(null);
-  //   setInCorrectId();
-  // }, [loginId, setInCorrectId]);
-
-  // useEffect(() => {
-  //   setNicknameMessage(null);
-  //   setIsInCorrectNickname();
-  // }, [nicknameControl, setIsInCorrectNickname]);
 
   return (
     <div className={styles.container}>

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -33,6 +33,7 @@ interface StudentFormValues {
   gender: string,
   email: string | null,
   nickname: string | null,
+  marketing_notification_agreement: boolean,
 }
 
 function StudentDetail({ onNext, onBack }: VerificationProps) {

--- a/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -1,9 +1,10 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { isKoinError } from '@bcsdlab/koin';
 import { useMutation } from '@tanstack/react-query';
 import {
   checkId, emailDuplicateCheck, nicknameDuplicateCheck, signupStudent,
 } from 'api/auth';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   Controller, FieldError, useFormContext, useFormState, useWatch,
 } from 'react-hook-form';
@@ -50,7 +51,8 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
   const studentNumber = (useWatch({ control, name: 'student_number' }) ?? '') as string;
 
   const [isCorrectId, setIsCorrectId, setInCorrectId] = useBooleanState(false);
-  const [isCorrectNickname, setIsCorrectNickname, setIsInCorrectNickname] = useBooleanState(false);
+  const [isCorrectNickname, setIsCorrectNickname, setInCorrectNickname] = useBooleanState(false);
+  const [, setIsCorrectEmail, setInCorrectEmail] = useBooleanState(false);
 
   const [major, setMajor] = useState<string | null>(null);
   const [idMessage, setIdMessage] = useState<InputMessage | null>(null);
@@ -77,6 +79,7 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
     mutationFn: emailDuplicateCheck,
     onSuccess: () => {
       setEmailMessage({ type: 'success', content: MESSAGES.EMAIL.AVAILABLE });
+      setIsCorrectEmail();
     },
     onError: (err) => {
       if (isKoinError(err)) {
@@ -137,7 +140,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
 
   const onSubmit = async (formData: StudentFormValues) => {
     const {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       password_check, email, nickname, ...signupData
     } = formData;
     const completeEmail = email ? `${email}@koreatech.ac.kr` : null;
@@ -185,15 +187,15 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
     return emailMessage;
   };
 
-  useEffect(() => {
-    setIdMessage(null);
-    setInCorrectId();
-  }, [loginId, setInCorrectId]);
+  // useEffect(() => {
+  //   setIdMessage(null);
+  //   setInCorrectId();
+  // }, [loginId, setInCorrectId]);
 
-  useEffect(() => {
-    setNicknameMessage(null);
-    setIsInCorrectNickname();
-  }, [nicknameControl, setIsInCorrectNickname]);
+  // useEffect(() => {
+  //   setNicknameMessage(null);
+  //   setIsInCorrectNickname();
+  // }, [nicknameControl, setIsInCorrectNickname]);
 
   return (
     <div className={styles.container}>
@@ -243,6 +245,11 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
               render={({ field, fieldState }) => (
                 <CustomInput
                   {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    setIdMessage(null);
+                    setInCorrectId();
+                  }}
                   placeholder="5~13자리로 입력해 주세요."
                   isButton
                   message={fieldState.error ? { type: 'warning', content: MESSAGES.USERID.REQUIRED } : idMessage}
@@ -343,6 +350,11 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
               render={({ field, fieldState }) => (
                 <CustomInput
                   {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    setNicknameMessage(null);
+                    setInCorrectNickname();
+                  }}
                   placeholder="닉네임은 변경 가능합니다."
                   isDelete
                   isButton
@@ -383,11 +395,9 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
                     placeholder="이메일을 입력해 주세요."
                     message={getEmailMessage(field.value, fieldState.error)}
                     onChange={(e) => {
-                      const { value } = e.target;
                       field.onChange(e);
-                      if (value === '') {
-                        setEmailMessage(null);
-                      }
+                      setEmailMessage(null);
+                      setInCorrectEmail();
                     }}
                     userType="학생"
                     value={field.value ?? ''}

--- a/src/pages/Auth/SignupPage/Steps/Terms/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/Terms/index.tsx
@@ -9,7 +9,7 @@ interface TermsProps {
   onNext: () => void;
 }
 
-const TERMS_NAMES = ['agreeToPrivacyPolicy', 'agreeToKoinTerms', 'agreeToMarketing'];
+const TERMS_NAMES = ['privacy_policy_agreement', 'koin_terms_agreement', 'marketing_notification_agreement'];
 
 export default function Terms({ onNext }: TermsProps) {
   const { register, setValue, watch } = useFormContext();
@@ -43,11 +43,11 @@ export default function Terms({ onNext }: TermsProps) {
           </span>
         </label>
         {!isMobile && <div className={styles['small-divider']} /> }
-        <label className={styles.term} htmlFor="agreeToPrivacyPolicy">
+        <label className={styles.term} htmlFor="privacy_policy_agreement">
           <CustomCheckbox
-            id="agreeToPrivacyPolicy"
-            checked={watch('agreeToPrivacyPolicy')}
-            {...register('agreeToPrivacyPolicy')}
+            id="privacy_policy_agreement"
+            checked={watch('privacy_policy_agreement')}
+            {...register('privacy_policy_agreement')}
           />
           <span className={styles.term__title}>{isMobile ? '개인정보 이용약관(필수)' : '[필수] 개인정보 이용약관'}</span>
         </label>
@@ -61,12 +61,12 @@ export default function Terms({ onNext }: TermsProps) {
             [styles.term]: true,
             [styles['term__koin-use']]: true,
           })}
-          htmlFor="agreeToKoinTerms"
+          htmlFor="koin_terms_agreement"
         >
           <CustomCheckbox
-            id="agreeToKoinTerms"
-            checked={watch('agreeToKoinTerms')}
-            {...register('agreeToKoinTerms')}
+            id="koin_terms_agreement"
+            checked={watch('koin_terms_agreement')}
+            {...register('koin_terms_agreement')}
           />
           <span className={styles.term__title}>
             {isMobile ? '코인 이용약관(필수)' : '[필수] 코인 이용약관'}
@@ -82,12 +82,12 @@ export default function Terms({ onNext }: TermsProps) {
             [styles.term]: true,
             [styles.term__marketing]: true,
           })}
-          htmlFor="agreeToMarketing"
+          htmlFor="marketing_notification_agreement"
         >
           <CustomCheckbox
-            id="agreeToMarketing"
-            checked={watch('agreeToMarketing')}
-            {...register('agreeToMarketing', { required: false })}
+            id="marketing_notification_agreement"
+            checked={watch('marketing_notification_agreement')}
+            {...register('marketing_notification_agreement', { required: false })}
           />
           <span className={styles.term__title}>
             {isMobile ? '마케팅 수신 동의(선택)' : '[선택] 마케팅 수신 동의'}

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/VerificationStep.module.scss
@@ -91,6 +91,10 @@
   }
 }
 
+.input-wrapper {
+  position: relative;
+}
+
 .checkbox-wrapper {
   display: flex;
   gap: 32px;
@@ -161,12 +165,11 @@
   }
 }
 
-.label-link {
+.label-link-wrapper {
   display: flex;
-  position: relative;
-  top: 17px;
-  right: 213px;
-  align-items: flex-start;
+  position: absolute;
+  top: 74px;
+  align-items: center;
 
   &__text {
     font-family: Pretendard, sans-serif;
@@ -183,6 +186,10 @@
     font-weight: 400;
     line-height: 160%;
     color: #175c8e;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
   }
 }
 

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -201,6 +201,11 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
               render={({ field }) => (
                 <CustomInput
                   {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    setPhoneMessage(null);
+                    setIsCodeCorrect(false);
+                  }}
                   placeholder="숫자만 입력해 주세요."
                   isDelete
                   message={phoneMessage}
@@ -263,7 +268,12 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
             render={({ field }) => (
               <CustomInput
                 {...field}
+                onChange={(e) => {
+                  field.onChange(e);
+                  setVerificationMessage(null);
+                }}
                 placeholder="인증번호를 입력해주세요."
+                maxLength={6}
                 isDelete
                 isTimer={isCodeCorrect ? false : isTimer}
                 timerValue={timerValue}

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -229,17 +229,16 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                       로그인하기
                     </button>
 
-                    <div className={styles['label-link']}>
-                      <div className={styles['label-link__text']}>
+                    <div className={styles['label-link-wrapper']}>
+                      <div className={styles['label-link-wrapper__text']}>
                         해당 전화번호로 가입하신 적 없으신가요?
                       </div>
-                      <button
-                        onClick={goToLogin}
-                        type="button"
-                        className={styles['label-link__button']}
+                      <a
+                        href="https://open.kakao.com/o/sgiYx4Qg"
+                        className={styles['label-link-wrapper__button']}
                       >
                         문의하기
-                      </button>
+                      </a>
                     </div>
                   </>
                   )}

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -94,6 +94,7 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
   const { mutate: checkPhoneNumber } = useMutation({
     mutationFn: checkPhone,
     onSuccess: () => {
+      setIsCodeCorrect(false);
       sendSMSToUser({ phone_number: phoneNumber });
     },
     onError: (err) => {
@@ -280,7 +281,7 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                 message={verificationMessage}
                 isButton
                 buttonText="인증번호 확인"
-                buttonDisabled={!field.value}
+                buttonDisabled={!field.value || isCodeCorrect}
                 buttonOnClick={() => {
                   checkVerificationCode({
                     phone_number: phoneNumber,

--- a/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
@@ -141,7 +141,7 @@
       &--domain {
         padding: 8px 0;
       }
-  
+
       &--button {
         padding: 8px 0;
       }

--- a/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
@@ -62,8 +62,9 @@
   align-items: center;
 
   &__input {
-    min-width: 296px;
-    height: 32px;
+    box-sizing: border-box;
+    width: 320px;
+    height: 48px;
     padding: 8px 12px;
     border-radius: 12px;
     border: 1px solid #e1e1e1;
@@ -75,6 +76,14 @@
       font-family: Pretendard, sans-serif;
       color: #cacaca;
       font-size: 12px;
+    }
+
+    &--domain {
+      padding: 8px 130px 8px 12px;
+    }
+
+    &--button {
+      padding: 8px 35px 8px 12px;
     }
   }
 
@@ -113,6 +122,7 @@
   }
 
   @include media.media-breakpoint(mobile) {
+    box-sizing: content-box;
     width: 100%;
 
     &__input {
@@ -126,6 +136,14 @@
 
       &::placeholder {
         font-size: 14px;
+      }
+
+      &--domain {
+        padding: 8px 0;
+      }
+  
+      &--button {
+        padding: 8px 0;
       }
     }
 

--- a/src/pages/Auth/SignupPage/components/CustomInput/index.tsx
+++ b/src/pages/Auth/SignupPage/components/CustomInput/index.tsx
@@ -67,6 +67,7 @@ const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>((
   };
 
   const inputType = getInputType();
+  const isDomain = args.name === 'email' && userType === '학생';
 
   return (
     <div className={styles.container}>
@@ -75,7 +76,11 @@ const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>((
 
           <input
             ref={ref}
-            className={styles['input-wrapper__input']}
+            className={cn({
+              [styles['input-wrapper__input']]: true,
+              [styles['input-wrapper__input--domain']]: isDomain,
+              [styles['input-wrapper__input--button']]: Boolean(isDelete || isVisibleButton),
+            })}
             type={inputType}
             placeholder={placeholder}
             value={value}

--- a/src/pages/Auth/SignupPage/index.tsx
+++ b/src/pages/Auth/SignupPage/index.tsx
@@ -43,6 +43,7 @@ function SignupPage() {
       email: null,
       nickname: null,
       verification_code: '',
+      marketing_notification_agreement: false,
     },
   });
 


### PR DESCRIPTION
- Close #849 
  
## What is this PR? 🔍

- 기능 : api 필드 추가 및 에러 수정을 진행하였습니다.
- issue : #849 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
* 학생 회원가입(문자 인증)과 일반인 회원가입(문자 인증)의 Request body에 추가된 필드를 수정하였습니다.
* 기존에 `useEffect`를 많이 사용하는 방식 대신, `react-form-hook`의 `onChange`를 활용하여 코드를 리팩토링하였습니다.
* 회의 때 진행한 임시 QA에서 나온 이슈를 해결하였습니다.
  * input의 padding 조절
  * 문자 인증 에러 메시지 위치 조절



## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

https://github.com/user-attachments/assets/cd373180-4ee5-45b3-b3f2-c3b8118ea786


## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
