### PR TITLE
[유저] QA 이슈 수정

### DIFF
--- a/src/pages/Auth/FindPasswordPage/Mobile/MobileVerifyEmail/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/Mobile/MobileVerifyEmail/index.tsx
@@ -23,7 +23,6 @@ function MobileVerifyEmail({ onNext, setContactType }: MobileFindPasswordProps) 
     checkVerificationEmailVerify,
     isDisabled,
     isVerified,
-    isCodeVerified,
     emailSendCountData,
     isCodeCorrect,
     setIncorrect,
@@ -145,14 +144,12 @@ function MobileVerifyEmail({ onNext, setContactType }: MobileFindPasswordProps) 
               <CustomInput
                 {...field}
                 placeholder="인증번호를 입력해주세요."
-                isDelete={!isCodeVerified}
                 isTimer={isVerified ? false : isTimer}
                 timerValue={timerValue}
                 message={verificationMessage}
                 isButton
-                disabled={isCodeVerified}
                 buttonText="인증번호 확인"
-                buttonDisabled={!field.value || isCodeVerified}
+                buttonDisabled={!field.value || isCodeCorrect}
                 buttonOnClick={() => onClickSendVerificationButton()}
               />
             )}

--- a/src/pages/Auth/FindPasswordPage/Mobile/MobileVerifyPhone/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/Mobile/MobileVerifyPhone/index.tsx
@@ -101,6 +101,7 @@ function MobileVerifyPhone({ onNext, goToEmailStep, setContactType }: MobileFind
                 <CustomInput
                   {...field}
                   placeholder="- 없이 번호를 입력해 주세요."
+                  maxLength={11}
                   isDelete={!isVerified}
                   message={phoneMessage}
                   isButton

--- a/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/index.tsx
@@ -33,7 +33,6 @@ function PCVerifyEmail({ onNext, onBack, setContactType }: FindPasswordProps) {
     isSendingVerification,
     isDisabled,
     isVerified,
-    isCodeVerified,
     emailSendCountData,
     isCodeCorrect,
     setIncorrect,
@@ -195,7 +194,6 @@ function PCVerifyEmail({ onNext, onBack, setContactType }: FindPasswordProps) {
                   isTimer={isCodeCorrect ? false : isTimer}
                   timerValue={timerValue}
                   message={verificationMessage}
-                  disabled={isCodeVerified}
                   isDelete={!isVerified}
                   onClear={() => {
                     setVerificationMessage(null);

--- a/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/PC/PCVerifyEmail/index.tsx
@@ -30,6 +30,7 @@ function PCVerifyEmail({ onNext, onBack, setContactType }: FindPasswordProps) {
     emailMessage,
     checkEmailExists,
     checkVerificationEmailVerify,
+    isSendingVerification,
     isDisabled,
     isVerified,
     isCodeVerified,
@@ -135,7 +136,7 @@ function PCVerifyEmail({ onNext, onBack, setContactType }: FindPasswordProps) {
                     stopTimer();
                     setIncorrect();
                     setVerificationMessage(null);
-                    setValue('verificationCode', ''); // 변화가 있을시 인증코드 값을 삭제합니다.
+                    setValue('verificationCode', '');
                   }}
                   placeholder="이메일을 입력해 주세요."
                   isRequired
@@ -164,10 +165,9 @@ function PCVerifyEmail({ onNext, onBack, setContactType }: FindPasswordProps) {
                   className={styles['check-button']}
                   disabled={!field.value || isDisabled || isVerified}
                 >
-                  {buttonText}
+                  {isSendingVerification ? '...' : buttonText}
                 </button>
               </div>
-
             )}
           />
         </div>

--- a/src/pages/Auth/FindPasswordPage/PC/PCVerifyPhone/index.tsx
+++ b/src/pages/Auth/FindPasswordPage/PC/PCVerifyPhone/index.tsx
@@ -34,6 +34,7 @@ function PCVerifyPhone({
     phoneMessage,
     checkPhoneExists,
     checkVerificationSmsVerify,
+    isSendingVerification,
     isDisabled,
     isVerified,
     isCodeVerified,
@@ -167,7 +168,7 @@ function PCVerifyPhone({
                     className={styles['check-button']}
                     disabled={!field.value || isDisabled || isVerified}
                   >
-                    {buttonText}
+                    {isSendingVerification ? '...' : buttonText}
                   </button>
                 </div>
                 {!isVerificationSent && (

--- a/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/pages/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -49,6 +49,7 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
 
   const {
     checkVerificationSmsVerify,
+    isSendingVerification,
     isVerified,
     isCodeVerified,
     smsSendCountData,
@@ -224,12 +225,12 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                     type="button"
                     onClick={() => {
                       checkPhoneNumber(phoneNumber);
-                      setButtonText('인증번호 발송');
+                      setButtonText('인증번호 재발송');
                     }}
                     className={styles['check-button']}
                     disabled={!field.value || isDisabled || isVerified}
                   >
-                    {buttonText}
+                    {isSendingVerification ? '...' : buttonText}
                   </button>
                 </div>
               </div>

--- a/src/pages/Auth/SignupPage/components/PCCustomInput/index.tsx
+++ b/src/pages/Auth/SignupPage/components/PCCustomInput/index.tsx
@@ -134,6 +134,7 @@ const PCCustomInput = forwardRef<HTMLInputElement, PCCustomInputProps>((
               type="button"
               onClick={togglePasswordVisible}
               className={styles['input-wrapper__optionButton']}
+              tabIndex={-1}
             >
               {isPasswordVisible ? <EyeOpenIcon /> : <EyeCloseIcon />}
             </button>

--- a/src/utils/hooks/auth/useEmailVerification.ts
+++ b/src/utils/hooks/auth/useEmailVerification.ts
@@ -22,8 +22,8 @@ function useEmailVerification({ email, onNext }: UseEmailVerificationProps) {
   const [verificationMessage, setVerificationMessage] = useState<InputMessage | null>(null);
   const [emailMessage, setEmailMessage] = useState<InputMessage | null>(null);
   const [isDisabled, enableButton, disableButton] = useBooleanState(false);
-  const [isVerified, enableVerified] = useBooleanState(false);
-  const [isCodeVerified, enableCodeVerified] = useBooleanState(false);
+  const [isVerified, enableVerified, disableVerified] = useBooleanState(false);
+  const [isCodeVerified, enableCodeVerified, disableCodeVerified] = useBooleanState(false);
   const [isCodeCorrect, setCorrect, setIncorrect] = useBooleanState(false);
   const [idMessage, setIdMessage] = useState<InputMessage | null>(null);
 
@@ -37,6 +37,16 @@ function useEmailVerification({ email, onNext }: UseEmailVerificationProps) {
       if (!isVerified) setVerificationMessage({ type: 'warning', content: MESSAGES.VERIFICATION.TIMEOUT });
     },
   });
+
+  const resetVerificationState = () => {
+    disableButton();
+    disableVerified();
+    disableCodeVerified();
+    setIncorrect();
+    stopTimer();
+    setEmailMessage(null);
+    setVerificationMessage(null);
+  };
 
   const { mutate: sendVerificationEmail } = useMutation({
     mutationFn: verificationEmailSend,
@@ -119,6 +129,7 @@ function useEmailVerification({ email, onNext }: UseEmailVerificationProps) {
           showToast('error', '아이디와 이메일이 일치하지 않습니다');
         }
       }
+      resetVerificationState();
     },
   });
 

--- a/src/utils/hooks/auth/useEmailVerification.ts
+++ b/src/utils/hooks/auth/useEmailVerification.ts
@@ -48,7 +48,10 @@ function useEmailVerification({ email, onNext }: UseEmailVerificationProps) {
     setVerificationMessage(null);
   };
 
-  const { mutate: sendVerificationEmail } = useMutation({
+  const {
+    mutate: sendVerificationEmail,
+    isPending: isSendingVerification,
+  } = useMutation({
     mutationFn: verificationEmailSend,
     onSuccess: ({ remaining_count }) => {
       setEmailMessage({ type: 'success', content: MESSAGES.EMAIL.CODE_SENT });
@@ -137,6 +140,7 @@ function useEmailVerification({ email, onNext }: UseEmailVerificationProps) {
     emailMessage,
     checkEmailExists,
     checkVerificationEmailVerify,
+    isSendingVerification,
     findEmail,
     isDisabled,
     disableButton,

--- a/src/utils/hooks/auth/usePhoneVerification.ts
+++ b/src/utils/hooks/auth/usePhoneVerification.ts
@@ -29,8 +29,8 @@ function usePhoneVerification({ phoneNumber, onNext }: UsePhoneVerificationProps
   const [phoneMessage, setPhoneMessage] = useState<InputMessage | null>(null);
   const [verificationMessage, setVerificationMessage] = useState<InputMessage | null>(null);
   const [isDisabled, enableButton, disableButton] = useBooleanState(false);
-  const [isVerified, enableVerified] = useBooleanState(false);
-  const [isCodeVerified, enableCodeVerified] = useBooleanState(false);
+  const [isVerified, enableVerified, disableVerified] = useBooleanState(false);
+  const [isCodeVerified, enableCodeVerified, disableCodeVerified] = useBooleanState(false);
   const [smsSendCount, setSmsSendCount] = useState(0);
   const [isCodeCorrect, setCorrect, setIncorrect] = useBooleanState(false);
   const [idMessage, setIdMessage] = useState<InputMessage | null>(null);
@@ -52,7 +52,20 @@ function usePhoneVerification({ phoneNumber, onNext }: UsePhoneVerificationProps
     },
   });
 
-  const { mutate: sendVerificationSms } = useMutation({
+  const resetVerificationState = () => {
+    disableButton();
+    disableVerified();
+    disableCodeVerified();
+    setIncorrect();
+    stopTimer();
+    setPhoneMessage(null);
+    setVerificationMessage(null);
+  };
+
+  const {
+    mutate: sendVerificationSms,
+    isPending: isSendingVerification,
+  } = useMutation({
     mutationFn: smsSend,
     onSuccess: ({ remaining_count }) => {
       setPhoneMessage({ type: 'success', content: MESSAGES.PHONE.CODE_SENT });
@@ -195,6 +208,7 @@ function usePhoneVerification({ phoneNumber, onNext }: UsePhoneVerificationProps
           showToast('error', '아이디와 휴대폰 번호가 일치하지 않습니다');
         }
       }
+      resetVerificationState();
     },
   });
 
@@ -202,6 +216,7 @@ function usePhoneVerification({ phoneNumber, onNext }: UsePhoneVerificationProps
     phoneMessage,
     checkPhoneExists,
     checkVerificationSmsVerify,
+    isSendingVerification,
     findId,
     isDisabled,
     disableButton,


### PR DESCRIPTION
- Close #914 
  
## What is this PR? 🔍

- 기능 : 유저팀 QA 수정
- issue : #914 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
* 아이디와 일치하지 않은 이메일로도 아이디/비번찾기 가능
  * 한번 인증하면 이메일 칸이 잠겨서 옳은 이메일로 수정이 안되는 현상
* 인증 번호 전송 버튼에 pending 상태 추가
* 그 외, 중복 처리나 브랜치 최신화에 따른 코드 수정


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
**비밀번호 찾기- 휴대전화**

https://github.com/user-attachments/assets/48350cf8-ca87-43c1-b43a-c306c03add47




**비밀번호 찾기 - 이메일**


https://github.com/user-attachments/assets/50def7ed-1823-47b5-a3b2-abda670fe858



## Test CheckList ✅

가입한 `아이디-전화번호`와 `아이디-이메일`가 일치하지 않게 입력하고 인증을 완료한 후, 다음 버튼을 눌렀을 때
잠겼던 입력창이 풀어지는 것을 확인하면 됩니다.



## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
