### PR TITLE
[유저] 회원가입 UI 에러 수정

### DIFF
--- a/src/pages/Auth/AuthPage/Auth.module.scss
+++ b/src/pages/Auth/AuthPage/Auth.module.scss
@@ -24,7 +24,7 @@
     justify-content: center;
 
     @include media.media-breakpoint(mobile) {
-      margin: 0 48px;
+      margin: 0 24px;
     }
   }
 

--- a/src/pages/Auth/SignupPage/SignupPage.module.scss
+++ b/src/pages/Auth/SignupPage/SignupPage.module.scss
@@ -3,9 +3,9 @@
 .container {
   @include media.media-breakpoint(mobile) {
     width: 100%;
-    height: 100vh;
+    height: 100dvh;
     box-sizing: border-box;
-    padding: 32px 24px 40px;
+    padding: 32px 0 40px;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/MobileVerification.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/MobileVerification.module.scss
@@ -156,3 +156,17 @@
     }
   }
 }
+
+.input {
+  &__error-message {
+    @include media.media-breakpoint(mobile) {
+      display: flex;
+      gap: 8px;
+      font-weight: 400;
+      font-size: 12px;
+      line-height: 160%;
+      color: #727272;
+      margin-top: -16px;
+    }
+  }
+}

--- a/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
@@ -6,9 +6,9 @@ import { checkPhone, smsSend, smsVerify } from 'api/auth';
 import { useMutation } from '@tanstack/react-query';
 import { isKoinError } from '@bcsdlab/koin';
 import { GENDER_OPTIONS, MESSAGES } from 'static/auth';
-import ROUTES from 'static/routes';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
 import type { SmsSendResponse } from 'api/auth/entity';
+import ROUTES from 'static/routes';
 import useCountdownTimer from '../../hooks/useCountdownTimer';
 import styles from './MobileVerification.module.scss';
 
@@ -169,7 +169,7 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
                     </div>
                   )}
                   {
-                    phoneMessage?.type === 'error' && (
+                    phoneMessage?.type === 'error' && phoneMessage?.content === '이미 가입된 전화 번호입니다.' && (
                       <a href={ROUTES.Auth()} className={styles['label-link-button']}>로그인하기</a>
                     )
                   }
@@ -177,6 +177,12 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
               )}
             />
           </div>
+          {phoneMessage?.type === 'error' && phoneMessage?.content === '이미 가입된 전화 번호입니다.' && (
+            <div className={styles['input__error-message']}>
+              해당 전화번호로 가입하신 적 없으신가요?
+              <a href={ROUTES.Inquery()} target="_blank" rel="noopener noreferrer" className={styles['label-link-button']}>로그인하기</a>
+            </div>
+          )}
 
           {isVerificationShown && (
           <div className={styles['input-wrapper']}>
@@ -206,7 +212,6 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
                     >
                       문의하기
                     </a>
-
                   )}
                 </CustomInput>
               )}

--- a/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
@@ -180,7 +180,7 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
           {phoneMessage?.type === 'error' && phoneMessage?.content === '이미 가입된 전화 번호입니다.' && (
             <div className={styles['input__error-message']}>
               해당 전화번호로 가입하신 적 없으신가요?
-              <a href={ROUTES.Inquery()} target="_blank" rel="noopener noreferrer" className={styles['label-link-button']}>로그인하기</a>
+              <a href={ROUTES.Inquery()} target="_blank" rel="noopener noreferrer" className={styles['label-link-button']}>문의하기</a>
             </div>
           )}
 

--- a/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
@@ -180,7 +180,7 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
           {phoneMessage?.type === 'error' && phoneMessage?.content === '이미 가입된 전화 번호입니다.' && (
             <div className={styles['input__error-message']}>
               해당 전화번호로 가입하신 적 없으신가요?
-              <a href={ROUTES.Inquery()} target="_blank" rel="noopener noreferrer" className={styles['label-link-button']}>문의하기</a>
+              <a href={ROUTES.Inquiry()} target="_blank" rel="noopener noreferrer" className={styles['label-link-button']}>문의하기</a>
             </div>
           )}
 

--- a/src/pages/Auth/SignupPage/Steps/Terms/Terms.module.scss
+++ b/src/pages/Auth/SignupPage/Steps/Terms/Terms.module.scss
@@ -148,6 +148,7 @@
   }
 
   @include media.media-breakpoint(mobile) {
+    width: 100%;
     margin-top: 32px;
     padding: 12px 0;
     height: 50px;

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -240,10 +240,8 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                         해당 전화번호로 가입하신 적 없으신가요?
                       </div>
                       <a
-                        href={ROUTES.Inquery()}
+                        href="https://open.kakao.com/o/sgiYx4Qg"
                         className={styles['label-link-wrapper__button']}
-                        target="_blank"
-                        rel="noopener noreferrer"
                       >
                         문의하기
                       </a>

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -225,7 +225,7 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                       /5)
                     </div>
                   )}
-                  {phoneMessage?.type === 'error' && (
+                  {phoneMessage?.type === 'error' && phoneMessage?.content === '이미 가입된 전화 번호입니다.' && (
                   <>
                     <button
                       onClick={goToLogin}
@@ -240,8 +240,10 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                         해당 전화번호로 가입하신 적 없으신가요?
                       </div>
                       <a
-                        href="https://open.kakao.com/o/sgiYx4Qg"
+                        href={ROUTES.Inquery()}
                         className={styles['label-link-wrapper__button']}
+                        target="_blank"
+                        rel="noopener noreferrer"
                       >
                         문의하기
                       </a>

--- a/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
+++ b/src/pages/Auth/SignupPage/components/CustomInput/CustomInput.module.scss
@@ -134,6 +134,10 @@
       border-radius: 0;
       font-size: 13px;
 
+      &:focus {
+        outline: none;
+      }
+
       &::placeholder {
         font-size: 14px;
       }
@@ -143,7 +147,7 @@
       }
 
       &--button {
-        padding: 8px 0;
+        padding: 8px 24px 8px 4px;
       }
     }
 

--- a/src/static/routes.ts
+++ b/src/static/routes.ts
@@ -48,6 +48,7 @@ const ROUTES = {
   Webview: () => '/webview',
   WebviewCampusInfo: () => '/webview/campusinfo',
   PrivatePolicy: () => '/policy',
+  Inquery: () => 'https://forms.gle/qYw17r2kihThiJvj7',
 };
 
 export default ROUTES;

--- a/src/static/routes.ts
+++ b/src/static/routes.ts
@@ -48,7 +48,7 @@ const ROUTES = {
   Webview: () => '/webview',
   WebviewCampusInfo: () => '/webview/campusinfo',
   PrivatePolicy: () => '/policy',
-  Inquery: () => 'https://forms.gle/qYw17r2kihThiJvj7',
+  Inquiry: () => 'https://forms.gle/qYw17r2kihThiJvj7',
 };
 
 export default ROUTES;


### PR DESCRIPTION
  ## What is this PR? 🔍

- 기능 : 회원가입 UI 에러 수정

## Changes 📝
- 전체 UI의 Layout margin, padding 변경
- 에러 메시지 별 다른 UI 적용
  - 요청 횟수 초과 시 `로그인하기` 링크 삭제
  - 이미 가입된 전화번호 일 때 `로그인하기` 링크와 `문의하기` 링크 및 문구 추가
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
https://github.com/user-attachments/assets/db29b63e-4029-40e5-8cab-3ec9700b8b97

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
