### PR TITLE
[유저] 로그인 API 버전 업 및 유저 상태 관리 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ import MobileFindIdEmailPage from 'pages/Auth/FindIdPage/Mobile/EmailPage';
 import MobileFindIdPhonePage from 'pages/Auth/FindIdPage/Mobile/PhonePage';
 import MobileFindIdResultPage from 'pages/Auth/FindIdPage/Mobile/ResultPage';
 import FindIdResultPage from 'pages/Auth/FindIdPage/PC/ResultPage';
+import ProtectedLostItemChatPage from 'pages/Articles/LostItemChatPage/ProtectedLostItemChatPage';
 
 interface WrapperProps {
   title: string;
@@ -119,7 +120,7 @@ function App() {
           </Route>
           <Route path={ROUTES.LostItemFound()} element={<Wrapper title="습득물 글쓰기" element={<LostItemWritePage />} />} />
           <Route path={ROUTES.LostItemLost()} element={<Wrapper title="분실물 글쓰기" element={<LostItemWritePage />} />} />
-          <Route path={ROUTES.LostItemChat()} element={<Wrapper needAuth title="분실물 쪽지" element={<LostItemChatPage />} />} />
+          <Route path={ROUTES.LostItemChat()} element={<Wrapper needAuth title="분실물 쪽지" element={<ProtectedLostItemChatPage />} />} />
           <Route path={ROUTES.CampusInfo()} element={<Wrapper title="교내 시설물 정보" element={<CampusInfo />} />} />
           {!isMobile && <Route path={ROUTES.AuthSignup({ isLink: false })} element={<Wrapper title="회원가입" element={<SignupPage />} />} />}
           {!isMobile && (
@@ -142,7 +143,6 @@ function App() {
           <Route path={ROUTES.AuthFindPW()} element={<Wrapper title="비밀번호 찾기" element={<FindPasswordPage />} />} />
           <Route path={ROUTES.AuthModifyInfo()} element={<Wrapper needAuth title="유저 정보변경" element={<ModifyInfoPage />} />} />
         </Route>
-
         <Route path={ROUTES.Webview()}>
           <Route path={ROUTES.WebviewCampusInfo()} element={<Wrapper title="코인 - 교내 시설물 정보" element={<CampusInfo />} />} />
         </Route>

--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -38,12 +38,13 @@ import {
   EmailExistsRequest,
   IdFindSmsResponse,
   IdFindSmsRequest,
+  GeneralUserResponse,
 } from './entity';
 
 export class Login<R extends LoginResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
 
-  path = '/user/login';
+  path = '/v2/users/login';
 
   response!: R;
 
@@ -107,6 +108,18 @@ export class User<R extends UserResponse> implements APIRequest<R> {
   method = HTTP_METHOD.GET;
 
   path = '/user/student/me';
+
+  response!: R;
+
+  auth = false;
+
+  constructor(public authorization: string) { }
+}
+
+export class GeneralUser<R extends GeneralUserResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path = '/v2/users/me';
 
   response!: R;
 

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -1,8 +1,8 @@
 import { APIResponse } from 'interfaces/APIResponse';
 
 export type LoginRequest = {
-  email: string;
-  password: string;
+  login_id: string;
+  login_pw: string;
 };
 
 export type LoginStudentRequest = {
@@ -31,7 +31,7 @@ export type LoginGeneralRequest = {
 export interface LoginResponse extends APIResponse {
   token: string;
   refresh_token: string;
-  userType: 'STUDENT';
+  user_type: 'STUDENT' | 'GENERAL';
 }
 
 export interface NicknameDuplicateCheckResponse extends APIResponse {
@@ -86,6 +86,17 @@ export interface UserResponse extends APIResponse {
   nickname: string;
   phone_number: string;
   student_number: string;
+}
+
+export interface GeneralUserResponse extends APIResponse {
+  id: number;
+  login_id: string;
+  email: string;
+  gender: 0 | 1;
+  name: string;
+  nickname: string;
+  phone_number: string;
+  user_type: 'GENERAL';
 }
 
 export interface UserAcademicInfoResponse extends APIResponse {

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -6,6 +6,7 @@ import {
   SignupStudent,
   SignupGeneral,
   User,
+  GeneralUser,
   UserAcademicInfo,
   UpdateUser,
   FindPassword,
@@ -36,6 +37,8 @@ export const signupGeneral = APIClient.of(SignupGeneral);
 export const refresh = APIClient.of(Refresh);
 
 export const getUser = APIClient.of(User);
+
+export const getGeneralUser = APIClient.of(GeneralUser);
 
 export const getUserAcademicInfo = APIClient.of(UserAcademicInfo);
 

--- a/src/components/analytics/PageViewTracker/index.tsx
+++ b/src/components/analytics/PageViewTracker/index.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import * as gtag from 'lib/gtag';
 import { UserResponse } from 'api/auth/entity';
 import { useUser } from 'utils/hooks/state/useUser';
+import { isStudentUser } from 'utils/ts/userTypeGuards';
 
 const userUniqueIdGenerator = (userInfo: UserResponse | null) => {
   if (!userInfo) {
@@ -37,7 +38,11 @@ export default function PageViewTracker() {
   const { data: userInfo } = useUser();
   const prevPathname = useRef('');
 
+  const isStudent = userInfo && isStudentUser(userInfo);
+
   useEffect(() => {
+    if (!isStudent) return;
+
     const handlePageView = () => {
       if (prevPathname.current !== window.location.pathname) {
         setTimeout(() => {
@@ -50,6 +55,6 @@ export default function PageViewTracker() {
       }
     };
     handlePageView();
-  }, [location, userInfo]);
+  }, [location, userInfo, isStudent]);
   return null;
 }

--- a/src/pages/Articles/LostItemChatPage/ProtectedLostItemChatPage.tsx
+++ b/src/pages/Articles/LostItemChatPage/ProtectedLostItemChatPage.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import ROUTES from 'static/routes';
+import { useUser } from 'utils/hooks/state/useUser';
+import { isStudentUser } from 'utils/ts/userTypeGuards';
+import LostItemChatPage from '.';
+
+export default function ProtectedLostItemChatPage() {
+  const { data: userInfo } = useUser();
+
+  if (!userInfo || !isStudentUser(userInfo)) {
+    return <Navigate to={ROUTES.NotFound()} replace />;
+  }
+
+  return <LostItemChatPage userInfo={userInfo} />;
+}

--- a/src/pages/Auth/LoginPage/components/LoginForm/index.tsx
+++ b/src/pages/Auth/LoginPage/components/LoginForm/index.tsx
@@ -33,7 +33,7 @@ export default function LoginForm() {
     const userId = userIdInput ? userIdInput.value : '';
     const password = passwordInput ? passwordInput.value : '';
 
-    submitLogin({ userId, password });
+    submitLogin({ login_id: userId, login_pw: password });
   };
 
   return (

--- a/src/pages/TimetablePage/hooks/useMySemester.ts
+++ b/src/pages/TimetablePage/hooks/useMySemester.ts
@@ -1,13 +1,15 @@
 import { timetable } from 'api';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useTokenStore } from 'utils/zustand/auth';
 
 export const MY_SEMESTER_INFO_KEY = 'my_semester';
 
 function useSemesterCheck(token: string) {
+  const { userType } = useTokenStore();
   const { data } = useSuspenseQuery(
     {
       queryKey: [MY_SEMESTER_INFO_KEY],
-      queryFn: () => (token ? timetable.getMySemester(token) : null),
+      queryFn: () => ((token && userType === 'STUDENT') ? timetable.getMySemester(token) : null),
     },
   );
 

--- a/src/pages/TimetablePage/hooks/useTimetableFrameList.ts
+++ b/src/pages/TimetablePage/hooks/useTimetableFrameList.ts
@@ -1,15 +1,17 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { timetable } from 'api';
 import { Semester } from 'api/timetable/entity';
+import { useTokenStore } from 'utils/zustand/auth';
 
 export const TIMETABLE_FRAME_KEY = 'timetable_frame';
 
 function useTimetableFrameList(token: string, semester: Semester) {
+  const { userType } = useTokenStore();
   const { data } = useSuspenseQuery(
     {
       queryKey: [TIMETABLE_FRAME_KEY + semester.year + semester.term],
       queryFn: async () => {
-        if (token) {
+        if (token && userType === 'STUDENT') {
           try {
             return await timetable.getTimetableFrame(token, semester);
           } catch (error) {

--- a/src/utils/hooks/state/useUser.ts
+++ b/src/utils/hooks/state/useUser.ts
@@ -1,12 +1,25 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { getUser } from 'api/auth';
-import { useTokenStore } from 'utils/zustand/auth';
+import { getGeneralUser, getUser } from 'api/auth';
+import { GeneralUserResponse, UserResponse } from 'api/auth/entity';
+import { UserType, useTokenStore } from 'utils/zustand/auth';
+
+export type UnionUserResponse = UserResponse | GeneralUserResponse;
+
+const getUserInfo = async (token: string, userType: UserType): Promise<UnionUserResponse> => {
+  if (userType === 'STUDENT') {
+    return getUser(token);
+  }
+  return getGeneralUser(token);
+};
 
 export const useUser = () => {
-  const { token } = useTokenStore();
+  const { token, userType } = useTokenStore();
   const { data, isError } = useSuspenseQuery({
-    queryKey: ['userInfo', token],
-    queryFn: () => (token ? getUser(token) : null),
+    queryKey: ['userInfo', token, userType],
+    queryFn: () => {
+      if (!token) return null;
+      return getUserInfo(token, userType);
+    },
   });
 
   return {

--- a/src/utils/ts/userTypeGuards.ts
+++ b/src/utils/ts/userTypeGuards.ts
@@ -1,0 +1,10 @@
+import { UserResponse } from 'api/auth/entity';
+import { UnionUserResponse } from 'utils/hooks/state/useUser';
+
+export function isStudentUser(user: UnionUserResponse): user is UserResponse {
+  return (user as UserResponse).student_number !== undefined;
+}
+
+export function isGeneralUser(user: UnionUserResponse): user is UserResponse {
+  return (user as UserResponse).student_number === undefined;
+}

--- a/src/utils/zustand/auth.ts
+++ b/src/utils/zustand/auth.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { getCookie } from 'utils/ts/cookie';
 
-export type UserType = 'STUDENT' | 'GENERAL' | null;
+export type UserType = 'STUDENT' | 'GENERAL';
 
 type State = {
   token: string;

--- a/src/utils/zustand/auth.ts
+++ b/src/utils/zustand/auth.ts
@@ -2,14 +2,18 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { getCookie } from 'utils/ts/cookie';
 
+export type UserType = 'STUDENT' | 'GENERAL' | null;
+
 type State = {
   token: string;
   refreshToken: string;
+  userType: UserType;
 };
 
 type Actions = {
   setToken: (token: string) => void;
   setRefreshToken: (refreshToken: string) => void;
+  setUserType: (userType: UserType) => void;
 };
 
 export const useTokenStore = create(
@@ -17,12 +21,17 @@ export const useTokenStore = create(
     (set) => ({
       token: getCookie('AUTH_TOKEN_KEY') || '',
       refreshToken: '',
+      userType: (getCookie('AUTH_USER_TYPE') || null) as UserType,
       setToken: (token) => set({ token }),
       setRefreshToken: (refreshToken) => set({ refreshToken }),
+      setUserType: (userType) => set({ userType }),
     }),
     {
       name: 'refresh-token-storage',
-      partialize: (state) => ({ refreshToken: state.refreshToken }) as State & Actions,
+      partialize: (state) => ({
+        refreshToken: state.refreshToken,
+        userType: state.userType,
+      }) as State & Actions,
     },
   ),
 );


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 로그인 API 버전 업 및 유저 상태 관리 변경

## Changes 📝
- 로그인 API를 v2로 업데이트
- 유저 상태 관리 변경
  - 일반 유저 추가
  - `useUser`에서 일반 유저도 사용 가능하도록 추가
  - `isStudent` `isGeneralUser` 타입 가드 추가

- `학생 Response` 만 필요로 하는 곳의 타입 가드 추가

## Precaution
일부 타입 가드가 적용 안된 부분이 있는데(정보 수정 페이지) 그 부분은 추후 PR에 올라올 예정입니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
