### PR TITLE
[공통] Sentry 클라이언트 노이즈 에러 필터링 (#1222)

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -9,6 +9,32 @@ Sentry.init({
   environment,
   release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
 
+  beforeSend(event, hint) {
+    const error = hint.originalException;
+
+    // Axios 네트워크/타임아웃/취소 에러
+    if (
+      error != null
+      && typeof error === 'object'
+      && 'code' in error
+      && (error.code === 'ERR_NETWORK' || error.code === 'ECONNABORTED' || error.code === 'ERR_CANCELED')
+    ) {
+      return null;
+    }
+
+    // 브라우저 네트워크 에러 (fetch, Safari)
+    if (error instanceof TypeError && /Load failed|Failed to fetch/.test(error.message)) {
+      return null;
+    }
+
+    // 배포 후 이전 청크 캐시 요청 실패
+    if (error instanceof Error && error.name === 'ChunkLoadError') {
+      return null;
+    }
+
+    return event;
+  },
+
   integrations: [
     Sentry.replayIntegration({
       maskAllText: false,


### PR DESCRIPTION
- Close #1222

## What is this PR? 🔍

- 기능 : Sentry 클라이언트 노이즈 에러 필터링
- issue : #1222

## Changes 📝

- `src/instrumentation-client.ts`에 `beforeSend` 훅을 추가하여 클라이언트에서 조치 불가능한 노이즈 에러를 필터링
  - Axios: `ERR_NETWORK`, `ECONNABORTED`, `ERR_CANCELED`
  - fetch/Safari: `Load failed`, `Failed to fetch`
  - Next.js: `ChunkLoadError`

## ScreenShot 📷

N/A

## Test CheckList ✅

- [ ] 프로덕션 배포 후 Sentry에서 해당 노이즈 에러가 더 이상 수집되지 않는지 확인
- [ ] 실제 서버 에러(4xx, 5xx)는 정상적으로 수집되는지 확인

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 네트워크 타임아웃, 연결 오류, 요청 취소, 페칭 실패, 청크 로드 오류 등 특정 유형의 오류 보고를 자동으로 필터링하여 오류 추적 시스템의 노이즈를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->