### PR TITLE
[유저] 정보수정 페이지 레이아웃 중복 버그 수정

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,6 +1,12 @@
 import { Suspense } from 'react';
 import Footer from 'components/layout/Footer';
 import Header from 'components/layout/Header';
+import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
+
+interface LayoutProps {
+  children: React.ReactNode;
+  hideLayout?: boolean;
+}
 
 export function SSRLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -12,8 +18,13 @@ export function SSRLayout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children, hideLayout = false }: LayoutProps) {
+  const isMobile = useMediaQuery();
   const isNativeWebView = typeof window !== 'undefined' && !!window.webkit?.messageHandlers;
+
+  if (isMobile && hideLayout) {
+    return <>{children}</>;
+  }
 
   return (
     <div id="root">

--- a/src/pages/auth/modifyinfo/index.tsx
+++ b/src/pages/auth/modifyinfo/index.tsx
@@ -25,6 +25,7 @@ import CustomSelector from 'components/Auth/SignupPage/components/CustomSelector
 import useDeptList from 'components/Auth/SignupPage/hooks/useDeptList';
 import useNicknameDuplicateCheck from 'components/Auth/SignupPage/hooks/useNicknameDuplicateCheck';
 import LoadingSpinner from 'components/feedback/LoadingSpinner';
+import Layout from 'components/layout';
 import { Portal } from 'components/modal/Modal/PortalProvider';
 import { REGEX, STORAGE_KEY, COMPLETION_STATUS } from 'static/auth';
 import ROUTES from 'static/routes';
@@ -1316,5 +1317,6 @@ function ModifyInfoPage() {
 }
 
 ModifyInfoPage.requireAuth = true;
+ModifyInfoPage.getLayout = (page: React.ReactNode) => <Layout hideLayout>{page}</Layout>;
 
 export default ModifyInfoPage;


### PR DESCRIPTION
- Close #1090
  
## What is this PR? 🔍

- 기능 : 모바일 정보수정 페이지 중복 레이아웃 버그를 수정합니다.
- issue : #1090

## Changes 📝
<img width="380" height="737" alt="image" src="https://github.com/user-attachments/assets/e80bd819-2c7d-4435-9763-0ca52f1023c4" />

<img width="381" height="738" alt="image" src="https://github.com/user-attachments/assets/d7c0239d-21ce-409c-a8a4-beab197b18f7" />

## Precaution
정보수정 페이지의 경우 모바일과 pc가 별도 파일로 나눠져있지 않아 layout컴포넌트에서 props로 받아 숨길 수 있도록 수정했습니다.
더 좋은 방법이 있을 것 같은데 생각이 나지 않아 우선 이렇게 진행했습니다.
피드백 주시면 감사드리겠습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
