### PR TITLE
[유저] 이메일로 비밀번호 찾기 페이지 추가

### DIFF
--- a/src/api/auth/APIDetail.ts
+++ b/src/api/auth/APIDetail.ts
@@ -402,7 +402,7 @@ export class IdMatchPhone<R extends IdMatchPhoneResponse> implements APIRequest<
 export class IdMatchEmail<R extends IdMatchEmailResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
 
-  path = '/users/id/match/phone';
+  path = '/users/id/match/email';
 
   response!: R;
 

--- a/src/pages/Auth/FindIdPage/PC/ResultPage/index.tsx
+++ b/src/pages/Auth/FindIdPage/PC/ResultPage/index.tsx
@@ -10,7 +10,7 @@ function ResultPage() {
     navigate(ROUTES.Auth());
   };
   const onClickPassword = () => {
-    navigate(ROUTES.AuthFindPW());
+    navigate(ROUTES.AuthFindPW({ step: '계정인증', isLink: true }));
   };
 
   return (

--- a/src/pages/Auth/FindPasswordPage/PC/PCResetPasswordPhone/PCResetPasswordPhone.module.scss
+++ b/src/pages/Auth/FindPasswordPage/PC/PCResetPasswordPhone/PCResetPasswordPhone.module.scss
@@ -63,7 +63,6 @@
   label {
     justify-self: start;
     font-size: 18px;
-    font-style: normal;
     font-weight: 400;
     line-height: 160%;
 

--- a/src/pages/Auth/FindPasswordPage/PC/PCResetPasswordPhone/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/PC/PCResetPasswordPhone/index.tsx
@@ -2,7 +2,7 @@ import {
   Controller, useFormContext, useWatch, FieldError,
 } from 'react-hook-form';
 import { ContactType, MESSAGES, REGEX } from 'static/auth';
-import { cn } from '@bcsdlab/utils';
+import { cn, sha256 } from '@bcsdlab/utils';
 import BackIcon from 'assets/svg/arrow-back.svg';
 import PCCustomInput, { type InputMessage } from 'pages/Auth/SignupPage/components/PCCustomInput';
 import { isKoinError } from '@bcsdlab/koin';
@@ -74,20 +74,21 @@ function PCResetPasswordPhone({ onNext, onBack, contactType }: PCResetPasswordPh
     },
   });
 
