### PR TITLE
fix: 모바일뷰 이미지 사이즈 조정

### DIFF
--- a/src/pages/Club/ClubListPage/ClubListPage.module.scss
+++ b/src/pages/Club/ClubListPage/ClubListPage.module.scss
@@ -252,6 +252,11 @@ main {
       height: 160px;
       flex-shrink: 0;
       aspect-ratio: 1/1;
+
+      @include media.media-breakpoint(mobile) {
+        width: 100px;
+        height: 100px;
+      }
     }
   }
 }


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 모바일뷰 이미지 사이즈 조정
- issue : #

## Changes 📝
모바일뷰 이미지 사이즈를 조정했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
