### PR TITLE
[복덕방/Hotfix] Naver Maps SDK destroy 시 TypeError 수정

### DIFF
--- a/src/components/Room/RoomPage/hooks/useNaverMap.ts
+++ b/src/components/Room/RoomPage/hooks/useNaverMap.ts
@@ -7,27 +7,33 @@ function useNaverMap(latitude: number, longitude: number, isLoaded: boolean = tr
     if (!isLoaded || !window.naver?.maps) return;
     if (!document.getElementById('map')) return;
 
-    if (!mapRef.current) {
-      const mapInstance = new window.naver.maps.Map('map', {
-        center: new window.naver.maps.LatLng(latitude, longitude),
-        maxZoom: 20,
-        minZoom: 15,
-        logoControl: false,
-        zoomControl: true,
-        scrollWheel: false,
-        draggable: true,
-        zoomControlOptions: { position: window.naver.maps.Position.TOP_LEFT },
-      });
-      mapRef.current = mapInstance;
+    const mapInstance = new window.naver.maps.Map('map', {
+      center: new window.naver.maps.LatLng(latitude, longitude),
+      maxZoom: 20,
+      minZoom: 15,
+      logoControl: false,
+      zoomControl: true,
+      scrollWheel: false,
+      draggable: true,
+      zoomControlOptions: { position: window.naver.maps.Position.TOP_LEFT },
+    });
+    mapRef.current = mapInstance;
 
-      return () => {
+    return () => {
+      try {
         mapInstance.destroy();
-        mapRef.current = null;
-      };
-    }
-
-    mapRef.current.setCenter(new window.naver.maps.LatLng(latitude, longitude));
+      } catch {
+        // Naver Maps SDK 내부 _clearSwipe 타이밍 이슈 방어
+      }
+      mapRef.current = null;
+    };
   }, [isLoaded, latitude, longitude]);
+
+  useEffect(() => {
+    if (mapRef.current) {
+      mapRef.current.setCenter(new window.naver.maps.LatLng(latitude, longitude));
+    }
+  }, [latitude, longitude]);
 
   const getMap = () => mapRef.current;
 


### PR DESCRIPTION
## Summary
- `useNaverMap` 훅의 effect를 생성/파괴용과 좌표 업데이트용으로 분리
- `destroy()` 호출을 `try-catch`로 감싸 Naver Maps SDK 내부 `_clearSwipe` 타이밍 이슈 방어

## 관련 이슈
- closes #1220
- Sentry: [KOIN-PROD-6](https://bcsd.sentry.io/issues/7373657484/?alert_rule_id=16842350&alert_type=issue&environment=production&notification_uuid=f52f564d-d4af-4646-a87e-7bc2a3046255&project=4511024395255808&referrer=slack)

## 원인
- cleanup 함수가 `if (!mapRef.current)` 블록 안에서만 반환되어 항상 보장되지 않음
- Naver Maps SDK `destroy()` 내부에서 `setTimeout`으로 예약된 `_clearSwipe`가 DOM 제거 후 실행되면서 `releaseCapture` 접근 시 TypeError 발생
- 카카오톡 인앱 브라우저(Android)에서 재현됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Naver Map 인스턴스 정리 시 발생할 수 있는 타이밍 이슈를 개선했습니다.

* **개선사항**
  * 지도 초기화 프로세스와 중심 위치 업데이트 로직을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->