### PR TITLE
[유저] 유효하지 않은 시간표 frame id로 인한 버그 수정

### DIFF
--- a/src/api/timetable/queries.ts
+++ b/src/api/timetable/queries.ts
@@ -31,6 +31,9 @@ type FrameListQueryParams = {
 const canUseStudentTimetableQuery = (token: string, userType?: TimetableUserType) =>
   Boolean(token) && (!userType || userType === 'STUDENT');
 
+export const isValidTimetableFrameId = (timetableFrameId: number | null | undefined): timetableFrameId is number =>
+  typeof timetableFrameId === 'number' && Number.isInteger(timetableFrameId) && timetableFrameId > 0;
+
 export const createDefaultTimetableFrameList = (): TimetableFrameListResponse => [
   {
     id: null,
@@ -92,7 +95,10 @@ export const timetableQueries = {
   lectureInfo: (authorization: string, timetableFrameId: number) =>
     queryOptions({
       queryKey: timetableQueryKeys.lectureInfo(timetableFrameId),
-      queryFn: () => (authorization ? getTimetableLectureInfo(authorization, timetableFrameId) : null),
+      queryFn: () =>
+        authorization && isValidTimetableFrameId(timetableFrameId)
+          ? getTimetableLectureInfo(authorization, timetableFrameId)
+          : null,
     }),
 
   allLectures: (token: string) =>

--- a/src/components/IndexComponents/IndexTimetable/index.tsx
+++ b/src/components/IndexComponents/IndexTimetable/index.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { isValidTimetableFrameId } from 'api/timetable/queries';
 import ErrorBoundary from 'components/boundary/ErrorBoundary';
 import Timetable from 'components/TimetablePage/components/Timetable';
+import TimetableGridPlaceholder from 'components/TimetablePage/components/TimetableGridPlaceholder';
 import useSemesterOptionList from 'components/TimetablePage/hooks/useSemesterOptionList';
 import useTimetableFrameList from 'components/TimetablePage/hooks/useTimetableFrameList';
 import ROUTES from 'static/routes';
@@ -29,8 +30,7 @@ export default function IndexTimeTable() {
   }, [semesterOptionList, updateSemester]);
 
   const renderPlaceholder = (
-    <Timetable
-      timetableFrameId={0}
+    <TimetableGridPlaceholder
       columnWidth={44}
       firstColumnWidth={29}
       rowHeight={17.3}

--- a/src/components/IndexComponents/IndexTimetable/index.tsx
+++ b/src/components/IndexComponents/IndexTimetable/index.tsx
@@ -1,5 +1,6 @@
 ﻿import { useEffect } from 'react';
 import Link from 'next/link';
+import { isValidTimetableFrameId } from 'api/timetable/queries';
 import ErrorBoundary from 'components/boundary/ErrorBoundary';
 import Timetable from 'components/TimetablePage/components/Timetable';
 import useSemesterOptionList from 'components/TimetablePage/hooks/useSemesterOptionList';
@@ -19,16 +20,17 @@ export default function IndexTimeTable() {
   const token = useTokenState();
   const { data: timetableFrameList } = useTimetableFrameList(token, semester);
 
-  const currentFrameId = timetableFrameList?.find((frame) => frame.is_main)?.id ?? 0;
+  const currentFrameId = timetableFrameList?.find((frame) => frame.is_main)?.id;
+  const hasValidCurrentFrameId = isValidTimetableFrameId(currentFrameId);
   const isClient = useMount();
 
   useEffect(() => {
     if (semesterOptionList.length > 0) updateSemester(semesterOptionList[0].value);
   }, [semesterOptionList, updateSemester]);
 
-  const renderTimetable = (
+  const renderPlaceholder = (
     <Timetable
-      timetableFrameId={currentFrameId}
+      timetableFrameId={0}
       columnWidth={44}
       firstColumnWidth={29}
       rowHeight={17.3}
@@ -36,17 +38,16 @@ export default function IndexTimeTable() {
     />
   );
 
-  const renderPlaceholder = (
-    <div
-      aria-hidden
-      style={{
-        height: 369,
-        width: '100%',
-        borderRadius: 12,
-        backgroundColor: '#f7f8fa',
-        border: '1px solid #e4e8ee',
-      }}
+  const renderTimetable = hasValidCurrentFrameId ? (
+    <Timetable
+      timetableFrameId={currentFrameId}
+      columnWidth={44}
+      firstColumnWidth={29}
+      rowHeight={17.3}
+      totalHeight={369}
     />
+  ) : (
+    renderPlaceholder
   );
 
   return (

--- a/src/components/TimetablePage/components/MainTimetable/index.tsx
+++ b/src/components/TimetablePage/components/MainTimetable/index.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { deptQueries } from 'api/dept/queries';
+import { Lecture, MyLectureInfo } from 'api/timetable/entity';
 import { isValidTimetableFrameId } from 'api/timetable/queries';
 import DownloadIcon from 'assets/svg/download-icon.svg';
 import GraduationIcon from 'assets/svg/graduation-icon.svg';
 import EditIcon from 'assets/svg/pen-icon.svg';
 import Curriculum from 'components/TimetablePage/components/Curriculum';
 import Timetable from 'components/TimetablePage/components/Timetable';
+import TimetableGridPlaceholder from 'components/TimetablePage/components/TimetableGridPlaceholder';
 import TotalGrades from 'components/TimetablePage/components/TotalGrades';
 import useMyLectures from 'components/TimetablePage/hooks/useMyLectures';
 import useSemesterCheck from 'components/TimetablePage/hooks/useMySemester';
@@ -21,7 +23,105 @@ import { useSemester } from 'utils/zustand/semester';
 import DownloadTimetableModal from './DownloadTimetableModal';
 import styles from './MyLectureTimetable.module.scss';
 
-function MainTimetable({ timetableFrameId }: { timetableFrameId: number }) {
+interface MainTimetableLayoutProps {
+  curriculum: React.ReactNode;
+  myLectures: Lecture[] | MyLectureInfo[] | undefined;
+  onClickDownloadImage: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClickEdit: () => void;
+  onClickGraduation: () => void;
+  timetableContent: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+function MainTimetableLayout({
+  curriculum,
+  myLectures,
+  onClickDownloadImage,
+  onClickEdit,
+  onClickGraduation,
+  timetableContent,
+  footer,
+}: MainTimetableLayoutProps) {
+  return (
+    <div className={styles['page__timetable-wrap']}>
+      <div className={styles.page__filter}>
+        <div className={styles['page__total-grades']}>
+          <TotalGrades myLectureList={myLectures} />
+        </div>
+        <button type="button" className={styles.page__button} onClick={onClickGraduation}>
+          <GraduationIcon />
+          졸업학점 계산기
+        </button>
+        {curriculum}
+        <button type="button" className={styles.page__button} onClick={onClickDownloadImage}>
+          <DownloadIcon />
+          이미지 저장
+        </button>
+        <button type="button" className={styles.page__button} onClick={onClickEdit}>
+          <div className={styles['page__edit-icon']}>
+            <EditIcon />
+          </div>
+          시간표 수정
+        </button>
+      </div>
+      <div className={styles.page__timetable}>{timetableContent}</div>
+      <div>{footer}</div>
+    </div>
+  );
+}
+
+function InvalidMainTimetable() {
+  const token = useTokenState();
+  const semester = useSemester();
+  const logger = useLogger();
+  const router = useRouter();
+  const { data: timeTableFrameList } = useTimetableFrameList(token, semester);
+  const { data: deptList } = useSuspenseQuery(deptQueries.list());
+  const { data: mySemester } = useSemesterCheck(token);
+
+  const isSemesterAndTimetableExist = () => {
+    if (mySemester?.semesters.length === 0) {
+      toast.error('학기가 존재하지 않습니다. 학기를 추가해주세요.');
+      return false;
+    }
+
+    if (!timeTableFrameList.some((frame) => isValidTimetableFrameId(frame.id))) {
+      toast.error('시간표가 존재하지 않습니다. 시간표를 추가해주세요.');
+      return false;
+    }
+
+    return true;
+  };
+
+  const onClickDownloadImage = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    isSemesterAndTimetableExist();
+  };
+
+  const onClickEdit = () => {
+    isSemesterAndTimetableExist();
+  };
+
+  return (
+    <MainTimetableLayout
+      curriculum={<Curriculum list={deptList} />}
+      myLectures={[]}
+      onClickDownloadImage={onClickDownloadImage}
+      onClickEdit={onClickEdit}
+      onClickGraduation={() => {
+        router.push(ROUTES.GraduationCalculator());
+        logger.actionEventClick({
+          team: 'USER',
+          event_label: 'graduation_calculator',
+          value: '졸업학점 계산기',
+        });
+      }}
+      timetableContent={<TimetableGridPlaceholder columnWidth={140} firstColumnWidth={70} rowHeight={33} totalHeight={700} />}
+    />
+  );
+}
+
+function ValidMainTimetable({ timetableFrameId }: { timetableFrameId: number }) {
   const [isModalOpen, openModal, closeModal] = useBooleanState(false);
   const token = useTokenState();
   const semester = useSemester();
@@ -69,50 +169,33 @@ function MainTimetable({ timetableFrameId }: { timetableFrameId: number }) {
   };
 
   return (
-    <div className={styles['page__timetable-wrap']}>
-      <div className={styles.page__filter}>
-        <div className={styles['page__total-grades']}>
-          <TotalGrades myLectureList={myLectures} />
-        </div>
-        <button
-          type="button"
-          className={styles.page__button}
-          onClick={() => {
-            router.push(ROUTES.GraduationCalculator());
-            logger.actionEventClick({
-              team: 'USER',
-              event_label: 'graduation_calculator',
-              value: '졸업학점 계산기',
-            });
-          }}
-        >
-          <GraduationIcon />
-          졸업학점 계산기
-        </button>
-        <Curriculum list={deptList} />
-        <button type="button" className={styles.page__button} onClick={onClickDownloadImage}>
-          <DownloadIcon />
-          이미지 저장
-        </button>
-        <button type="button" className={styles.page__button} onClick={onClickEdit}>
-          <div className={styles['page__edit-icon']}>
-            <EditIcon />
-          </div>
-          시간표 수정
-        </button>
-      </div>
-      <div className={styles.page__timetable}>
-        <Timetable
-          timetableFrameId={timetableFrameId}
-          columnWidth={140}
-          firstColumnWidth={70}
-          rowHeight={33}
-          totalHeight={700}
-        />
-      </div>
-      <div>{isModalOpen && <DownloadTimetableModal onClose={closeModal} timetableFrameId={timetableFrameId} />}</div>
-    </div>
+    <MainTimetableLayout
+      curriculum={<Curriculum list={deptList} />}
+      myLectures={myLectures}
+      onClickDownloadImage={onClickDownloadImage}
+      onClickEdit={onClickEdit}
+      onClickGraduation={() => {
+        router.push(ROUTES.GraduationCalculator());
+        logger.actionEventClick({
+          team: 'USER',
+          event_label: 'graduation_calculator',
+          value: '졸업학점 계산기',
+        });
+      }}
+      timetableContent={
+        <Timetable timetableFrameId={timetableFrameId} columnWidth={140} firstColumnWidth={70} rowHeight={33} totalHeight={700} />
+      }
+      footer={isModalOpen && <DownloadTimetableModal onClose={closeModal} timetableFrameId={timetableFrameId} />}
+    />
   );
+}
+
+function MainTimetable({ timetableFrameId }: { timetableFrameId: number }) {
+  if (!isValidTimetableFrameId(timetableFrameId)) {
+    return <InvalidMainTimetable />;
+  }
+
+  return <ValidMainTimetable timetableFrameId={timetableFrameId} />;
 }
 
 export default MainTimetable;

--- a/src/components/TimetablePage/components/MainTimetable/index.tsx
+++ b/src/components/TimetablePage/components/MainTimetable/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { deptQueries } from 'api/dept/queries';
+import { isValidTimetableFrameId } from 'api/timetable/queries';
 import DownloadIcon from 'assets/svg/download-icon.svg';
 import GraduationIcon from 'assets/svg/graduation-icon.svg';
 import EditIcon from 'assets/svg/pen-icon.svg';
@@ -37,7 +38,7 @@ function MainTimetable({ timetableFrameId }: { timetableFrameId: number }) {
       return false;
     }
 
-    if (timeTableFrameList.length === 0) {
+    if (!timeTableFrameList.some((frame) => isValidTimetableFrameId(frame.id))) {
       toast.error('시간표가 존재하지 않습니다. 시간표를 추가해주세요.');
       return false;
     }

--- a/src/components/TimetablePage/components/TimetableGridPlaceholder/index.tsx
+++ b/src/components/TimetablePage/components/TimetableGridPlaceholder/index.tsx
@@ -1,0 +1,93 @@
+import { cn } from '@bcsdlab/utils';
+import { DAYS_STRING } from 'static/timetable';
+import styles from 'components/TimetablePage/components/Timetable/Timetable.module.scss';
+
+const DEFAULT_TIME_STRING = ['9', '10', '11', '12', '13', '14', '15', '16', '17', '18'].flatMap((time) => [
+  time,
+  '',
+]);
+
+interface TimetableGridPlaceholderProps {
+  firstColumnWidth: number;
+  columnWidth: number;
+  rowHeight: number;
+  totalHeight: number;
+}
+
+export default function TimetableGridPlaceholder({
+  firstColumnWidth,
+  columnWidth,
+  rowHeight,
+  totalHeight,
+}: TimetableGridPlaceholderProps) {
+  const columnHeight = DEFAULT_TIME_STRING.length * rowHeight;
+
+  return (
+    <div className={styles.timetable} style={{ height: `${totalHeight}px`, fontSize: `${rowHeight / 2}px` }} aria-hidden>
+      <div className={styles.timetable__head} style={{ height: `${rowHeight + 5}px` }}>
+        <div
+          className={cn({
+            [styles.timetable__col]: true,
+            [styles['timetable__col--head']]: true,
+          })}
+          style={{ width: `${firstColumnWidth}px` }}
+        />
+        {DAYS_STRING.map((day) => (
+          <div
+            className={cn({
+              [styles.timetable__col]: true,
+              [styles['timetable__col--head']]: true,
+            })}
+            style={{ width: `${columnWidth}px` }}
+            key={day}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+      <div className={styles.timetable__content} style={{ height: `${20 * rowHeight}px` }}>
+        <div className={styles['timetable__row-container']} aria-hidden="true">
+          {DEFAULT_TIME_STRING.map((value, index) => (
+            <div
+              className={styles['timetable__row-line']}
+              style={{ height: `${rowHeight + 1}px` }}
+              key={`placeholder-row-${value}-${index}`}
+            />
+          ))}
+        </div>
+        <div
+          className={styles.timetable__col}
+          style={{
+            width: `${firstColumnWidth}px`,
+            fontSize: `${rowHeight / 2}px`,
+            height: `${columnHeight}px`,
+          }}
+          aria-hidden="true"
+        >
+          {DEFAULT_TIME_STRING.map((value, index) => (
+            <div
+              style={{ height: `${rowHeight}px` }}
+              key={`placeholder-time-${value}-${index}`}
+              className={
+                columnWidth > 50 ? styles['timetable__content--time'] : styles['timetable__content--time-main']
+              }
+            >
+              {value}
+            </div>
+          ))}
+        </div>
+
+        {DAYS_STRING.map((day) => (
+          <div
+            className={styles.timetable__col}
+            style={{
+              width: `${columnWidth}px`,
+              height: `${columnHeight}px`,
+            }}
+            key={`placeholder-day-${day}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/timetable/index.tsx
+++ b/src/pages/timetable/index.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import type { GetServerSidePropsContext } from 'next';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { isKoinError } from '@bcsdlab/koin';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { deptQueries } from 'api/dept/queries';
-import { createDefaultTimetableFrameList, timetableQueries, timetableQueryKeys } from 'api/timetable/queries';
+import {
+  createDefaultTimetableFrameList,
+  isValidTimetableFrameId,
+  timetableQueries,
+  timetableQueryKeys,
+} from 'api/timetable/queries';
 import { SSRLayout } from 'components/layout';
 import useTimetableFrameList from 'components/TimetablePage/hooks/useTimetableFrameList';
 import DefaultPage from 'components/TimetablePage/MainTimetablePage/DefaultPage';
@@ -30,7 +35,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const year = Number(query.year);
   const term = query.term as Term;
   const frameId = Number(query.timetableFrameId);
-  const validatedFrameId = Number.isNaN(frameId) ? null : frameId;
+  const validatedFrameId = isValidTimetableFrameId(frameId) ? frameId : null;
 
   if (token) {
     try {
@@ -80,24 +85,24 @@ function TimetablePage() {
   const { timetableFrameId } = router.query;
   const { data: timetableFrameList } = useTimetableFrameList(token, semester);
   const mainFrame = timetableFrameList.find((frame) => frame.is_main === true);
-  const [currentFrameIndex, setCurrentFrameIndex] = React.useState(mainFrame?.id ? mainFrame.id : 0);
+  const mainFrameId = isValidTimetableFrameId(mainFrame?.id) ? mainFrame.id : 0;
+  const queryFrameId = typeof timetableFrameId === 'string' ? Number(timetableFrameId) : Number.NaN;
+  const initialFrameId = isValidTimetableFrameId(queryFrameId) ? queryFrameId : mainFrameId;
+  const [currentFrameIndex, setCurrentFrameIndex] = useState(initialFrameId);
+  const resolvedCurrentFrameIndex = timetableFrameList.some((frame) => frame.id === currentFrameIndex)
+    ? currentFrameIndex
+    : initialFrameId;
 
-  React.useEffect(() => {
-    if (timetableFrameId) {
-      setCurrentFrameIndex(Number(timetableFrameId));
-    } else {
-      setCurrentFrameIndex(mainFrame?.id ? mainFrame.id : 0);
-    }
+  useEffect(() => {
     sessionStorage.setItem('enterTimetablePage', new Date().getTime().toString());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <div className={styles.page}>
       {!isMobile ? (
-        <DefaultPage timetableFrameId={currentFrameIndex} setCurrentFrameId={setCurrentFrameIndex} />
+        <DefaultPage timetableFrameId={resolvedCurrentFrameIndex} setCurrentFrameId={setCurrentFrameIndex} />
       ) : (
-        <MobilePage timetableFrameId={currentFrameIndex} setCurrentFrameId={setCurrentFrameIndex} />
+        <MobilePage timetableFrameId={resolvedCurrentFrameIndex} setCurrentFrameId={setCurrentFrameIndex} />
       )}
     </div>
   );


### PR DESCRIPTION
- Close #1224

## What is this PR? 🔍

- 기능 : PC 시간표 관련 invalid frame id 조회를 막고, 홈 우측 시간표 위젯이 빈 시간표 셸을 렌더하도록 수정
- issue : #1224

## Changes 📝

- `timetable_frame_id`가 `0` 또는 `null` 상태일 때 시간표 상세 조회가 나가지 않도록 공통 가드를 추가했습니다.
- `/timetable` 페이지에서 invalid query/main frame 값을 직접 state 로 밀어넣지 않도록 정리해 클라이언트 예외 경로를 제거했습니다.
- 시간표가 실제로 없는 경우 수정/다운로드 액션이 잘못된 frame 기준으로 진행되지 않도록 체크를 강화했습니다.
- 메인 홈 우측 시간표 위젯은 연회색 박스 대신 빈 시간표 셸을 렌더하도록 바꿨습니다.

## ScreenShot 📷

- 없음

## Test CheckList ✅

- [x] `yarn eslint src/api/timetable/queries.ts src/components/IndexComponents/IndexTimetable/index.tsx src/components/TimetablePage/components/MainTimetable/index.tsx src/pages/timetable/index.tsx`
- [x] `yarn tsc --noEmit`
- [x] 유효한 frame id 가 없을 때 홈 위젯과 `/timetable` 페이지가 안전하게 렌더되도록 코드 경로 점검

## Precaution

- 작업 범위와 무관한 `src/assets/images/` 미추적 파일은 PR에 포함하지 않았습니다.
- `caniuse-lite is outdated` 경고는 기존 환경 경고로, 이번 수정 범위와는 별개입니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 유효하지 않은 시간표 ID에 대한 조회가 null로 안정화되어 잘못된 데이터 호출 방지
  * 다운로드/편집 등 동작에서 유효성 검증을 추가해 잘못된 상태 진행 차단

* **개선사항**
  * 유효한 프레임 ID가 없을 때 일관된 자리표시자(플레이스홀더)를 표시하도록 UI 개선
  * 초기 프레임 선택 및 렌더링 결정 로직을 개선해 시간표 표시 신뢰도 향상
* **신규**
  * 자리표시자 형태의 스켈레톤 컴포넌트 추가로 비어있는 상태 시 가시성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->