### PR TITLE
[버스 시간표] 버스 시간표 에러 수정

### DIFF
--- a/src/pages/Bus/BusRoutePage/components/RouteList/index.tsx
+++ b/src/pages/Bus/BusRoutePage/components/RouteList/index.tsx
@@ -22,6 +22,11 @@ export default function RouteList({
     depart,
     arrival,
   });
+  const isReady = Boolean(depart) && Boolean(arrival);
+
+  if (!isReady) {
+    return null;
+  }
 
   if (!data) return null;
 

--- a/src/pages/Bus/BusRoutePage/hooks/useBusRoute.ts
+++ b/src/pages/Bus/BusRoutePage/hooks/useBusRoute.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getBusRouteInfo } from 'api/bus';
 import { Arrival, BusRouteParams, Depart } from 'api/bus/entity';
 import { transformBusRoute } from 'pages/Bus/BusRoutePage/utils/transform';
@@ -14,21 +14,17 @@ const useBusRoute = (params: BusRouteQueryParams) => {
   const { depart, arrival, ...rest } = params;
   const isReady = Boolean(depart) && Boolean(arrival);
 
-  return useSuspenseQuery({
-    queryKey: [BUS_ROUTE_KEY, params],
+  return useQuery({
+    queryKey: [BUS_ROUTE_KEY, JSON.stringify(params)],
     queryFn: async () => {
-      if (!isReady) {
-        throw new Error('Invalid params');
-      }
-
       const response = await getBusRouteInfo({
         ...rest,
         depart: depart as Depart,
         arrival: arrival as Arrival,
       });
-
       return transformBusRoute(response);
     },
+    enabled: isReady,
   });
 };
 


### PR DESCRIPTION
- Close #992 
  
## What is this PR? 🔍

- 기능 : 버스 시간표 중복 문제 해결
- issue : #992 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
셔틀 노선 데이터에 동일한 14:10 셔틀이 2개 포함되어 있었고,
busName + departTime 조합으로 key를 만들면서 React가 같은 key를 가진 컴포넌트를 구분하지 못해 중복 경고가 발생했습니다.

기존에는 useSuspenseQuery에서 isReady 조건을 throw로 막아 React Query가 이전 캐시 데이터를 그대로 유지했고,
그 결과 중복된 데이터가 화면에 남는 문제가 있었습니다.

이를 useQuery + enabled 방식으로 변경하여,
isReady가 아닐 때는 쿼리를 실행하지 않도록 수정해 해결했습니다.



## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