-  const onClickSubmit = () => {
+  const onClickSubmit = async () => {
     const { loginId, email, phoneNumber } = getValues();
+    const hashedPassword = await sha256(newPassword);
 
     if (contactType === 'PHONE') {
       submitResetPasswordSms({
         login_id: loginId,
         phone_number: phoneNumber,
-        new_password: newPassword,
+        new_password: hashedPassword,
       });
     } else {
       submitResetPasswordEmail({
         login_id: loginId,
         email,
-        new_password: newPassword,
+        new_password: hashedPassword,
       });
     }
   };

--- a/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/PCVerifyEmail.module.scss
+++ b/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/PCVerifyEmail.module.scss
@@ -1,0 +1,193 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 640px;
+  margin: 120px 0 300px;
+  font-family: Pretendard, sans-serif;
+
+  &__wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  &__title-wrapper {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__back-button {
+    position: absolute;
+    left: 0;
+  }
+
+  &__title {
+    text-align: center;
+    font-size: 30px;
+    font-weight: 700;
+  }
+}
+
+.divider {
+  width: 640px;
+  border: 2px solid #175c8e;
+
+  &--top {
+    margin: 64px 0 48px;
+  }
+
+  &--bottom {
+    margin: 48px 0;
+  }
+}
+
+.form-container {
+  display: flex;
+  flex-direction: column;
+  width: 592px;
+  justify-content: center;
+  gap: 48px;
+}
+
+.input-wrapper {
+  width: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  &__input {
+    box-sizing: border-box;
+    width: 320px;
+    height: 48px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    border: 1px solid #e1e1e1;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 160%;
+
+    &::placeholder {
+      font-family: Pretendard, sans-serif;
+      color: #cacaca;
+      font-size: 12px;
+    }
+
+    &--button {
+      padding: 8px 35px 8px 12px;
+    }
+  }
+
+  &__optionButton {
+    position: absolute;
+    right: 12px;
+    display: flex;
+    background: none;
+    cursor: pointer;
+  }
+}
+
+.contactType-wrapper {
+  display: flex;
+  gap: 80px;
+  align-items: center;
+  font-family: Pretendard, sans-serif;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 160%;
+}
+
+.checkbox-wrapper {
+  display: flex;
+  gap: 32px;
+
+  &__checkbox {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.label-count-number {
+  color: #727272;
+  font-family: Pretendard, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 160%;
+  margin-left: 8px;
+}
+
+.input-with-button {
+  display: flex;
+  gap: 16px;
+  position: relative;
+}
+
+.check-button {
+  display: flex;
+  width: 120px;
+  height: 48px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 12px;
+  border: 1px solid #175c8e;
+  color: #175c8e;
+  font-family: Pretendard, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 160%;
+
+  &:disabled {
+    border: 1px solid #e1e1e1;
+    color: #cacaca;
+    cursor: not-allowed;
+  }
+}
+
+.button-next {
+  display: flex;
+  width: 320px;
+  height: 64px;
+  padding: 10px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 16px;
+  background: #cacaca;
+  color: #fff;
+  text-align: center;
+  font-family: Pretendard, sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 160%;
+
+  &--active {
+    background-color: #175c8e;
+  }
+}
+
+.email-navigate {
+  display: flex;
+  position: absolute;
+  left: 140px;
+
+  &__text {
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 160%;
+    color: #727272;
+  }
+
+  &__link {
+    font-family: Pretendard, sans-serif;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 160%;
+    color: #175c8e;
+    margin-left: 8px;
+  }
+}

--- a/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/index.tsx
@@ -1,24 +1,232 @@
-interface PCVerifyEmailProps {
+import { isKoinError } from '@bcsdlab/koin';
+import { cn } from '@bcsdlab/utils';
+import BackIcon from 'assets/svg/arrow-back.svg';
+import PCCustomInput from 'pages/Auth/SignupPage/components/PCCustomInput';
+import { useState } from 'react';
+import {
+  Controller, useFormContext, useWatch,
+} from 'react-hook-form';
+import { ContactType, MESSAGES } from 'static/auth';
+import useEmailVerification from 'utils/hooks/auth/useEmailVerification';
+import styles from './PCVerifyEmail.module.scss';
+
+interface FindPasswordProps {
   onNext: () => void;
   onBack: () => void;
+  setContactType: (type: ContactType) => void;
 }
 
-function PCVerifyEmail({ onNext, onBack }: PCVerifyEmailProps) {
+function PCVerifyEmail({ onNext, onBack, setContactType }: FindPasswordProps) {
+  const { control, setValue } = useFormContext();
+
+  const loginId = useWatch({ control, name: 'loginId' });
+
+  const email = useWatch({ control, name: 'email' });
+  const verificationCode = useWatch({ control, name: 'verificationCode' });
+
+  const [buttonText, setButtonText] = useState('인증번호 발송');
+
+  const {
+    emailMessage,
+    checkEmailExists,
+    checkVerificationEmailVerify,
+    isDisabled,
+    isVerified,
+    isCodeVerified,
+    smsSendCount,
+    isCodeCorrect,
+    setIncorrect,
+    setEmailMessage,
+    setVerificationMessage,
+    verificationMessage,
+    isTimer,
+    timerValue,
+    stopTimer,
+    checkIdExists,
+    checkIdMatchEmail,
+    idMessage,
+    setIdMessage,
+  } = useEmailVerification({ email, onNext });
+
+  const onClickSendVerificationButton = () => {
+    checkVerificationEmailVerify({ email, verification_code: verificationCode });
+  };
+
+  const handleNext = () => {
+    checkIdExists({
+      login_id: loginId,
+    }, {
+      onSuccess: () => {
+        // 아이디가 존재할 경우, 아이디-이메일 일치 여부 확인
+        setContactType('EMAIL');
+        checkIdMatchEmail({
+          login_id: loginId,
+          email,
+        });
+      },
+      onError: (err) => {
+        if (isKoinError(err)) {
+          if (err.status === 404) {
+            setIdMessage({ type: 'warning', content: MESSAGES.EMAIL.NOT_REGISTERED });
+          } else if (err.status === 400) {
+            setIdMessage({ type: 'warning', content: MESSAGES.EMAIL.FORMAT });
+          }
+        }
+      },
+    });
+  };
+
+  const isFormFilled = loginId && email && verificationCode && isCodeCorrect;
+
   return (
-    <div>
-      PC Email 인증 페이지
-      <button
-        type="button"
-        onClick={onNext}
-      >
-        Next 버튼
-      </button>
+    <div className={styles.container}>
+
+      <div className={styles.container__wrapper}>
+        <div className={styles['container__title-wrapper']}>
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="뒤로가기"
+            className={styles['container__back-button']}
+          >
+            <BackIcon />
+          </button>
+          <h1 className={styles.container__title}>비밀번호 찾기</h1>
+        </div>
+      </div>
+
+      <div className={`${styles.divider} ${styles['divider--top']}`} />
+
+      <div className={styles['form-container']}>
+
+        <div className={styles['input-wrapper']}>
+          <Controller
+            name="loginId"
+            control={control}
+            defaultValue=""
+            render={({ field }) => (
+              <PCCustomInput
+                {...field}
+                htmlFor="loginId"
+                labelName="아이디"
+                placeholder="아이디를 입력해 주세요."
+                isDelete
+                isRequired
+                message={idMessage}
+              />
+            )}
+          />
+        </div>
+
+        <div className={styles['input-wrapper']}>
+          <Controller
+            name="email"
+            control={control}
+            defaultValue=""
+            render={({ field }) => (
+              <div className={styles['input-with-button']}>
+                <PCCustomInput
+                  htmlFor="email"
+                  labelName="이메일"
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    setEmailMessage(null);
+                    stopTimer();
+                    setIncorrect();
+                    setVerificationMessage(null);
+                    setValue('verificationCode', ''); // 변화가 있을시 인증코드 값을 삭제합니다.
+                  }}
+                  placeholder="이메일을 입력해 주세요."
+                  isRequired
+                  message={emailMessage}
+                  disabled={isVerified}
+                  isDelete={!isVerified}
+                  onClear={() => {
+                    setEmailMessage(null);
+                    setButtonText('인증번호 발송');
+                  }}
+                >
+                  {emailMessage?.type === 'success' && (
+                    <div className={styles['label-count-number']}>
+                      {' '}
+                      남은 횟수 (
+                      {smsSendCount}
+                      /5)
+                    </div>
+                  )}
+                </PCCustomInput>
+                <button
+                  type="button"
+                  onClick={() => {
+                    checkEmailExists({ email });
+                  }}
+                  className={styles['check-button']}
+                  disabled={!field.value || isDisabled || isVerified}
+                >
+                  {buttonText}
+                </button>
+              </div>
+
+            )}
+          />
+        </div>
+
+        <div className={styles['input-wrapper']}>
+          <Controller
+            name="verificationCode"
+            control={control}
+            defaultValue=""
+            render={({ field }) => (
+              <div className={styles['input-with-button']}>
+                <PCCustomInput
+                  {...field}
+                  htmlFor="verificationCode"
+                  labelName="이메일 인증"
+                  onChange={(e) => {
+                    field.onChange(e);
+                    setVerificationMessage(null);
+                  }}
+                  placeholder="인증번호를 입력해주세요."
+                  isRequired
+                  maxLength={6}
+                  isTimer={isCodeCorrect ? false : isTimer}
+                  timerValue={timerValue}
+                  message={verificationMessage}
+                  disabled={isCodeVerified}
+                  isDelete={!isVerified}
+                  onClear={() => {
+                    setVerificationMessage(null);
+                    setIncorrect();
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => onClickSendVerificationButton()}
+                  className={styles['check-button']}
+                  disabled={!field.value || isCodeCorrect}
+                >
+                  인증번호 확인
+                </button>
+              </div>
+            )}
+          />
+        </div>
+
+      </div>
+
+      <div className={`${styles.divider} ${styles['divider--bottom']}`} />
 
       <button
         type="button"
-        onClick={onBack}
+        onClick={handleNext}
+        className={cn({
+          [styles['button-next']]: true,
+          [styles['button-next--active']]: isFormFilled,
+        })}
+        disabled={!isFormFilled}
       >
-        Back 버튼
+        다음
       </button>
     </div>
   );

--- a/src/pages/Auth/FindPasswordPage/PC/PCVerifyPhone/PCVerifyPhone.module.scss
+++ b/src/pages/Auth/FindPasswordPage/PC/PCVerifyPhone/PCVerifyPhone.module.scss
@@ -190,5 +190,4 @@
     color: #175c8e;
     margin-left: 8px;
   }
-  
 }

--- a/src/pages/Auth/FindPasswordPage/PC/PCVerifyPhone/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/PC/PCVerifyPhone/index.tsx
@@ -84,7 +84,6 @@ function PCVerifyPhone({
 
   return (
     <div className={styles.container}>
-
       <div className={styles.container__wrapper}>
         <div className={styles['container__title-wrapper']}>
           <button
@@ -102,7 +101,6 @@ function PCVerifyPhone({
       <div className={`${styles.divider} ${styles['divider--top']}`} />
 
       <div className={styles['form-container']}>
-
         <div className={styles['input-wrapper']}>
           <Controller
             name="loginId"
@@ -184,7 +182,6 @@ function PCVerifyPhone({
                       이메일로 찾기
                     </button>
                   </div>
-
                 )}
               </div>
             )}
@@ -231,7 +228,6 @@ function PCVerifyPhone({
             )}
           />
         </div>
-
       </div>
 
       <div className={`${styles.divider} ${styles['divider--bottom']}`} />

--- a/src/utils/hooks/auth/useEmailVerification.ts
+++ b/src/utils/hooks/auth/useEmailVerification.ts
@@ -111,7 +111,7 @@ function useEmailVerification({ email, onNext }: UseEmailVerificationProps) {
   const { mutate: checkIdMatchEmail } = useMutation({
     mutationFn: idMatchEmail,
     onSuccess: () => {
-      if (onNext) onNext(); // 다음 단계로 이동
+      if (onNext) onNext();
     },
     onError: (err) => {
       if (isKoinError(err)) {

--- a/src/utils/hooks/auth/useEmailVerification.ts
+++ b/src/utils/hooks/auth/useEmailVerification.ts
@@ -2,7 +2,7 @@ import useBooleanState from 'utils/hooks/state/useBooleanState';
 import { type InputMessage } from 'pages/Auth/SignupPage/components/CustomInput';
 import useCountdownTimer from 'pages/Auth/SignupPage/hooks/useCountdownTimer';
 import {
-  emailExists, verificationEmailSend, verificationEmailVerify, idFindEmail,
+  emailExists, verificationEmailSend, verificationEmailVerify, idFindEmail, idExists, idMatchEmail,
 } from 'api/auth';
 import { MESSAGES } from 'static/auth';
 import { isKoinError } from '@bcsdlab/koin';
@@ -10,8 +10,14 @@ import ROUTES from 'static/routes';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
+import showToast from 'utils/ts/showToast';
 
-function useEmailVerification({ email }: { email: string }) {
+interface UseEmailVerificationProps {
+  email: string;
+  onNext?: () => void;
+}
+
+function useEmailVerification({ email, onNext }: UseEmailVerificationProps) {
   const navigate = useNavigate();
   const [verificationMessage, setVerificationMessage] = useState<InputMessage | null>(null);
   const [emailMessage, setEmailMessage] = useState<InputMessage | null>(null);
@@ -19,6 +25,7 @@ function useEmailVerification({ email }: { email: string }) {
   const [isVerified, enableVerified] = useBooleanState(false);
   const [isCodeVerified, enableCodeVerified] = useBooleanState(false);
   const [isCodeCorrect, setCorrect, setIncorrect] = useBooleanState(false);
+  const [idMessage, setIdMessage] = useState<InputMessage | null>(null);
 
   const [smsSendCount, setSmsSendCount] = useState(0);
 
@@ -55,7 +62,7 @@ function useEmailVerification({ email }: { email: string }) {
     mutationFn: emailExists,
     onSuccess: () => {
       sendVerificationEmail({ email });
-      setEmailMessage({ type: 'success', content: MESSAGES.EMAIL.CODE_SENT });
+      // setEmailMessage({ type: 'success', content: MESSAGES.EMAIL.CODE_SENT });
     },
     onError: (err) => {
       if (isKoinError(err)) {
@@ -90,6 +97,31 @@ function useEmailVerification({ email }: { email: string }) {
     },
   });
 
+  const { mutate: checkIdExists } = useMutation({
+    mutationFn: idExists,
+    onError: (err) => {
+      if (isKoinError(err)) {
+        if (err.status === 400) setIdMessage({ type: 'warning', content: MESSAGES.ID.FORMAT });
+
+        if (err.status === 404) setIdMessage({ type: 'warning', content: MESSAGES.ID.NOT_REGISTERED });
+      }
+    },
+  });
+
+  const { mutate: checkIdMatchEmail } = useMutation({
+    mutationFn: idMatchEmail,
+    onSuccess: () => {
+      if (onNext) onNext(); // 다음 단계로 이동
+    },
+    onError: (err) => {
+      if (isKoinError(err)) {
+        if (err.status === 400 || err.status === 404) {
+          showToast('error', '아이디와 이메일이 일치하지 않습니다');
+        }
+      }
+    },
+  });
+
   return {
     emailMessage,
     checkEmailExists,
@@ -108,6 +140,10 @@ function useEmailVerification({ email }: { email: string }) {
     isTimer,
     timerValue,
     stopTimer,
+    idMessage,
+    setIdMessage,
+    checkIdExists,
+    checkIdMatchEmail,
   };
 }
 


### PR DESCRIPTION
- Close #885 
  
## What is this PR? 🔍

- 기능 : 이메일로 비밀번호 찾는 플로우를 추가하였습니다.
- issue : #885 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
이메일로 비밀번호를 찾는 플로우를 추가하였습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="510" alt="image" src="https://github.com/user-attachments/assets/645e2a86-1a07-41e7-abc4-18c4549eac95" />

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] 이메일 인증이 잘 되는지
- [x] 비밀번호가 잘 변경되는지

## Precaution
제 개인 네이버 계정이기 때문에 테스트 계정을 제공해 드릴 수 없습니다...!
테스트는 아이디와 이메일이 등록되어 있는 계정으로만 가능합니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
