### PR TITLE
[공통] refresh 실패 시 브라우저 환경에서도 토큰 초기화 실행

### DIFF
--- a/src/utils/ts/apiClient.ts
+++ b/src/utils/ts/apiClient.ts
@@ -109,15 +109,14 @@ export default class APIClient {
         }
       })
       .catch(() => {
+        useTokenStore.getState().setToken('');
+        useTokenStore.getState().setRefreshToken('');
+
         if (typeof window !== 'undefined' && window.webkit?.messageHandlers != null) {
-          useTokenStore.getState().setToken('');
-          useTokenStore.getState().setRefreshToken('');
           saveTokensToNative('', ''); // 네이티브 상태도 동기화
           redirectToClub();
           return;
         }
-        useTokenStore.getState().setToken('');
-        useTokenStore.getState().setRefreshToken('');
         redirectToLogin();
       })
       .finally(() => {


### PR DESCRIPTION
- Close #1052 
  
## What is this PR? 🔍

- 기능 : refresh 실패 시, 브라우저 환경에서도 토큰 초기화 실행
- issue : #1052 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
네이티브 환경이 아닐 때, 토큰 리프레시를 실패하면 토큰 초기화를 하지 않는 문제가 있습니다.

apiClient의 errorMiddleware 401 분기에서 deleteCookie('AUTH_TOKEN_KEY')를 통해 쿠키에서는 토큰이 제거되지만, 
zustand에서는 처리된 바가 없는 문제가 있습니다.


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
