### PR TITLE
[교내 시설물 정보] 웹뷰 환경에서 레이아웃 렌더링

### DIFF
--- a/src/pages/webview/campusinfo/index.tsx
+++ b/src/pages/webview/campusinfo/index.tsx
@@ -3,3 +3,5 @@ import CampusInfo from 'components/CampusInfo';
 export default function WebviewCampusInfo() {
   return <CampusInfo />;
 }
+
+WebviewCampusInfo.getLayout = (page: React.ReactNode) => page;


### PR DESCRIPTION
- Close #1004
  
## What is this PR? 🔍

- 기능 :웹뷰 교내 시설물 정보 레이아웃 제거
- issue : #1004

## Changes 📝
웹뷰 교내 시설물 정보 컴포넌트에 빈 레이아웃을 설정하여 기본 레이아웃을 렌더링 되지 않도록 수정했습니다.


## ScreenShot 📷

<img width="355" height="759" alt="image" src="https://github.com/user-attachments/assets/35ccbfbe-a278-4ae2-a638-69d92459c2e7" />


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
