### PR TITLE
[정보수정/hotfix] 비밀번호 검증하지 않고 정보수정 가능한 문제 수정 

### DIFF
--- a/src/pages/Auth/ModifyInfoPage/index.tsx
+++ b/src/pages/Auth/ModifyInfoPage/index.tsx
@@ -1217,7 +1217,7 @@ function ModifyInfoDefaultPage() {
 
   useEffect(() => {
     if (!isAuthenticated) {
-      openModal();
+      navigate(ROUTES.Main(), { replace: true });
     }
   }, [isAuthenticated, openModal]);
 


### PR DESCRIPTION
- Close #1018
  
## What is this PR? 🔍

- 기능 :URL 직접 접근 차단
- issue : #1018

## Changes 📝

<img width="358" height="389" alt="image" src="https://github.com/user-attachments/assets/3d773953-e52c-409d-b1bb-fc728fb9aff1" />

페이지에 url로 직접 접근 후 개발자도구로 비밀번호 검증 모달을 제거하면 검증 없이 정보수정이 가능한 문제가 발견되어 url로 직접 접근 시 메인 페이지로 이동되도록 임시 처리해두었습니다.

## Precaution
next 마이그레이션이 진행되면 두번 작업을 해야되기에 간단하게 리다이렉트로 임시조치 해두었습니다.
