### PR TITLE
[fix] next 로깅 방식에서 이전 로깅 방식으로 변경

### DIFF
--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -1,5 +1,3 @@
-import { sendGTMEvent } from '@next/third-parties/google';
-
 type GTagEvent = {
   team: string;
   event_category: string;
@@ -17,13 +15,14 @@ type SessionEvent = {
   custom_session_id: string;
 };
 
-export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID;
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 const API_PATH = process.env.NEXT_PUBLIC_API_PATH;
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageView = (url: string, userId?: string) => {
-  sendGTMEvent({
-    event: 'page_view',
+  if (typeof window === 'undefined' || typeof window.gtag === 'undefined') return;
+
+  window.gtag('config', GA_TRACKING_ID as string, {
     page_path: url,
     user_id: userId,
   });
@@ -39,9 +38,9 @@ export const event = ({
   previous_page,
   current_page,
 }: GTagEvent) => {
-  sendGTMEvent({
-    event: team,
-    team,
+  if (typeof window === 'undefined' || typeof window.gtag === 'undefined') return;
+
+  window.gtag('event', team, {
     event_category,
     event_label,
     value,
@@ -70,8 +69,9 @@ export const startSession = ({
   event_category,
   custom_session_id,
 }: SessionEvent) => {
-  sendGTMEvent({
-    event: 'session_start',
+  if (typeof window === 'undefined' || typeof window.gtag === 'undefined') return;
+
+  window.gtag('event', 'session_start', {
     event_label,
     value,
     event_category,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -118,6 +118,26 @@ export default function App({ Component, pageProps }: AppPropsWithAuth) {
     //     delete window.setTokens;
     //   }
     // };
+    // 로깅을 위한 userId 전달 및 gtag 함수 정의
+    if (typeof window !== 'undefined') {
+      const userId = localStorage.getItem('uuid') || '';
+
+      window.dataLayer = window.dataLayer || [];
+
+      if (userId) {
+        window.dataLayer.push({
+          user_id: userId,
+          event: 'userIdAvailable',
+        });
+      }
+
+      if (typeof window.gtag === 'undefined') {
+        window.gtag = function gtag() {
+          // eslint-disable-next-line prefer-rest-params
+          window.dataLayer.push(arguments);
+        };
+      }
+    }
   }, []);
 
   const needAuth = Component.requireAuth;


### PR DESCRIPTION
  ## What is this PR? 🔍

- 기능 : next 로깅 방식에서 이전 로깅 방식으로 변경

## Changes 📝
- next에서 제공하는 서드파티가 로깅 되지 않아 이전 로깅 방식으로 회귀하였습니다.
<!-- 이번 PR에서의 변경점 -->

## Precaution
arguments를 그대로 쓰는 코드를 작성했는데, 더 좋은 방식 있으면 리뷰 남겨주세요... (lint 에러 발생)

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
