### PR TITLE
[hotfix] 버스 페이지에서 메인 화면 이동 시 흰 화면 렌더링

### DIFF
--- a/src/pages/Bus/BusRoutePage/hooks/useCoopSemester.ts
+++ b/src/pages/Bus/BusRoutePage/hooks/useCoopSemester.ts
@@ -2,7 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { coopshop } from 'api';
 
 const useCoopSemester = () => useSuspenseQuery({
-  queryKey: ['semester'],
+  queryKey: ['coopSemester'],
   queryFn: async () => coopshop.getAllShopInfo(),
 });
 


### PR DESCRIPTION
- Close #988
  
## What is this PR? 🔍

- 기능 : useCoopSemester의 query key 네이밍을 변경했습니다.
- issue : #988

## Changes 📝
https://github.com/BCSDLab/KOIN_WEB_RECODE/pull/982
위 작업에서 api에서 내려주는 학기 값을 이용하기 위해 useCoopSemester 훅을 만들었는데
이때 사용한 queryKey 값이 semester로 useSemesterOptionList 훅의 queryKey와 동일하여 버그가 발생하여 수정했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
