### PR TITLE
[hotfix, 공지사항] 문자열이 아닐 때 replaceAll 사용 제한

### DIFF
--- a/src/pages/Articles/utils/setArticleRegisteredDate.ts
+++ b/src/pages/Articles/utils/setArticleRegisteredDate.ts
@@ -7,7 +7,12 @@ const isCheckNewArticle = (registered: number[]) => {
   return false;
 };
 
-const convertDate = (time: string) => time.split(' ')[0].replaceAll('-', '.');
+const convertDate = (time: string) => {
+  if (typeof time !== 'string') {
+    return '';
+  }
+  return time.split(' ')[0].replaceAll('-', '.');
+};
 
 function setArticleRegisteredDate(time: string) {
   const registered = convertDate(time).split('.').map((item: string) => parseInt(item, 10));


### PR DESCRIPTION
- Close #928 
  
## What is this PR? 🔍

- 기능 :  메서드 사용 제한
- issue : #928 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- replaceAll 메서드가 문자열 메서드이기 때문에 string 타입일 때만 로직을 수행하도록 수정했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
