### PR TITLE
[hotfix] 가장 빠른 버스 파라미터 네이밍 오류 수정

### DIFF
--- a/src/api/bus/APIDetail.ts
+++ b/src/api/bus/APIDetail.ts
@@ -103,14 +103,14 @@ export class BusRouteInfo<R extends BusRouteInfoResponseDTO> implements APIReque
 
   path = '/bus/route';
 
-  params: { date: string; time: string; busType: BusTypeRequest; depart?: Depart; arrival?: Arrival };
+  params: { date: string; time: string; bus_type: BusTypeRequest; depart?: Depart; arrival?: Arrival };
 
   response!: R;
 
   auth = false;
 
   constructor({ dayOfMonth: date, time, busType, depart, arrival }: BusRouteParams) {
-    this.params = { date, time, busType, depart, arrival };
+    this.params = { date, time, bus_type: busType, depart, arrival };
   }
 }
 


### PR DESCRIPTION
- Close #1106
  
## What is this PR? 🔍

- 기능 : 버스 경로 API에 입력되는 params 네이밍이 api와 다르게 입력되어 발생하는 버그 수정
- issue : #1106

## Changes 📝
params 네이밍 변경

## ScreenShot 📷

<img width="1916" height="879" alt="image" src="https://github.com/user-attachments/assets/0e9430f7-e2ac-476f-a7a2-365cc33d416a" />

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
