### PR TITLE
[공통] Next.js prefetch 및 ssr 서버 요청으로 인한 페이지 이동 및 로드 속도 저하 문제 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 import { withSentryConfig } from '@sentry/nextjs';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  compress: false,
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/i,

--- a/src/api/review/mutations.ts
+++ b/src/api/review/mutations.ts
@@ -9,7 +9,8 @@ interface ReviewMutationCallbacks {
 
 const invalidateStoreReviewQueries = async (queryClient: QueryClient, shopId: string) => {
   await Promise.all([
-    queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId)) }),
+    queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId), 'public') }),
+    queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId), 'auth') }),
     queryClient.invalidateQueries({ queryKey: storeQueryKeys.myReviews(shopId) }),
     queryClient.invalidateQueries({ queryKey: storeQueryKeys.detail(shopId) }),
     queryClient.invalidateQueries({ queryKey: storeQueryKeys.detailPage(shopId) }),

--- a/src/api/store/mutations.ts
+++ b/src/api/store/mutations.ts
@@ -9,7 +9,8 @@ interface StoreMutationCallbacks {
 
 const invalidateStoreReviewQueries = async (queryClient: QueryClient, shopId: string) => {
   await Promise.all([
-    queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId)) }),
+    queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId), 'public') }),
+    queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId), 'auth') }),
     queryClient.invalidateQueries({ queryKey: storeQueryKeys.myReviews(shopId) }),
     queryClient.invalidateQueries({ queryKey: storeQueryKeys.detail(shopId) }),
     queryClient.invalidateQueries({ queryKey: storeQueryKeys.detailPage(shopId) }),
@@ -42,7 +43,10 @@ export const storeMutations = {
     mutationOptions({
       mutationFn: (data: ReviewReportRequest) => postReviewReport(Number(shopId), Number(reviewId), data, token),
       onSuccess: async () => {
-        await queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId)) });
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId), 'public') }),
+          queryClient.invalidateQueries({ queryKey: storeQueryKeys.reviews(Number(shopId), 'auth') }),
+        ]);
         await callbacks.onSuccess?.();
       },
     }),

--- a/src/api/store/queries.ts
+++ b/src/api/store/queries.ts
@@ -27,6 +27,12 @@ interface StoreReviewListQueryParams {
   token?: string;
 }
 
