### PR TITLE
[공통] css, scss 파일 prettier 적용 예외 처리

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,11 @@
   "workbench.editorAssociations": {
     "*.svg": "default"
   },
+  "[css]": {
+    "editor.formatOnSave": false
+  },
+  "[scss]": {
+    "editor.formatOnSave": false
+  },
   "cSpell.words": ["bcsdlab", "BUGSINK", "GLITCHTIP", "Koin", "tanstack", "zustand"]
 }


### PR DESCRIPTION
- Close #1037 
## What is this PR? 🔍

- 기능 : css, scss 파일에서 prettier 충돌 오류 해결
- issue : #1037

## Changes 📝

vscode setting에서 css,scss는 format on save 기능 off

- 주된 충돌 지점 
<img width="482" height="74" alt="image" src="https://github.com/user-attachments/assets/750ce5ce-d7b2-4add-88a2-7b46b83a5dac" />

prettier는 따옴표, stylelint는 쌍따옴표로 규칙 지정되어 있어서 해당 부분에서 충돌 발생

시도한 방법
   - prettierIgnore : vscode 하단에 prettier 무시된다는 표시, 출력에서 로그 발생으로 개인적인 불편함 발생  
<img width="1270" height="128" alt="image" src="https://github.com/user-attachments/assets/c7ed3152-d9d9-4bfb-95f5-41ffbb949742" />

   - stylelint config : eslint-prettier-config 와 같이 충돌나는 규칙을 정리해줌, prettier 규칙이 stylelint보다 높은 우선순위로 적용
   - vscode setting 변경 : 현재 저장 시 자동 포매팅에 prettier가 적용되어 있기에 css, scss만 자동 포매팅에서 제거

결론 : 개인적인 선호로 인해 vscode setting을 변경하는 방법으로 진행했습니다. 의견 주시면 반영하도록 하겠습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
