### PR TITLE
[hotfix] 필수 정보가 모두 기입된 사용자도 정보 입력 모달 노출

### DIFF
--- a/src/components/ui/UserInfoModal/hooks/useUserInfoModal.ts
+++ b/src/components/ui/UserInfoModal/hooks/useUserInfoModal.ts
@@ -25,7 +25,9 @@ export default function useUserInfoModal() {
       'login_id', 'gender', 'major', 'name', 'phone_number', 'student_number',
     ];
 
-    const isInfoMissing = requiredFields.some((field) => !userInfo[field]);
+    const isInfoMissing = requiredFields.some(
+      (field) => userInfo[field] === undefined || userInfo[field] === null || userInfo[field] === '',
+    );
 
     if (!isInfoMissing) {
       localStorage.setItem(STORAGE_KEY.USER_INFO_COMPLETION, COMPLETION_STATUS.COMPLETED);


### PR DESCRIPTION
- Close #967 
  
## What is this PR? 🔍

- 기능 : 정보 누락 검증 로직을 수정했습니다.
- issue : #967

## Changes 📝

userInfo의 gender 값이 0과 1로 응답값이 내려오기 때문에 기존 로직에서 남자의 경우 정보 기입이 된 사용자도 COMPLETE 처리 되지 않는 문제가 있어 수정했습니다.


## ScreenShot 📷

https://github.com/user-attachments/assets/223f691a-8596-4a93-a5c9-0e51b1d7587a

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
