### PR TITLE
[hotfix] 동아리 오픈채팅 길이 초과 이슈

### DIFF
--- a/src/pages/Club/ClubDetailPage/index.tsx
+++ b/src/pages/Club/ClubDetailPage/index.tsx
@@ -485,7 +485,7 @@ export default function ClubDetailPage() {
                 rel="noopener noreferrer"
                 className={styles['club-detail__summary__contacts__row__link']}
               >
-                {clubDetail.open_chat}
+                https://open.kakao.com/o/...
               </a>
               <button
                 className={styles['copy-button']}


### PR DESCRIPTION
- Close #975  
## What is this PR? 🔍

- 기능 : 오픈채팅 링크 길이 초과 방지를 위해 static하게 적용 및 말줄임표 처리
- issue : #975

## Changes 📝

<img width="376" height="622" alt="image" src="https://github.com/user-attachments/assets/2f79e797-25dc-41a6-a59e-89b2938ed43b" />

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
