### PR TITLE
[hotfix/메인페이지] 메인화면 시간표 간헐적 비렌더링 버그

### DIFF
--- a/src/pages/IndexPage/components/IndexTimetable/index.tsx
+++ b/src/pages/IndexPage/components/IndexTimetable/index.tsx
@@ -13,23 +13,13 @@ import styles from './IndexTimetable.module.scss';
 function CurrentSemesterTimetable() {
   const semester = useSemester();
   const token = useTokenState();
-  const [currentFrameIndex, setCurrentFrameIndex] = React.useState<number>(0);
   const { data: timetableFrameList } = useTimetableFrameList(token, semester);
 
-  useEffect(() => {
-    if (timetableFrameList) {
-      const mainFrame = timetableFrameList.find(
-        (frame) => frame.is_main,
-      );
-      if (mainFrame && mainFrame.id) {
-        setCurrentFrameIndex(mainFrame.id);
-      }
-    }
-  }, [timetableFrameList]);
+  const currentFrameId = timetableFrameList?.find((frame) => frame.is_main)?.id || 0;
 
   return (
     <Timetable
-      timetableFrameId={currentFrameIndex}
+      timetableFrameId={currentFrameId}
       columnWidth={44}
       firstColumnWidth={29}
       rowHeight={17.3}


### PR DESCRIPTION
- Close #1008
  
## What is this PR? 🔍

- 기능 : 버그 수정
- issue : #1008

## Changes 📝
간헐적으로 메인화면의 시간표가 빈 시간표로 렌더링 되는 버그 발생하여 
기존 useEffect 내부에서 timetableFrameId를 설정하는 방식에서 단순 변수로 관리하는 방식으로 수정했습니다.

## Precaution
버그 제보를 받고 상황 재현을 해보려고 했으나 불가능하여 일단 의심되는 부분을 수정한 것이라 버그가 정상적으로 해결됐는지 확인이 어려운 상황입니다. 이후 재발한다면 다시 수정해보도록 하겠습니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