+export type StoreReviewViewerScope = 'public' | 'auth';
+
+export function getStoreReviewViewerScope(token?: string): StoreReviewViewerScope {
+  return token ? 'auth' : 'public';
+}
+
 export const storeQueryKeys = {
   all: ['store'] as const,
   categories: () => [...storeQueryKeys.all, 'categories'] as const,
@@ -40,11 +46,12 @@ export const storeQueryKeys = {
   benefitCategory: () => [...storeQueryKeys.all, 'benefit-category'] as const,
   benefitList: (id: string) => [...storeQueryKeys.all, 'benefit-list', id] as const,
   relatedSearch: (query: string) => [...storeQueryKeys.all, 'related-search', query] as const,
-  reviews: (shopId: number) => ['review', shopId] as const,
-  reviewFeed: (shopId: number, sorter: string) => [...storeQueryKeys.reviews(shopId), sorter] as const,
-  reviewList: ({ shopId, page, sorter }: Omit<StoreReviewListQueryParams, 'token'>) =>
-    [...storeQueryKeys.reviewFeed(shopId, sorter), page] as const,
-  myReviews: (shopId: string) => ['review', 'my-review', shopId] as const,
+  reviews: (shopId: number, viewerScope: StoreReviewViewerScope) => ['review', viewerScope, shopId] as const,
+  reviewFeed: (shopId: number, sorter: string, viewerScope: StoreReviewViewerScope) =>
+    [...storeQueryKeys.reviews(shopId, viewerScope), sorter] as const,
+  reviewList: ({ shopId, page, sorter, token }: StoreReviewListQueryParams) =>
+    [...storeQueryKeys.reviewFeed(shopId, sorter, getStoreReviewViewerScope(token)), page] as const,
+  myReviews: (shopId: string) => ['review', 'auth', 'my-review', shopId] as const,
   myReview: (shopId: string, sorter: string) => [...storeQueryKeys.myReviews(shopId), sorter] as const,
 };
 
@@ -105,13 +112,13 @@ export const storeQueries = {
 
   reviewList: ({ shopId, page, sorter, token }: StoreReviewListQueryParams) =>
     queryOptions({
-      queryKey: storeQueryKeys.reviewList({ shopId, page, sorter }),
+      queryKey: storeQueryKeys.reviewList({ shopId, page, sorter, token }),
       queryFn: () => getReviewList(shopId, page, sorter, token),
     }),
 
   reviewFeed: ({ shopId, sorter, token }: Omit<StoreReviewListQueryParams, 'page'>) =>
     infiniteQueryOptions({
-      queryKey: storeQueryKeys.reviewFeed(shopId, sorter),
+      queryKey: storeQueryKeys.reviewFeed(shopId, sorter, getStoreReviewViewerScope(token)),
       initialPageParam: 1,
       queryFn: ({ pageParam }) => getReviewList(shopId, pageParam, sorter, token),
       getNextPageParam: (lastPage) => {

--- a/src/components/IndexComponents/IndexArticles/index.tsx
+++ b/src/components/IndexComponents/IndexArticles/index.tsx
@@ -42,7 +42,11 @@ export default function IndexArticles() {
       <ul className={styles.list}>
         {articlesData?.articles.slice(0, 7).map((article) => (
           <li key={article.id} className={styles.list__item}>
-            <Link href={ROUTES.ArticlesDetail({ id: String(article.id) })} className={styles['list__item-link']}>
+            <Link
+              href={ROUTES.ArticlesDetail({ id: String(article.id) })}
+              prefetch={false}
+              className={styles['list__item-link']}
+            >
               <span className={styles['list__item-type']}>{convertArticlesTag(article.board_id)}</span>
               <span className={styles['list__item-title']}>{article.title}</span>
               {article.isNew && (

--- a/src/components/Store/StoreDetailPage/components/Review/components/AverageRating/AverageRating.tsx
+++ b/src/components/Store/StoreDetailPage/components/Review/components/AverageRating/AverageRating.tsx
@@ -1,13 +1,25 @@
-import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { storeQueries } from 'api/store/queries';
+import { useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { storeQueries, storeQueryKeys } from 'api/store/queries';
 import Rating from 'components/Store/StoreDetailPage/components/Review/components/Rating/Rating';
 import StarList from 'components/Store/StoreDetailPage/components/Review/components/StarList/StarList';
 import useTokenState from 'utils/hooks/state/useTokenState';
+import type { InfiniteData } from '@tanstack/react-query';
+import type { ReviewListResponse } from 'api/store/entity';
 import styles from './AverageRating.module.scss';
 
 export default function AverageRating({ id }: { id: string }) {
   const token = useTokenState();
-  const { data } = useSuspenseInfiniteQuery(storeQueries.reviewFeed({ shopId: Number(id), sorter: 'LATEST', token }));
+  const queryClient = useQueryClient();
+  const publicReviewFeedKey = storeQueryKeys.reviewFeed(Number(id), 'LATEST', 'public');
+  const publicInitialData = token
+    ? queryClient.getQueryData<InfiniteData<ReviewListResponse, number>>(publicReviewFeedKey)
+    : undefined;
+
+  const { data } = useSuspenseInfiniteQuery({
+    ...storeQueries.reviewFeed({ shopId: Number(id), sorter: 'LATEST', token }),
+    initialData: publicInitialData,
+    initialDataUpdatedAt: publicInitialData ? 0 : undefined,
+  });
   const totalReviewCount = data.pages[0].total_count;
 
   const ratingObject = data.pages[0].statistics;

--- a/src/components/Store/StoreDetailPage/components/Review/components/AverageRating/AverageRating.tsx
+++ b/src/components/Store/StoreDetailPage/components/Review/components/AverageRating/AverageRating.tsx
@@ -1,24 +1,15 @@
-import { useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { storeQueries, storeQueryKeys } from 'api/store/queries';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { storeQueries } from 'api/store/queries';
 import Rating from 'components/Store/StoreDetailPage/components/Review/components/Rating/Rating';
 import StarList from 'components/Store/StoreDetailPage/components/Review/components/StarList/StarList';
 import useTokenState from 'utils/hooks/state/useTokenState';
-import type { InfiniteData } from '@tanstack/react-query';
-import type { ReviewListResponse } from 'api/store/entity';
 import styles from './AverageRating.module.scss';
 
 export default function AverageRating({ id }: { id: string }) {
   const token = useTokenState();
-  const queryClient = useQueryClient();
-  const publicReviewFeedKey = storeQueryKeys.reviewFeed(Number(id), 'LATEST', 'public');
-  const publicInitialData = token
-    ? queryClient.getQueryData<InfiniteData<ReviewListResponse, number>>(publicReviewFeedKey)
-    : undefined;
 
   const { data } = useSuspenseInfiniteQuery({
     ...storeQueries.reviewFeed({ shopId: Number(id), sorter: 'LATEST', token }),
-    initialData: publicInitialData,
-    initialDataUpdatedAt: publicInitialData ? 0 : undefined,
   });
   const totalReviewCount = data.pages[0].total_count;
 

--- a/src/components/Store/StoreDetailPage/components/Review/components/ReviewList/ReviewList.tsx
+++ b/src/components/Store/StoreDetailPage/components/Review/components/ReviewList/ReviewList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useDeferredValue, useEffect, useRef, useState } from 'react';
-import { keepPreviousData, useQuery, useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { storeQueries, storeQueryKeys } from 'api/store/queries';
+import { keepPreviousData, useQuery, useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { storeQueries } from 'api/store/queries';
 import ChervronUp from 'assets/svg/chervron-up.svg';
 import NoReview from 'assets/svg/Review/no-review.svg';
 import LoginRequiredModal from 'components/modal/LoginRequiredModal';
@@ -12,8 +12,6 @@ import { useDropdown } from 'components/Store/StoreDetailPage/hooks/useDropdown'
 import useModalPortal from 'utils/hooks/layout/useModalPortal';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import { useUser } from 'utils/hooks/state/useUser';
-import type { InfiniteData } from '@tanstack/react-query';
-import type { ReviewListResponse } from 'api/store/entity';
 import styles from './ReviewList.module.scss';
 
 type SortType = 'LATEST' | 'OLDEST' | 'HIGHEST_RATING' | 'LOWEST_RATING';
@@ -42,11 +40,6 @@ export default function ReviewList({ id }: { id: string }) {
   const previousSortType = useDeferredValue(currentSortType);
   const currentSortLabel = typeToLabel[currentSortType];
   const token = useTokenState();
-  const queryClient = useQueryClient();
-  const publicReviewFeedKey = storeQueryKeys.reviewFeed(Number(id), previousSortType, 'public');
-  const publicInitialData = token
-    ? queryClient.getQueryData<InfiniteData<ReviewListResponse, number>>(publicReviewFeedKey)
-    : undefined;
 
   const { data, hasNextPage, fetchNextPage } = useSuspenseInfiniteQuery({
     ...storeQueries.reviewFeed({
@@ -54,8 +47,6 @@ export default function ReviewList({ id }: { id: string }) {
       sorter: previousSortType,
       token,
     }),
-    initialData: publicInitialData,
-    initialDataUpdatedAt: publicInitialData ? 0 : undefined,
   });
   const reviews = data.pages.flatMap((page) => page.reviews);
   const { data: myReview } = useQuery({

--- a/src/components/Store/StoreDetailPage/components/Review/components/ReviewList/ReviewList.tsx
+++ b/src/components/Store/StoreDetailPage/components/Review/components/ReviewList/ReviewList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useDeferredValue, useEffect, useRef, useState } from 'react';
-import { keepPreviousData, useQuery, useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { storeQueries } from 'api/store/queries';
+import { keepPreviousData, useQuery, useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { storeQueries, storeQueryKeys } from 'api/store/queries';
 import ChervronUp from 'assets/svg/chervron-up.svg';
 import NoReview from 'assets/svg/Review/no-review.svg';
 import LoginRequiredModal from 'components/modal/LoginRequiredModal';
@@ -12,6 +12,8 @@ import { useDropdown } from 'components/Store/StoreDetailPage/hooks/useDropdown'
 import useModalPortal from 'utils/hooks/layout/useModalPortal';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import { useUser } from 'utils/hooks/state/useUser';
+import type { InfiniteData } from '@tanstack/react-query';
+import type { ReviewListResponse } from 'api/store/entity';
 import styles from './ReviewList.module.scss';
 
 type SortType = 'LATEST' | 'OLDEST' | 'HIGHEST_RATING' | 'LOWEST_RATING';
@@ -40,13 +42,21 @@ export default function ReviewList({ id }: { id: string }) {
   const previousSortType = useDeferredValue(currentSortType);
   const currentSortLabel = typeToLabel[currentSortType];
   const token = useTokenState();
-  const { data, hasNextPage, fetchNextPage } = useSuspenseInfiniteQuery(
-    storeQueries.reviewFeed({
+  const queryClient = useQueryClient();
+  const publicReviewFeedKey = storeQueryKeys.reviewFeed(Number(id), previousSortType, 'public');
+  const publicInitialData = token
+    ? queryClient.getQueryData<InfiniteData<ReviewListResponse, number>>(publicReviewFeedKey)
+    : undefined;
+
+  const { data, hasNextPage, fetchNextPage } = useSuspenseInfiniteQuery({
+    ...storeQueries.reviewFeed({
       shopId: Number(id),
       sorter: previousSortType,
       token,
     }),
-  );
+    initialData: publicInitialData,
+    initialDataUpdatedAt: publicInitialData ? 0 : undefined,
+  });
   const reviews = data.pages.flatMap((page) => page.reviews);
   const { data: myReview } = useQuery({
     ...storeQueries.myReview(id, previousSortType, token),

--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -118,9 +118,11 @@ function Footer(): JSX.Element {
                   아우누리 바로가기
                 </a>
               </li>
-              <Link href={ROUTES.PrivatePolicy()} prefetch={false} className={styles.sitemap__link}>
-                개인정보 처리방침
-              </Link>
+              <li className={styles.sitemap__link}>
+                <Link href={ROUTES.PrivatePolicy()} prefetch={false}>
+                  개인정보 처리방침
+                </Link>
+              </li>
             </ul>
           ) : (
             <ul className={styles.sitemap__content}>
@@ -144,9 +146,11 @@ function Footer(): JSX.Element {
                   BCSD Lab 바로가기
                 </a>
               </li>
-              <Link href={ROUTES.PrivatePolicy()} prefetch={false} className={styles.sitemap__link}>
-                개인정보 처리방침
-              </Link>
+              <li className={styles.sitemap__link}>
+                <Link href={ROUTES.PrivatePolicy()} prefetch={false}>
+                  개인정보 처리방침
+                </Link>
+              </li>
             </ul>
           )}
           <div className={styles['sitemap__icon-links']}>

--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -76,6 +76,7 @@ function Footer(): JSX.Element {
                 <li className={styles.footer__service} key={submenuInfo.title}>
                   <Link
                     href={isStage && submenuInfo.stageLink ? submenuInfo.stageLink : submenuInfo.link}
+                    prefetch={false}
                     onClick={(e) => handleClickMenu(e, submenuInfo.title)}
                   >
                     {submenuInfo.title}
@@ -117,7 +118,7 @@ function Footer(): JSX.Element {
                   아우누리 바로가기
                 </a>
               </li>
-              <Link href={ROUTES.PrivatePolicy()} className={styles.sitemap__link}>
+              <Link href={ROUTES.PrivatePolicy()} prefetch={false} className={styles.sitemap__link}>
                 개인정보 처리방침
               </Link>
             </ul>
@@ -143,7 +144,7 @@ function Footer(): JSX.Element {
                   BCSD Lab 바로가기
                 </a>
               </li>
-              <Link href={ROUTES.PrivatePolicy()} className={styles.sitemap__link}>
+              <Link href={ROUTES.PrivatePolicy()} prefetch={false} className={styles.sitemap__link}>
                 개인정보 처리방침
               </Link>
             </ul>

--- a/src/components/layout/Header/PCHeader/index.tsx
+++ b/src/components/layout/Header/PCHeader/index.tsx
@@ -242,7 +242,12 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
               return (
                 <li className={styles.megamenu__menu} key={menu.title}>
                   {/* TODO: 키보드 Focus 접근성 향상 */}
-                  <Link className={styles.megamenu__link} href={href} onClick={(e) => handleMenuClick(e, menu.title)}>
+                  <Link
+                    className={styles.megamenu__link}
+                    href={href}
+                    prefetch={false}
+                    onClick={(e) => handleMenuClick(e, menu.title)}
+                  >
                     {menu.title}
                   </Link>
                 </li>
@@ -257,6 +262,7 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
             <li className={styles['header__auth-link']}>
               <Link
                 href={ROUTES.AuthSignup({ currentStep: '약관동의' })}
+                prefetch={false}
                 onClick={() => {
                   sessionLogger.actionSessionEvent({
                     session_name: 'sign_up',
@@ -272,6 +278,7 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
             <li className={styles['header__auth-link']}>
               <Link
                 href={ROUTES.Auth()}
+                prefetch={false}
                 onClick={() => {
                   logger.actionEventClick({
                     team: 'USER',

--- a/src/components/ui/Banner/index.tsx
+++ b/src/components/ui/Banner/index.tsx
@@ -7,7 +7,7 @@ import { useSwipeable } from 'react-swipeable';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
-import { setCookie } from 'utils/ts/cookie';
+import { getCookie, setCookie } from 'utils/ts/cookie';
 import styles from './Banner.module.scss';
 
 interface BannerCardProps {
@@ -63,18 +63,34 @@ function BannerCard({ handleImageLinkClick, image_url, redirect_link, isFirst }:
 interface BannerProps {
   bannersList: BannersResponse;
   bannerCategoryId: number;
-  isBannerOpen: boolean;
 }
 
 const HIDE_BANNER_DURATION_DAYS = 7;
+const HIDE_BANNER_COOKIE = 'HIDE_BANNER';
 
-function Banner({ bannersList, bannerCategoryId, isBannerOpen }: BannerProps) {
+function Banner({ bannersList, bannerCategoryId }: BannerProps) {
   const isMobile = useMediaQuery();
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const logger = useLogger();
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const currentBanner = bannersList.banners[currentPageIndex];
-  const [isModalOpen, , closeModal] = useBooleanState(isBannerOpen);
+  const [isModalOpen, openModal, closeModal] = useBooleanState(false);
+
+  useEffect(() => {
+    if (bannersList.count === 0) {
+      closeModal();
+      return;
+    }
+
+    // 배너 노출 여부를 SSR에서 분리해 페이지 HTML 캐시를 안전하게 유지
+    const isBannerHidden = getCookie(HIDE_BANNER_COOKIE) === `modal_category_${bannerCategoryId}`;
+    if (isBannerHidden) {
+      closeModal();
+      return;
+    }
+
+    openModal();
+  }, [bannerCategoryId, bannersList.count, closeModal, openModal]);
 
   const resetAutoSlide = useCallback(() => {
     if (intervalRef.current) clearTimeout(intervalRef.current);
@@ -128,7 +144,7 @@ function Banner({ bannersList, bannerCategoryId, isBannerOpen }: BannerProps) {
       value: `${currentBanner.title}`,
     });
     if (bannerCategoryId === 1) {
-      setCookie('HIDE_BANNER', `modal_category_${bannerCategoryId}`, HIDE_BANNER_DURATION_DAYS);
+      setCookie(HIDE_BANNER_COOKIE, `modal_category_${bannerCategoryId}`, HIDE_BANNER_DURATION_DAYS);
     }
     closeModal();
   };

--- a/src/pages/articles/[id]/index.tsx
+++ b/src/pages/articles/[id]/index.tsx
@@ -1,26 +1,65 @@
-import { GetServerSidePropsContext } from 'next';
-import { getArticle } from 'api/articles';
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import { getArticle, getArticles } from 'api/articles';
 import { ArticleResponseWithNew } from 'api/articles/entity';
 import ArticlesPageLayout from 'components/Articles/ArticlesPage';
 import ArticleContent from 'components/Articles/components/ArticleContent';
 import ArticleHeader from 'components/Articles/components/ArticleHeader';
 import { isNewArticle } from 'components/Articles/utils/setArticleRegisteredDate';
 import { SSRLayout } from 'components/layout';
+import {
+  ARTICLE_DETAIL_ISR_REVALIDATE_SECONDS,
+  ARTICLE_HOT_PATH_LIMIT,
+  isNotFoundKoinError,
+  withStaticFetchRetry,
+} from 'utils/ts/isr';
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const id = ctx.query.id;
-  if (typeof id !== 'string') {
-    return { notFound: true };
+export const getStaticPaths: GetStaticPaths = async () => {
+  try {
+    const { articles } = await withStaticFetchRetry(() => getArticles('', '1'));
+
+    return {
+      paths: articles.slice(0, ARTICLE_HOT_PATH_LIMIT).map((article) => ({
+        params: { id: String(article.id) },
+      })),
+      fallback: 'blocking',
+    };
+  } catch (error) {
+    console.error('[ISR] failed to prebuild article detail paths:', error);
+
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
   }
-  const article = await getArticle(id);
-  const serverTime = new Date(); // 서버 시간 고정
+};
 
-  const articleWithNew: ArticleResponseWithNew = {
-    ...article,
-    isNew: isNewArticle(article.registered_at, serverTime),
-  };
+export const getStaticProps: GetStaticProps<{ article: ArticleResponseWithNew }, { id: string }> = async ({
+  params,
+}) => {
+  const id = params?.id;
+  if (!id) {
+    return { notFound: true, revalidate: ARTICLE_DETAIL_ISR_REVALIDATE_SECONDS };
+  }
 
-  return { props: { article: articleWithNew } };
+  try {
+    const article = await withStaticFetchRetry(() => getArticle(id));
+    const serverTime = new Date();
+
+    const articleWithNew: ArticleResponseWithNew = {
+      ...article,
+      isNew: isNewArticle(article.registered_at, serverTime),
+    };
+
+    return {
+      props: { article: articleWithNew },
+      revalidate: ARTICLE_DETAIL_ISR_REVALIDATE_SECONDS,
+    };
+  } catch (error) {
+    if (isNotFoundKoinError(error)) {
+      return { notFound: true, revalidate: ARTICLE_DETAIL_ISR_REVALIDATE_SECONDS };
+    }
+    throw error;
+  }
 };
 
 export default function ArticlesDetailPage({ article }: { article: ArticleResponseWithNew }) {

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -12,8 +12,9 @@ import { SSRLayout } from 'components/layout';
 import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const { token, query } = parseServerSideParams(context);
   const pageNumber = typeof query.page === 'string' ? query.page : '1';
 
@@ -26,13 +27,17 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   await Promise.all(prefetchPromises);
 
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
       initialPage: pageNumber,
     },
   };
-};
+});
 
 function usePageParams(initialPage: string) {
   const router = useRouter();

--- a/src/pages/benefitstore/index.tsx
+++ b/src/pages/benefitstore/index.tsx
@@ -11,9 +11,10 @@ import { STORE_PAGE } from 'static/store';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useParamsHandler from 'utils/hooks/routing/useParamsHandler';
+import { STORE_PUBLIC_SSR_CACHE_CONTROL, withCacheControl } from 'utils/ts/withCacheControl';
 import styles from './StoreBenefitPage.module.scss';
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const queryClient = new QueryClient();
   const { category } = context.query;
   const categoryId = Array.isArray(category) ? category[0] : category;
@@ -31,12 +32,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // StoreList 페이지에서 사용하는 API
   await queryClient.prefetchQuery(storeQueries.categories());
 
+  cacheControl.enablePublicCache(STORE_PUBLIC_SSR_CACHE_CONTROL);
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
   };
-}
+});
 
 function StoreBenefit() {
   const { params, searchParams, setParams } = useParamsHandler();

--- a/src/pages/bus/shuttle/index.tsx
+++ b/src/pages/bus/shuttle/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GetServerSideProps } from 'next';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import { dehydrate, QueryClient, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { busQueries } from 'api/bus/queries';
@@ -15,6 +15,7 @@ import { BUS_FEEDBACK_FORM, SHUTTLE_COURSES } from 'static/bus';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useMount from 'utils/hooks/state/useMount';
+import { BUS_SHUTTLE_ISR_REVALIDATE_SECONDS, withStaticFetchRetry } from 'utils/ts/isr';
 import styles from './ShuttleBusTimetable.module.scss';
 
 interface TemplateShuttleVersionProps {
@@ -32,18 +33,21 @@ function asString(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery({
-    ...busQueries.shuttleCourse(),
-    staleTime: 1000 * 60 * 10,
-  });
+  await withStaticFetchRetry(() =>
+    queryClient.prefetchQuery({
+      ...busQueries.shuttleCourse(),
+      staleTime: 1000 * 60 * 10,
+    }),
+  );
 
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
+    revalidate: BUS_SHUTTLE_ISR_REVALIDATE_SECONDS,
   };
 };
 

--- a/src/pages/bus/shuttle/index.tsx
+++ b/src/pages/bus/shuttle/index.tsx
@@ -37,7 +37,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const queryClient = new QueryClient();
 
   await withStaticFetchRetry(() =>
-    queryClient.prefetchQuery({
+    queryClient.fetchQuery({
       ...busQueries.shuttleCourse(),
       staleTime: 1000 * 60 * 10,
     }),

--- a/src/pages/cafeteria/index.tsx
+++ b/src/pages/cafeteria/index.tsx
@@ -13,9 +13,10 @@ import { useSessionLogger } from 'utils/hooks/analytics/useSessionLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import styles from './Cafeteria.module.scss';
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const queryClient = new QueryClient();
   const { date } = context.query;
 
@@ -27,12 +28,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   await queryClient.prefetchQuery(coopshopQueries.cafeteriaInfo());
 
+  cacheControl.enablePublicCache();
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
   };
-}
+});
 
 function Cafeteria() {
   const isMobile = useMediaQuery();

--- a/src/pages/clubs/[id]/index.tsx
+++ b/src/pages/clubs/[id]/index.tsx
@@ -36,6 +36,7 @@ import useTokenState from 'utils/hooks/state/useTokenState';
 import { formatPhoneNumber } from 'utils/ts/formatPhoneNumber';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
 import showToast from 'utils/ts/showToast';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import { useHeaderTitle } from 'utils/zustand/customTitle';
 import styles from './ClubDetailPage.module.scss';
 
@@ -58,7 +59,7 @@ const TAB: Record<string, TabType> = {
   'Q&A': 'qna',
 };
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const { params, query } = context;
   const { token } = parseServerSideParams(context);
   const id = params?.id;
@@ -90,6 +91,10 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     await queryClient.prefetchQuery(clubQueries.eventDetail(clubId, numericEventId));
   }
 
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
@@ -98,7 +103,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       initialEventId: numericEventId,
     },
   };
-};
+});
 
 interface ClubDetailPageProps {
   initialClubId: number;

--- a/src/pages/clubs/index.tsx
+++ b/src/pages/clubs/index.tsx
@@ -30,6 +30,7 @@ import {
   parseQueryString,
   parseServerSideParams,
 } from 'utils/ts/parseServerSideParams';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import styles from './ClubListPage.module.scss';
 
 const DEFAULT_OPTION_INDEX = 0;
@@ -71,7 +72,7 @@ export const parseClubListQuery = createQueryParser<ClubListQuery>({
   },
 });
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const { token, query } = parseServerSideParams(context);
   const params = parseClubListQuery(query);
 
@@ -90,6 +91,10 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     ),
   ]);
 
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
@@ -97,7 +102,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       serverToken: token ?? null,
     },
   };
-};
+});
 
 function ClubListPage({ initialQuery, serverToken }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const logger = useLogger();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,9 +20,10 @@ import { COOKIE_KEY } from 'static/url';
 import { getRecentSemester } from 'utils/timetable/semester';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
 import { clearServerAuthCookies, isServerAuthError } from 'utils/ts/ssrAuth';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import styles from './IndexPage.module.scss';
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const queryClient = new QueryClient();
   let token = parseServerSideParams(context).token ?? '';
   let userType = context.req.cookies[COOKIE_KEY.AUTH_USER_TYPE] || '';
@@ -88,6 +89,10 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     }
   }
 
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
   return {
     props: {
       bannerCategoryId,
@@ -98,7 +103,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       dehydratedState: dehydrate(queryClient),
     },
   };
-};
+});
 
 function Index({
   bannersList,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -67,8 +67,6 @@ export const getServerSideProps = withCacheControl(async (context: GetServerSide
 
   const bannerCategoryId = Number(banners.banner_categories[0].id);
   const bannersList = await queryClient.fetchQuery(bannerQueries.list(bannerCategoryId));
-  const isBannerOpen =
-    context.req.cookies['HIDE_BANNER'] !== `modal_category_${bannerCategoryId}` && bannersList.count !== 0;
 
   if (token && userType === 'STUDENT') {
     try {
@@ -97,7 +95,6 @@ export const getServerSideProps = withCacheControl(async (context: GetServerSide
     props: {
       bannerCategoryId,
       bannersList,
-      isBannerOpen,
       categories,
       hotClubInfo,
       dehydratedState: dehydrate(queryClient),
@@ -110,11 +107,10 @@ function Index({
   categories,
   // hotClubInfo,
   bannerCategoryId,
-  isBannerOpen,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <main className={styles.template}>
-      <Banner bannersList={bannersList} bannerCategoryId={bannerCategoryId} isBannerOpen={isBannerOpen} />
+      <Banner bannersList={bannersList} bannerCategoryId={bannerCategoryId} />
       <UserInfoModal />
       <div className={styles['left-container']}>
         <IndexStore categories={categories} />

--- a/src/pages/lost-item/[id]/index.tsx
+++ b/src/pages/lost-item/[id]/index.tsx
@@ -25,9 +25,10 @@ import useBooleanState from 'utils/hooks/state/useBooleanState';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import styles from './LostItemDetailPage.module.scss';
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const { token } = parseServerSideParams(context);
   const id = context.query.id;
   if (typeof id !== 'string') {
@@ -44,13 +45,17 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     queryClient.prefetchInfiniteQuery(articleQueries.lostItemInfiniteList(token ?? '', latestLostItemParams)),
   ]);
 
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
       articleId,
     },
   };
-};
+});
 
 interface LostItemDetailPageProps {
   articleId: number;

--- a/src/pages/lost-item/index.tsx
+++ b/src/pages/lost-item/index.tsx
@@ -13,9 +13,10 @@ import { SSRLayout } from 'components/layout';
 import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import styles from './LostItemArticleListPage.module.scss';
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const queryClient = new QueryClient();
   const { token, query } = parseServerSideParams(context);
 
@@ -34,13 +35,17 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   await queryClient.prefetchQuery(articleQueries.lostItemList(token ?? '', apiParams));
 
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
       initialParams: params,
     },
   };
-};
+});
 
 function useLostItemParams(initialParams: LostItemParams) {
   const router = useRouter();

--- a/src/pages/room/[id]/index.tsx
+++ b/src/pages/room/[id]/index.tsx
@@ -54,7 +54,7 @@ export const getStaticProps: GetStaticProps<RoomDetailPageProps, { id: string }>
   const queryClient = new QueryClient();
 
   try {
-    await withStaticFetchRetry(() => queryClient.prefetchQuery(roomQueries.detail(id)));
+    await withStaticFetchRetry(() => queryClient.fetchQuery(roomQueries.detail(id)));
   } catch (error) {
     if (isNotFoundKoinError(error)) {
       return { notFound: true, revalidate: ROOM_ISR_REVALIDATE_SECONDS };

--- a/src/pages/room/[id]/index.tsx
+++ b/src/pages/room/[id]/index.tsx
@@ -1,6 +1,7 @@
-import type { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
+import type { GetStaticPaths, GetStaticProps } from 'next';
 import Image from 'next/image';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
+import { getRoomList } from 'api/room';
 import { roomQueries } from 'api/room/queries';
 import { SSRLayout } from 'components/layout';
 import RoomDetailImg from 'components/Room/components/RoomDetailImg';
@@ -10,32 +11,67 @@ import RoomDetailTable from 'components/Room/components/RoomDetailTable';
 import useRoomDetail from 'components/Room/RoomDetailPage/hooks/useRoomDetail';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
-import { parseQueryString, parseServerSideParams } from 'utils/ts/parseServerSideParams';
+import {
+  isNotFoundKoinError,
+  ROOM_HOT_PATH_LIMIT,
+  ROOM_ISR_REVALIDATE_SECONDS,
+  withStaticFetchRetry,
+} from 'utils/ts/isr';
 import styles from './RoomDetailPage.module.scss';
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const { query } = parseServerSideParams(context);
-  const id = parseQueryString(query.id);
+interface RoomDetailPageProps {
+  id: string;
+}
 
-  if (!id) {
+export const getStaticPaths: GetStaticPaths = async () => {
+  try {
+    const { lands } = await withStaticFetchRetry(() => getRoomList());
+
     return {
-      notFound: true,
+      paths: lands
+        .filter((land) => !land.softDeleted)
+        .slice(0, ROOM_HOT_PATH_LIMIT)
+        .map((land) => ({
+          params: { id: String(land.id) },
+        })),
+      fallback: 'blocking',
+    };
+  } catch (error) {
+    console.error('[ISR] failed to prebuild room detail paths:', error);
+
+    return {
+      paths: [],
+      fallback: 'blocking',
     };
   }
+};
 
+export const getStaticProps: GetStaticProps<RoomDetailPageProps, { id: string }> = async ({ params }) => {
+  const id = params?.id;
+  if (!id) {
+    return { notFound: true, revalidate: ROOM_ISR_REVALIDATE_SECONDS };
+  }
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery(roomQueries.detail(id));
+  try {
+    await withStaticFetchRetry(() => queryClient.prefetchQuery(roomQueries.detail(id)));
+  } catch (error) {
+    if (isNotFoundKoinError(error)) {
+      return { notFound: true, revalidate: ROOM_ISR_REVALIDATE_SECONDS };
+    }
+    throw error;
+  }
 
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
       id,
     },
+    revalidate: ROOM_ISR_REVALIDATE_SECONDS,
   };
 };
 
-function RoomDetailPage({ id }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function RoomDetailPage({ id }: RoomDetailPageProps) {
   const isMobile = useMediaQuery();
   const { roomDetail, roomOptions } = useRoomDetail(id);
   useScrollToTop();

--- a/src/pages/room/index.tsx
+++ b/src/pages/room/index.tsx
@@ -16,7 +16,7 @@ const LOCATION = { latitude: 36.764617, longitude: 127.283154 };
 export const getStaticProps: GetStaticProps = async () => {
   const queryClient = new QueryClient();
 
-  await withStaticFetchRetry(() => queryClient.prefetchQuery(roomQueries.list()));
+  await withStaticFetchRetry(() => queryClient.fetchQuery(roomQueries.list()));
 
   return {
     props: {

--- a/src/pages/room/index.tsx
+++ b/src/pages/room/index.tsx
@@ -1,3 +1,4 @@
+import type { GetStaticProps } from 'next';
 import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
 import { roomQueries } from 'api/room/queries';
 import { SSRLayout } from 'components/layout';
@@ -7,19 +8,21 @@ import useNaverMap from 'components/Room/RoomPage/hooks/useNaverMap';
 import useNaverMapScript from 'components/Room/RoomPage/hooks/useNaverMapScript';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
+import { ROOM_ISR_REVALIDATE_SECONDS, withStaticFetchRetry } from 'utils/ts/isr';
 import styles from './RoomPage.module.scss';
 
 const LOCATION = { latitude: 36.764617, longitude: 127.283154 };
 
-export const getServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery(roomQueries.list());
+  await withStaticFetchRetry(() => queryClient.prefetchQuery(roomQueries.list()));
 
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
+    revalidate: ROOM_ISR_REVALIDATE_SECONDS,
   };
 };
 

--- a/src/pages/store/[id].tsx
+++ b/src/pages/store/[id].tsx
@@ -77,16 +77,15 @@ export const getStaticProps: GetStaticProps<Props, { id: string }> = async ({ pa
   try {
     await withStaticFetchRetry(() =>
       Promise.all([
-        queryClient.prefetchQuery(storeQueries.detail(storeId)),
-        queryClient.prefetchQuery(storeQueries.detailMenu(storeId)),
-        queryClient.prefetchQuery(
+        queryClient.fetchQuery(storeQueries.detail(storeId)),
+        queryClient.fetchQuery(storeQueries.detailMenu(storeId)),
+        queryClient.fetchQuery(
           storeQueries.reviewList({
             shopId: Number(storeId),
             page: 1,
             sorter: 'LATEST',
           }),
         ),
-        queryClient.prefetchQuery(storeQueries.eventList(storeId)),
       ]),
     );
   } catch (error) {
@@ -94,6 +93,13 @@ export const getStaticProps: GetStaticProps<Props, { id: string }> = async ({ pa
       return { notFound: true, revalidate: STORE_DETAIL_ISR_REVALIDATE_SECONDS };
     }
     throw error;
+  }
+
+  try {
+    // 이벤트/공지 탭 데이터는 부가 정보이므로 ISR 생성을 막지 않도록 분리합니다.
+    await withStaticFetchRetry(() => queryClient.fetchQuery(storeQueries.eventList(storeId)));
+  } catch (error) {
+    console.error(`[ISR] failed to prefetch optional store events for ${storeId}:`, error);
   }
 
   return {

--- a/src/pages/store/[id].tsx
+++ b/src/pages/store/[id].tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect, useRef } from 'react';
-import { GetServerSidePropsContext } from 'next';
+import type { GetStaticPaths, GetStaticProps } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { cn } from '@bcsdlab/utils';
@@ -11,6 +11,7 @@ import {
   useSuspenseQuery,
   type DehydratedState,
 } from '@tanstack/react-query';
+import { getStoreListV2 } from 'api/store';
 import { storeQueries, storeQueryKeys } from 'api/store/queries';
 import EmptyImageIcon from 'assets/svg/empty-thumbnail.svg';
 import Phone from 'assets/svg/Review/phone.svg';
@@ -32,6 +33,12 @@ import useParamsHandler from 'utils/hooks/routing/useParamsHandler';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
 import getDayOfWeek from 'utils/ts/getDayOfWeek';
+import {
+  isNotFoundKoinError,
+  STORE_DETAIL_ISR_REVALIDATE_SECONDS,
+  STORE_HOT_PATH_LIMIT,
+  withStaticFetchRetry,
+} from 'utils/ts/isr';
 import showToast from 'utils/ts/showToast';
 import styles from './StoreDetailPage.module.scss';
 
@@ -39,38 +46,64 @@ interface Props {
   id: string;
 }
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const queryClient = new QueryClient();
+export const getStaticPaths: GetStaticPaths = async () => {
+  try {
+    const { shops } = await withStaticFetchRetry(() => getStoreListV2('NONE', [], undefined));
 
-  const id = context.params!.id;
-  const storeId = Array.isArray(id) ? id[0] : id;
-
-  if (!storeId) {
     return {
-      notFound: true,
+      paths: shops.slice(0, STORE_HOT_PATH_LIMIT).map((shop) => ({
+        params: { id: String(shop.id) },
+      })),
+      fallback: 'blocking',
+    };
+  } catch (error) {
+    console.error('[ISR] failed to prebuild store detail paths:', error);
+
+    return {
+      paths: [],
+      fallback: 'blocking',
     };
   }
-  await Promise.all([
-    queryClient.prefetchQuery(storeQueries.detail(storeId)),
-    queryClient.prefetchQuery(storeQueries.detailMenu(storeId)),
-    queryClient.prefetchQuery(
-      storeQueries.reviewList({
-        shopId: Number(storeId),
-        page: 1,
-        sorter: 'LATEST',
-      }),
-    ),
-  ]);
+};
 
-  await queryClient.prefetchQuery(storeQueries.eventList(storeId));
+export const getStaticProps: GetStaticProps<Props, { id: string }> = async ({ params }) => {
+  const queryClient = new QueryClient();
+
+  const storeId = params?.id;
+  if (!storeId) {
+    return { notFound: true, revalidate: STORE_DETAIL_ISR_REVALIDATE_SECONDS };
+  }
+
+  try {
+    await withStaticFetchRetry(() =>
+      Promise.all([
+        queryClient.prefetchQuery(storeQueries.detail(storeId)),
+        queryClient.prefetchQuery(storeQueries.detailMenu(storeId)),
+        queryClient.prefetchQuery(
+          storeQueries.reviewList({
+            shopId: Number(storeId),
+            page: 1,
+            sorter: 'LATEST',
+          }),
+        ),
+        queryClient.prefetchQuery(storeQueries.eventList(storeId)),
+      ]),
+    );
+  } catch (error) {
+    if (isNotFoundKoinError(error)) {
+      return { notFound: true, revalidate: STORE_DETAIL_ISR_REVALIDATE_SECONDS };
+    }
+    throw error;
+  }
 
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
       id: storeId,
     },
+    revalidate: STORE_DETAIL_ISR_REVALIDATE_SECONDS,
   };
-}
+};
 
 function StoreDetailPage({ id }: Props) {
   const isMobile = useMediaQuery();

--- a/src/pages/store/index.tsx
+++ b/src/pages/store/index.tsx
@@ -3,7 +3,14 @@ import { GetServerSidePropsContext } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { cn } from '@bcsdlab/utils';
-import { dehydrate, HydrationBoundary, QueryClient, useQuery, useSuspenseQuery, type DehydratedState } from '@tanstack/react-query';
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+  useQuery,
+  useSuspenseQuery,
+  type DehydratedState,
+} from '@tanstack/react-query';
 import { storeQueries } from 'api/store/queries';
 import Close from 'assets/svg/close-icon-20x20.svg';
 import DesktopStoreList from 'components/Store/StorePage/components/DesktopStoreList';
@@ -19,10 +26,10 @@ import useLogger from 'utils/hooks/analytics/useLogger';
 import { useScrollLogging } from 'utils/hooks/analytics/useScrollLogging';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
-
 import { useLocalStorage } from 'utils/hooks/state/useLocalStorage';
 import useMount from 'utils/hooks/state/useMount';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
+import { STORE_PUBLIC_SSR_CACHE_CONTROL, withCacheControl } from 'utils/ts/withCacheControl';
 import type { StoreSorterType, StoreFilterType, StoreCategory } from 'api/store/entity';
 import styles from './StorePage.module.scss';
 
@@ -98,7 +105,7 @@ const useStoreList = (sorter: StoreSorterType, filter: StoreFilterType[], params
   return storeList || [];
 };
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const queryClient = new QueryClient();
 
   const { storeName } = context.query;
@@ -116,12 +123,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   await queryClient.prefetchQuery(storeQueries.allEvents());
 
+  cacheControl.enablePublicCache(STORE_PUBLIC_SSR_CACHE_CONTROL);
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
   };
-}
+});
 
 function Store() {
   const enterCategoryTimeRef = useRef<number | null>(null);

--- a/src/pages/timetable/index.tsx
+++ b/src/pages/timetable/index.tsx
@@ -20,6 +20,7 @@ import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
 import { getRecentSemester } from 'utils/timetable/semester';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
 import { clearServerAuthCookies, isServerAuthError } from 'utils/ts/ssrAuth';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import { useSemester } from 'utils/zustand/semester';
 import type { Term } from 'api/timetable/entity';
 import styles from './TimetablePage.module.scss';
@@ -29,7 +30,7 @@ const MobilePage = dynamic(
   { ssr: true },
 );
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const queryClient = new QueryClient();
   const { token, query } = parseServerSideParams(context);
   const year = Number(query.year);
@@ -69,12 +70,16 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     queryClient.setQueryData(timetableQueryKeys.frameList(semester), createDefaultTimetableFrameList());
   }
 
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
   };
-}
+});
 
 function TimetablePage() {
   const isMobile = useMediaQuery();

--- a/src/utils/ts/isr.ts
+++ b/src/utils/ts/isr.ts
@@ -1,0 +1,39 @@
+import { isKoinError } from '@bcsdlab/koin';
+
+export const ARTICLE_DETAIL_ISR_REVALIDATE_SECONDS = 60 * 10;
+export const BUS_SHUTTLE_ISR_REVALIDATE_SECONDS = 60 * 30;
+export const ROOM_ISR_REVALIDATE_SECONDS = 60 * 60;
+export const STORE_DETAIL_ISR_REVALIDATE_SECONDS = 60 * 60;
+
+export const ARTICLE_HOT_PATH_LIMIT = 10;
+export const ROOM_HOT_PATH_LIMIT = 24;
+export const STORE_HOT_PATH_LIMIT = 24;
+
+const STATIC_FETCH_RETRY_ATTEMPTS = 2;
+const STATIC_FETCH_RETRY_DELAY_MS = 300;
+
+export function isNotFoundKoinError(error: unknown): boolean {
+  return isKoinError(error) && error.status === 404;
+}
+
+export async function withStaticFetchRetry<T>(task: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= STATIC_FETCH_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return await task();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === STATIC_FETCH_RETRY_ATTEMPTS) {
+        break;
+      }
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, STATIC_FETCH_RETRY_DELAY_MS * (attempt + 1));
+      });
+    }
+  }
+
+  throw lastError;
+}

--- a/src/utils/ts/isr.ts
+++ b/src/utils/ts/isr.ts
@@ -16,6 +16,35 @@ export function isNotFoundKoinError(error: unknown): boolean {
   return isKoinError(error) && error.status === 404;
 }
 
+function hasAxiosErrorResponse(
+  error: object,
+): error is {
+  type: 'AXIOS_ERROR';
+  response?: {
+    status?: number;
+  };
+} {
+  return 'type' in error && error.type === 'AXIOS_ERROR';
+}
+
+function isRetryableStaticFetchError(error: unknown): boolean {
+  if (isKoinError(error)) {
+    return error.status === 429 || error.status >= 500;
+  }
+
+  if (typeof error === 'object' && error !== null && hasAxiosErrorResponse(error)) {
+    const status = error.response?.status;
+
+    if (typeof status === 'number') {
+      return status === 429 || status >= 500;
+    }
+
+    return true;
+  }
+
+  return true;
+}
+
 export async function withStaticFetchRetry<T>(task: () => Promise<T>): Promise<T> {
   let lastError: unknown;
 
@@ -23,6 +52,10 @@ export async function withStaticFetchRetry<T>(task: () => Promise<T>): Promise<T
     try {
       return await task();
     } catch (error) {
+      if (!isRetryableStaticFetchError(error)) {
+        throw error;
+      }
+
       lastError = error;
 
       if (attempt === STATIC_FETCH_RETRY_ATTEMPTS) {
@@ -35,5 +68,5 @@ export async function withStaticFetchRetry<T>(task: () => Promise<T>): Promise<T
     }
   }
 
-  throw lastError;
+  throw lastError ?? new Error('Static fetch failed without an error payload.');
 }

--- a/src/utils/ts/withCacheControl.ts
+++ b/src/utils/ts/withCacheControl.ts
@@ -1,0 +1,56 @@
+import type {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+  PreviewData,
+} from 'next';
+import type { ParsedUrlQuery } from 'querystring';
+
+export const PUBLIC_SSR_CACHE_CONTROL = 'public, s-maxage=60, stale-while-revalidate=300';
+export const STORE_PUBLIC_SSR_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=1800';
+
+type SSRPageProps = Record<string, unknown>;
+
+export interface SSRCacheControl {
+  enablePublicCache: (cacheControl?: string) => void;
+}
+
+export interface GetServerSidePropsWithCacheControl<
+  Props extends SSRPageProps = SSRPageProps,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+> {
+  (
+    context: GetServerSidePropsContext<Params, Preview>,
+    cacheControl: SSRCacheControl,
+  ): Promise<GetServerSidePropsResult<Props>>;
+}
+
+export interface WithCacheControl {
+  <
+    Props extends SSRPageProps = SSRPageProps,
+    Params extends ParsedUrlQuery = ParsedUrlQuery,
+    Preview extends PreviewData = PreviewData,
+  >(
+    getServerSideProps: GetServerSidePropsWithCacheControl<Props, Params, Preview>,
+  ): GetServerSideProps<Props, Params, Preview>;
+}
+
+export const withCacheControl: WithCacheControl = (getServerSideProps) => async (context) => {
+  let shouldCachePublicResponse = false;
+  let publicCacheControl = PUBLIC_SSR_CACHE_CONTROL;
+
+  const result = await getServerSideProps(context, {
+    enablePublicCache: (cacheControl) => {
+      shouldCachePublicResponse = true;
+      publicCacheControl = cacheControl ?? PUBLIC_SSR_CACHE_CONTROL;
+    },
+  });
+
+  // Redirect/notFound 응답은 공유 캐시 대상이 아니므로 페이지 props가 있을 때만 헤더를 설정합니다.
+  if (shouldCachePublicResponse && 'props' in result) {
+    context.res.setHeader('Cache-Control', publicCacheControl);
+  }
+
+  return result;
+};

--- a/src/utils/ts/withCacheControl.ts
+++ b/src/utils/ts/withCacheControl.ts
@@ -8,6 +8,7 @@ import type { ParsedUrlQuery } from 'querystring';
 
 export const PUBLIC_SSR_CACHE_CONTROL = 'public, s-maxage=60, stale-while-revalidate=300';
 export const STORE_PUBLIC_SSR_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=1800';
+export const PRIVATE_SSR_CACHE_CONTROL = 'private, no-store';
 
 type SSRPageProps = Record<string, unknown>;
 
@@ -47,9 +48,15 @@ export const withCacheControl: WithCacheControl = (getServerSideProps) => async 
     },
   });
 
-  // Redirect/notFound 응답은 공유 캐시 대상이 아니므로 페이지 props가 있을 때만 헤더를 설정합니다.
-  if (shouldCachePublicResponse && 'props' in result) {
-    context.res.setHeader('Cache-Control', publicCacheControl);
+  const setCookieHeader = context.res.getHeader('Set-Cookie');
+  const hasSetCookieHeader = Array.isArray(setCookieHeader) ? setCookieHeader.length > 0 : setCookieHeader !== undefined;
+  const hasCacheControlHeader = context.res.getHeader('Cache-Control') !== undefined;
+
+  // Redirect/notFound 응답은 제외하고, props 응답은 명시적인 캐시 정책을 부여합니다.
+  if ('props' in result && !hasCacheControlHeader) {
+    // 쿠키를 갱신하는 응답은 공용 캐시에 저장하면 안 되므로 private로 고정합니다.
+    const cacheControl = shouldCachePublicResponse && !hasSetCookieHeader ? publicCacheControl : PRIVATE_SSR_CACHE_CONTROL;
+    context.res.setHeader('Cache-Control', cacheControl);
   }
 
   return result;


### PR DESCRIPTION
- Close #1226

## What is this PR? 🔍

- 기능 : 공개 페이지 캐시 전략 개선 및 홈 보조 링크 prefetch 최적화
- issue : #1226

## Cause Analysis 🔎

  - 홈 진입 시 `/_next/data`와 페이지 청크 prefetch가 과도하게 발생해 초기 렌더 이후에도 불필요한 네트워크 요청이 이어지고 있었습니다.
  - 공개 페이지 다수가 SSR 기반으로 동작하고 있었고, shared cache가 적용되지 않아 재방문/재탐색 시 동일한 서버 렌더링 요청이 반복되고 있었습니다.
  - 공개 상세 페이지도 SSR로 처리되고 있어, 고정 성격이 강한 데이터까지 매 요청마다 서버에서 다시 렌더링하고 있었습니다.
  - 운영 환경에서는 Next.js 프로세스가 장기 실행 중 메모리 사용량이 점진적으로 증가했고, 메모리 압박 및 swap 진입 시 응답 지연이 더 커졌을 가능성이 있다고 판단했습니다.
  - 메모리 증가 원인은 V8 힙 확장, SSR 렌더링 중 생성되는 객체의 누적, allocator retain/fragmentation, swap 사용이 복합적으로 작용했을 가능성이 높습니다.

## Changes 📝

- 공개 SSR 페이지에 `withCacheControl`을 적용해 shared cache 헤더를 설정했습니다.
- `articles/[id]`, `store/[id]`, `room`, `room/[id]`, `bus/shuttle`을 ISR로 전환하고 재생성 주기 및 hot path 선생성을 적용했습니다.
- 상점 리뷰 query key를 `public/auth` 기준으로 분리해 익명 ISR 프리패치와 로그인 사용자 캐시가 섞이지 않도록 수정했습니다.
- 홈 기사 상세, 헤더 메가메뉴, 푸터 보조 링크의 `prefetch`를 줄이고 `compress: false`로 Next 압축을 비활성화했습니다.

## Test CheckList ✅

- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] HAR 기준 홈 prefetch 요청 확인 후 저가치 링크 prefetch 축소 적용

## Precaution
- 홈 prefetch는 전부 끈 것이 아니라 기사 상세, 헤더/푸터 보조 링크만 선택적으로 제한했습니다.
   - 기존에는 prefetch로 인해 22개의 페이지가 모두 미리 불러와지면서 많은 네트워크 요청이 발생해 속도 저하 및 서버 부하가 발생했기에 비교적 중요도가 낮다고 판단된 게시글 상세, 헤더 푸터의 보조링크 부분의 상시 prefetch를 해제했습니다.
   - prefetch는 false로 두어도 hover시 prefetch는 되기 때문에 큰 문제는 없다고 판단했습니다.

 - 서버에는 systemd를 적용해 장기 실행 중 Next.js 프로세스의 메모리 팽창과 swap 진입으로 인한 응답 지연을 완화하도록 헀습니다.
   - 적용 값 (prod):
      - `NODE_OPTIONS=--max-old-space-size=400`
      - `MemoryHigh=480M`
      - `MemoryMax=550M`
    - 적용 값 (prod):
      - `NODE_OPTIONS=--max-old-space-size=160`
      - `MemoryHigh=180M`
      - `MemoryMax=220M`
   - 적용된 값은 서버 과부하 상태에서의 메모리 사용량을 통해 임의로 적용한 값이라 이후 모니터링을 통해 재시작이 많이 관측된다면 값을 조절할 계획입니다.

- compress: false를 적용하여 next.js 서버에서 압축 동작을 끄고 nginx에서 gzip 압축을 처리하도록 하여 서버 부하를 줄였습니다.

- 기존에 vm.swappiness가 기본값인 60으로 설정되어 RAM 사용률이 적정 수준일 때도 memory swap이 발생했습니다. 이로 인해 디스크로 동작하게 되면서 속도 저하 발생하는 문제가 있어 이를 최소화하기 위해 vm.swappiness를 10으로 설정했습니다.

- production 서버에는 http2 설정이 되어 있지 않아 추가로 적용했습니다.


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **성능 개선**
  * 주요 페이지를 정적 생성으로 전환하여 로딩 속도 향상 (상품 상세, 강의실, 기사, 버스 셔틀)
  * 링크 미리로딩 기능 최적화로 네트워크 사용량 감소
  * 인증되지 않은 사용자를 위한 응답 캐싱 개선

* **기능 개선**
  * 리뷰 데이터 캐싱 로직 강화
  * 배너 표시 방식을 쿠키 기반으로 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->