### PR TITLE
[콜밴] 생성/참여 제한 사용자 모달 노출

### DIFF
--- a/src/api/callvan/APIDetail.ts
+++ b/src/api/callvan/APIDetail.ts
@@ -5,6 +5,7 @@ import {
   CallvanListResponse,
   CallvanNotificationsResponse,
   CallvanPostDetail,
+  CallvanRestrictionResponse,
   CallvanReportRequest,
   CreateCallvanRequest,
   CreateCallvanResponse,
@@ -34,6 +35,18 @@ export class GetCallvanNotifications<R extends CallvanNotificationsResponse> imp
   method = HTTP_METHOD.GET;
 
   path = '/callvan/notifications';
+
+  response!: R;
+
+  auth = true;
+
+  constructor(public authorization: string) {}
+}
+
+export class GetCallvanRestriction<R extends CallvanRestrictionResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
+
+  path = '/callvan/restriction';
 
   response!: R;
 

--- a/src/api/callvan/entity.ts
+++ b/src/api/callvan/entity.ts
@@ -74,13 +74,21 @@ export interface CallvanListResponse extends APIResponse {
   total_page: number;
 }
 
-export type CallvanRestrictionType = 'TEMPORARY_RESTRICTION_14_DAYS' | 'PERMANENT_RESTRICTION' | null;
+export type CallvanRestrictionType = 'TEMPORARY_RESTRICTION_14_DAYS' | 'PERMANENT_RESTRICTION';
 
-export interface CallvanRestrictionResponse {
-  is_restricted: boolean;
-  restriction_type: CallvanRestrictionType;
-  restricted_until: string | null;
+export interface UnrestrictedCallvanResponse {
+  is_restricted: false;
+  restriction_type: null;
+  restricted_until: null;
 }
+
+export interface RestrictedCallvanResponse {
+  is_restricted: true;
+  restriction_type: CallvanRestrictionType;
+  restricted_until: string;
+}
+
+export type CallvanRestrictionResponse = UnrestrictedCallvanResponse | RestrictedCallvanResponse;
 
 export type CallvanNotificationType =
   | 'RECRUITMENT_COMPLETE'

--- a/src/api/callvan/entity.ts
+++ b/src/api/callvan/entity.ts
@@ -74,6 +74,14 @@ export interface CallvanListResponse extends APIResponse {
   total_page: number;
 }
 
+export type CallvanRestrictionType = 'TEMPORARY_RESTRICTION_14_DAYS' | 'PERMANENT_RESTRICTION' | null;
+
+export interface CallvanRestrictionResponse {
+  is_restricted: boolean;
+  restriction_type: CallvanRestrictionType;
+  restricted_until: string | null;
+}
+
 export type CallvanNotificationType =
   | 'RECRUITMENT_COMPLETE'
   | 'NEW_MESSAGE'

--- a/src/api/callvan/index.ts
+++ b/src/api/callvan/index.ts
@@ -6,6 +6,7 @@ import {
   GetCallvanList,
   GetCallvanNotifications,
   GetCallvanPostDetail,
+  GetCallvanRestriction,
   PostCallvan,
   PostCallvanReport,
   PostCallvanChat,
@@ -20,6 +21,7 @@ import {
 export const getCallvanList = APIClient.of(GetCallvanList);
 export const getCallvanPostDetail = APIClient.of(GetCallvanPostDetail);
 export const getCallvanNotifications = APIClient.of(GetCallvanNotifications);
+export const getCallvanRestriction = APIClient.of(GetCallvanRestriction);
 export const markAllNotificationsRead = APIClient.of(PostMarkAllNotificationsRead);
 export const markNotificationRead = APIClient.of(PostMarkNotificationRead);
 export const deleteAllNotifications = APIClient.of(DeleteAllNotifications);

--- a/src/api/callvan/mutations.ts
+++ b/src/api/callvan/mutations.ts
@@ -19,7 +19,7 @@ const invalidateCallvanInfiniteList = (queryClient: QueryClient) =>
   queryClient.invalidateQueries({ queryKey: callvanQueryKeys.infiniteListRoot });
 
 const invalidateCallvanNotifications = (queryClient: QueryClient) =>
-  queryClient.invalidateQueries({ queryKey: callvanQueryKeys.notifications });
+  queryClient.invalidateQueries({ queryKey: ['callvan', 'notifications'] });
 
 export const callvanMutations = {
   create: (queryClient: QueryClient, token: string) =>

--- a/src/api/callvan/queries.ts
+++ b/src/api/callvan/queries.ts
@@ -1,6 +1,6 @@
 import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 import { CallvanListRequest } from './entity';
-import { getCallvanChat, getCallvanList, getCallvanNotifications, getCallvanPostDetail } from './index';
+import { getCallvanChat, getCallvanList, getCallvanNotifications, getCallvanPostDetail, getCallvanRestriction } from './index';
 
 const CALLVAN_LIST_LIMIT = 10;
 
@@ -13,6 +13,7 @@ export const callvanQueryKeys = {
   infiniteListRoot: ['callvan', 'infinite-list'] as const,
   infiniteList: (params: CallvanInfiniteListParams) => [...callvanQueryKeys.infiniteListRoot, params] as const,
   notifications: ['callvan', 'notifications'] as const,
+  restriction: ['callvan', 'restriction'] as const,
   postDetail: (postId: number) => ['callvan', 'post-detail', postId] as const,
   chat: (postId: number) => ['callvan', 'chat', postId] as const,
 };
@@ -47,6 +48,12 @@ export const callvanQueries = {
     queryOptions({
       queryKey: callvanQueryKeys.notifications,
       queryFn: () => getCallvanNotifications(token),
+    }),
+
+  restriction: (token: string) =>
+    queryOptions({
+      queryKey: callvanQueryKeys.restriction,
+      queryFn: () => getCallvanRestriction(token),
     }),
 
   postDetail: (token: string, postId: number) =>

--- a/src/api/callvan/queries.ts
+++ b/src/api/callvan/queries.ts
@@ -12,8 +12,8 @@ export const callvanQueryKeys = {
   list: (params: CallvanListRequest) => [...callvanQueryKeys.listRoot, params] as const,
   infiniteListRoot: ['callvan', 'infinite-list'] as const,
   infiniteList: (params: CallvanInfiniteListParams) => [...callvanQueryKeys.infiniteListRoot, params] as const,
-  notifications: ['callvan', 'notifications'] as const,
-  restriction: ['callvan', 'restriction'] as const,
+  notifications: (token: string) => ['callvan', 'notifications', token] as const,
+  restriction: (token: string) => ['callvan', 'restriction', token] as const,
   postDetail: (postId: number) => ['callvan', 'post-detail', postId] as const,
   chat: (postId: number) => ['callvan', 'chat', postId] as const,
 };
@@ -46,14 +46,16 @@ export const callvanQueries = {
 
   notifications: (token: string) =>
     queryOptions({
-      queryKey: callvanQueryKeys.notifications,
+      queryKey: callvanQueryKeys.notifications(token),
       queryFn: () => getCallvanNotifications(token),
+      staleTime: 60000,
     }),
 
   restriction: (token: string) =>
     queryOptions({
-      queryKey: callvanQueryKeys.restriction,
+      queryKey: callvanQueryKeys.restriction(token),
       queryFn: () => getCallvanRestriction(token),
+      staleTime: 0,
     }),
 
   postDetail: (token: string, postId: number) =>

--- a/src/components/Callvan/components/CallvanRestrictionModal/CallvanRestrictionModal.module.scss
+++ b/src/components/Callvan/components/CallvanRestrictionModal/CallvanRestrictionModal.module.scss
@@ -1,3 +1,6 @@
+$callvan-restriction-accent-color: #b611f5;
+$callvan-restriction-font-family: var(--font-pretendard), sans-serif;
+
 .modal {
   &__overlay {
     position: fixed;
@@ -50,14 +53,14 @@
   &__title {
     margin: 0;
     color: #4b4b4b;
-    font-family: Pretendard, sans-serif;
+    font-family: $callvan-restriction-font-family;
     font-size: 18px;
     font-weight: 500;
     line-height: 1.6;
   }
 
   &__accent {
-    color: #b611f5;
+    color: $callvan-restriction-accent-color;
   }
 
   &__description {
@@ -65,7 +68,7 @@
     flex-direction: column;
     width: 100%;
     color: #727272;
-    font-family: Pretendard, sans-serif;
+    font-family: $callvan-restriction-font-family;
     font-size: 14px;
     font-weight: 400;
     line-height: 1.6;
@@ -82,10 +85,10 @@
     justify-content: center;
     border: none;
     border-radius: 8px;
-    background: #b611f5;
+    background: $callvan-restriction-accent-color;
     padding: 12px;
     color: #fff;
-    font-family: Pretendard, sans-serif;
+    font-family: $callvan-restriction-font-family;
     font-size: 15px;
     font-weight: 500;
     line-height: 1.6;

--- a/src/components/Callvan/components/CallvanRestrictionModal/CallvanRestrictionModal.module.scss
+++ b/src/components/Callvan/components/CallvanRestrictionModal/CallvanRestrictionModal.module.scss
@@ -1,0 +1,94 @@
+.modal {
+  &__overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 300;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    box-sizing: border-box;
+  }
+
+  &__dim {
+    position: absolute;
+    inset: 0;
+    border: none;
+    background: rgb(0 0 0 / 70%);
+    padding: 0;
+    cursor: pointer;
+  }
+
+  &__sheet {
+    position: relative;
+    z-index: 301;
+    width: min(301px, 100%);
+    border-radius: 8px;
+    background: #fff;
+    box-shadow:
+      0 1px 2px rgb(0 0 0 / 4%),
+      0 4px 5px rgb(0 0 0 / 8%);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    align-items: center;
+    padding: 24px 32px;
+  }
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+    width: 100%;
+    text-align: center;
+  }
+
+  &__title {
+    margin: 0;
+    color: #4b4b4b;
+    font-family: Pretendard, sans-serif;
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 1.6;
+  }
+
+  &__accent {
+    color: #b611f5;
+  }
+
+  &__description {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    color: #727272;
+    font-family: Pretendard, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.6;
+
+    p {
+      margin: 0;
+    }
+  }
+
+  &__button {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 8px;
+    background: #b611f5;
+    padding: 12px;
+    color: #fff;
+    font-family: Pretendard, sans-serif;
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.6;
+    cursor: pointer;
+  }
+}

--- a/src/components/Callvan/components/CallvanRestrictionModal/index.tsx
+++ b/src/components/Callvan/components/CallvanRestrictionModal/index.tsx
@@ -1,14 +1,17 @@
 import { useEffect } from 'react';
-import { CallvanRestrictionResponse } from 'api/callvan/entity';
+import { RestrictedCallvanResponse } from 'api/callvan/entity';
 import { getCallvanRestrictionModalCopy } from 'components/Callvan/utils/callvanRestriction';
+import { useBodyScrollLock } from 'utils/hooks/ui/useBodyScrollLock';
 import styles from './CallvanRestrictionModal.module.scss';
 
 interface CallvanRestrictionModalProps {
-  restriction: CallvanRestrictionResponse | null;
+  restriction: RestrictedCallvanResponse | null;
   onClose: () => void;
 }
 
 export default function CallvanRestrictionModal({ restriction, onClose }: CallvanRestrictionModalProps) {
+  useBodyScrollLock();
+
   const { titleAccent, titleRest, descriptionLines } = getCallvanRestrictionModalCopy(restriction);
 
   useEffect(() => {
@@ -36,8 +39,8 @@ export default function CallvanRestrictionModal({ restriction, onClose }: Callva
               {titleRest}
             </h2>
             <div className={styles.modal__description}>
-              {descriptionLines.map((line) => (
-                <p key={line}>{line}</p>
+              {descriptionLines.map((line, index) => (
+                <p key={`${line}-${index}`}>{line}</p>
               ))}
             </div>
           </div>

--- a/src/components/Callvan/components/CallvanRestrictionModal/index.tsx
+++ b/src/components/Callvan/components/CallvanRestrictionModal/index.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { CallvanRestrictionResponse } from 'api/callvan/entity';
+import { getCallvanRestrictionModalCopy } from 'components/Callvan/utils/callvanRestriction';
+import styles from './CallvanRestrictionModal.module.scss';
+
+interface CallvanRestrictionModalProps {
+  restriction: CallvanRestrictionResponse | null;
+  onClose: () => void;
+}
+
+export default function CallvanRestrictionModal({ restriction, onClose }: CallvanRestrictionModalProps) {
+  const { titleAccent, titleRest, descriptionLines } = getCallvanRestrictionModalCopy(restriction);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div className={styles.modal__overlay} role="dialog" aria-modal="true" aria-labelledby="callvan-restriction-title">
+      <button type="button" className={styles.modal__dim} onClick={onClose} aria-label="닫기" />
+      <div className={styles.modal__sheet}>
+        <div className={styles.modal__content}>
+          <div className={styles.modal__text}>
+            <h2 id="callvan-restriction-title" className={styles.modal__title}>
+              <span className={styles.modal__accent}>{titleAccent}</span>
+              {titleRest}
+            </h2>
+            <div className={styles.modal__description}>
+              {descriptionLines.map((line) => (
+                <p key={line}>{line}</p>
+              ))}
+            </div>
+          </div>
+          <button type="button" className={styles.modal__button} onClick={onClose}>
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Callvan/hooks/useCallvanRestrictionModal.tsx
+++ b/src/components/Callvan/hooks/useCallvanRestrictionModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { sendClientError } from '@bcsdlab/koin';
 import { useQueryClient } from '@tanstack/react-query';
-import { CallvanRestrictionResponse } from 'api/callvan/entity';
+import { RestrictedCallvanResponse } from 'api/callvan/entity';
 import { callvanQueries } from 'api/callvan/queries';
 import CallvanRestrictionModal from 'components/Callvan/components/CallvanRestrictionModal';
 import { isCallvanRestrictedError } from 'components/Callvan/utils/callvanRestriction';
@@ -13,7 +13,7 @@ export default function useCallvanRestrictionModal(token: string) {
   const queryClient = useQueryClient();
 
   const open = useCallback(
-    (restriction: CallvanRestrictionResponse | null) => {
+    (restriction: RestrictedCallvanResponse) => {
       portalManager.open((portalOption: Portal) => (
         <CallvanRestrictionModal restriction={restriction} onClose={portalOption.close} />
       ));
@@ -25,20 +25,20 @@ export default function useCallvanRestrictionModal(token: string) {
     async (error: unknown) => {
       if (!isCallvanRestrictedError(error)) return false;
 
-      if (!token) {
-        open(null);
-        return true;
-      }
+      if (!token) return false;
 
       try {
         const restriction = await queryClient.fetchQuery(callvanQueries.restriction(token));
-        open(restriction.is_restricted ? restriction : null);
+        if (restriction.is_restricted) {
+          open(restriction);
+          return true;
+        }
+
+        return false;
       } catch (restrictionError) {
         sendClientError(restrictionError);
-        open(null);
+        return false;
       }
-
-      return true;
     },
     [open, queryClient, token],
   );

--- a/src/components/Callvan/hooks/useCallvanRestrictionModal.tsx
+++ b/src/components/Callvan/hooks/useCallvanRestrictionModal.tsx
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import { sendClientError } from '@bcsdlab/koin';
+import { useQueryClient } from '@tanstack/react-query';
+import { CallvanRestrictionResponse } from 'api/callvan/entity';
+import { callvanQueries } from 'api/callvan/queries';
+import CallvanRestrictionModal from 'components/Callvan/components/CallvanRestrictionModal';
+import { isCallvanRestrictedError } from 'components/Callvan/utils/callvanRestriction';
+import { Portal } from 'components/modal/Modal/PortalProvider';
+import useModalPortal from 'utils/hooks/layout/useModalPortal';
+
+export default function useCallvanRestrictionModal(token: string) {
+  const portalManager = useModalPortal();
+  const queryClient = useQueryClient();
+
+  const open = useCallback(
+    (restriction: CallvanRestrictionResponse | null) => {
+      portalManager.open((portalOption: Portal) => (
+        <CallvanRestrictionModal restriction={restriction} onClose={portalOption.close} />
+      ));
+    },
+    [portalManager],
+  );
+
+  const openFromError = useCallback(
+    async (error: unknown) => {
+      if (!isCallvanRestrictedError(error)) return false;
+
+      if (!token) {
+        open(null);
+        return true;
+      }
+
+      try {
+        const restriction = await queryClient.fetchQuery(callvanQueries.restriction(token));
+        open(restriction.is_restricted ? restriction : null);
+      } catch (restrictionError) {
+        sendClientError(restrictionError);
+        open(null);
+      }
+
+      return true;
+    },
+    [open, queryClient, token],
+  );
+
+  return { openFromError };
+}

--- a/src/components/Callvan/hooks/useCreateCallvan.ts
+++ b/src/components/Callvan/hooks/useCreateCallvan.ts
@@ -1,6 +1,7 @@
 import { isKoinError, sendClientError } from '@bcsdlab/koin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callvanMutations } from 'api/callvan/mutations';
+import useCallvanRestrictionModal from 'components/Callvan/hooks/useCallvanRestrictionModal';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import showToast from 'utils/ts/showToast';
 
@@ -8,10 +9,13 @@ const useCreateCallvan = () => {
   const token = useTokenState();
   const queryClient = useQueryClient();
   const mutation = callvanMutations.create(queryClient, token);
+  const { openFromError } = useCallvanRestrictionModal(token);
 
   const { mutate, isPending } = useMutation({
     ...mutation,
-    onError: (e) => {
+    onError: async (e) => {
+      if (await openFromError(e)) return;
+
       if (isKoinError(e)) {
         showToast('error', e.message || '게시글 작성에 실패했습니다.');
       } else {

--- a/src/components/Callvan/hooks/useCreateCallvan.ts
+++ b/src/components/Callvan/hooks/useCreateCallvan.ts
@@ -14,7 +14,11 @@ const useCreateCallvan = () => {
   const { mutate, isPending } = useMutation({
     ...mutation,
     onError: async (e) => {
-      if (await openFromError(e)) return;
+      try {
+        if (await openFromError(e)) return;
+      } catch (restrictionError) {
+        sendClientError(restrictionError);
+      }
 
       if (isKoinError(e)) {
         showToast('error', e.message || '게시글 작성에 실패했습니다.');

--- a/src/components/Callvan/hooks/useJoinCallvan.ts
+++ b/src/components/Callvan/hooks/useJoinCallvan.ts
@@ -18,7 +18,11 @@ const useJoinCallvan = () => {
       showToast('success', '참여가 완료되었습니다.');
     },
     onError: async (e) => {
-      if (await openFromError(e)) return;
+      try {
+        if (await openFromError(e)) return;
+      } catch (restrictionError) {
+        sendClientError(restrictionError);
+      }
 
       if (isKoinError(e)) {
         showToast('error', e.message || '참여에 실패했습니다.');

--- a/src/components/Callvan/hooks/useJoinCallvan.ts
+++ b/src/components/Callvan/hooks/useJoinCallvan.ts
@@ -1,6 +1,7 @@
 import { isKoinError, sendClientError } from '@bcsdlab/koin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callvanMutations } from 'api/callvan/mutations';
+import useCallvanRestrictionModal from 'components/Callvan/hooks/useCallvanRestrictionModal';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import showToast from 'utils/ts/showToast';
 
@@ -8,6 +9,7 @@ const useJoinCallvan = () => {
   const token = useTokenState();
   const queryClient = useQueryClient();
   const mutation = callvanMutations.join(queryClient, token);
+  const { openFromError } = useCallvanRestrictionModal(token);
 
   const { mutate, isPending } = useMutation({
     ...mutation,
@@ -15,7 +17,9 @@ const useJoinCallvan = () => {
       await mutation.onSuccess?.(...args);
       showToast('success', '참여가 완료되었습니다.');
     },
-    onError: (e) => {
+    onError: async (e) => {
+      if (await openFromError(e)) return;
+
       if (isKoinError(e)) {
         showToast('error', e.message || '참여에 실패했습니다.');
       } else {

--- a/src/components/Callvan/utils/callvanRestriction.ts
+++ b/src/components/Callvan/utils/callvanRestriction.ts
@@ -1,7 +1,7 @@
 import { isKoinError } from '@bcsdlab/koin';
 import { CallvanRestrictionResponse } from 'api/callvan/entity';
 
-export const CALLVAN_RESTRICTED_ERROR_CODE = 'FORBIDDEN_CALLVAN_RESTRICTED_USER';
+const CALLVAN_RESTRICTED_ERROR_STATUS = 403;
 
 interface CallvanRestrictionModalCopy {
   titleAccent: string;
@@ -18,7 +18,7 @@ const restrictionDateFormatter = new Intl.DateTimeFormat('ko-KR', {
 export function isCallvanRestrictedError(error: unknown): boolean {
   if (!isKoinError(error)) return false;
 
-  return String(error.code) === CALLVAN_RESTRICTED_ERROR_CODE;
+  return error.status === CALLVAN_RESTRICTED_ERROR_STATUS;
 }
 
 function formatRestrictedUntil(restrictedUntil: string | null): string | null {

--- a/src/components/Callvan/utils/callvanRestriction.ts
+++ b/src/components/Callvan/utils/callvanRestriction.ts
@@ -1,0 +1,61 @@
+import { isKoinError } from '@bcsdlab/koin';
+import { CallvanRestrictionResponse } from 'api/callvan/entity';
+
+export const CALLVAN_RESTRICTED_ERROR_CODE = 'FORBIDDEN_CALLVAN_RESTRICTED_USER';
+
+interface CallvanRestrictionModalCopy {
+  titleAccent: string;
+  titleRest: string;
+  descriptionLines: string[];
+}
+
+const restrictionDateFormatter = new Intl.DateTimeFormat('ko-KR', {
+  month: 'long',
+  day: 'numeric',
+  timeZone: 'Asia/Seoul',
+});
+
+export function isCallvanRestrictedError(error: unknown): boolean {
+  if (!isKoinError(error)) return false;
+
+  return String(error.code) === CALLVAN_RESTRICTED_ERROR_CODE;
+}
+
+function formatRestrictedUntil(restrictedUntil: string | null): string | null {
+  if (!restrictedUntil) return null;
+
+  const date = new Date(restrictedUntil);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return `${restrictionDateFormatter.format(date)}까지`;
+}
+
+export function getCallvanRestrictionModalCopy(
+  restriction: CallvanRestrictionResponse | null,
+): CallvanRestrictionModalCopy {
+  if (restriction?.restriction_type === 'TEMPORARY_RESTRICTION_14_DAYS') {
+    const formattedDate = formatRestrictedUntil(restriction.restricted_until);
+
+    return {
+      titleAccent: '14일',
+      titleRest: ' 이용 정지',
+      descriptionLines: formattedDate
+        ? [`해당 계정은 ${formattedDate}`, '콜밴팟 기능을 사용할 수 없습니다.']
+        : ['해당 계정은 콜밴팟 기능을', '사용할 수 없습니다.'],
+    };
+  }
+
+  if (restriction?.restriction_type === 'PERMANENT_RESTRICTION') {
+    return {
+      titleAccent: '영구',
+      titleRest: ' 정지',
+      descriptionLines: ['해당 계정은 콜밴팟 기능을', '사용할 수 없습니다.'],
+    };
+  }
+
+  return {
+    titleAccent: '이용',
+    titleRest: ' 제한',
+    descriptionLines: ['해당 계정은 콜밴팟 기능을', '사용할 수 없습니다.'],
+  };
+}

--- a/src/pages/callvan/index.tsx
+++ b/src/pages/callvan/index.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       queryClient.prefetchInfiniteQuery(callvanQueries.infiniteList(token ?? '', apiParams)),
       token
         ? queryClient.prefetchQuery(callvanQueries.notifications(token))
-        : queryClient.setQueryData(callvanQueryKeys.notifications, []),
+        : queryClient.setQueryData(callvanQueryKeys.notifications(''), []),
     ]);
   } catch (error) {
     console.error('[SSR] callvan prefetch failed:', error);

--- a/src/pages/callvan/notifications/index.tsx
+++ b/src/pages/callvan/notifications/index.tsx
@@ -27,7 +27,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     if (token) {
       await queryClient.prefetchQuery(callvanQueries.notifications(token));
     } else {
-      queryClient.setQueryData(callvanQueryKeys.notifications, []);
+      queryClient.setQueryData(callvanQueryKeys.notifications(''), []);
     }
   } catch (error) {
     console.error('[SSR] callvan notifications prefetch failed:', error);


### PR DESCRIPTION
- Close #1237

## What is this PR? 🔍

- 기능 : 콜밴 게시글 생성/참여 시 제한 사용자 모달 노출
- issue : #1237

## Changes 📝

- `/callvan/restriction` 조회 API와 query option을 추가했습니다.
- 제한 상태에 따라 `14일 이용 정지` / `영구 정지` 카피를 분기하는 콜밴 전용 모달을 구현했습니다.
- 게시글 생성/참여 mutation에서 `FORBIDDEN_CALLVAN_RESTRICTED_USER` 발생 시 제한 상태를 조회한 뒤 모달을 띄우도록 연결했습니다.

## ScreenShot 📷

- Figma 기준 구현
- https://www.figma.com/design/tDCzPQyt4AeWSW7937T10a/KOIN-Mobile?node-id=50984-81187&t=tC6y2Vjzivt4Ov3G-4
- https://www.figma.com/design/tDCzPQyt4AeWSW7937T10a/KOIN-Mobile?node-id=50807-179882&t=tC6y2Vjzivt4Ov3G-4
- https://www.figma.com/design/tDCzPQyt4AeWSW7937T10a/KOIN-Mobile?node-id=50807-179883&t=tC6y2Vjzivt4Ov3G-4

## Test CheckList ✅

- [x] `yarn tsc --noEmit --pretty false`
- [x] `yarn eslint src/api/callvan/queries.ts src/components/Callvan/hooks/useCallvanRestrictionModal.tsx src/components/Callvan/hooks/useCreateCallvan.ts src/components/Callvan/hooks/useJoinCallvan.ts`
- [ ] 실제 403 제한 응답 시나리오 수동 확인

## Precaution

- 제한 모달은 `FORBIDDEN_CALLVAN_RESTRICTED_USER` 응답에만 반응합니다.
- 제한 상세는 direct API 호출이 아니라 `callvanQueries.restriction` + `queryClient.fetchQuery`로 컨벤션을 맞췄습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 캘반 생성/참여 실패 시 계정 제한 정보를 자동 조회해 제한 안내 모달을 표시
  * 임시/영구 제한 유형과 제한 종료일을 사용자 친화적으로 노출

* **Improvements**
  * 제한 모달에 닫기 버튼·배경 클릭·Esc키로 닫기 가능하고 본문 스크롤을 잠금
  * 제한 안내 문구 및 날짜 포맷(한국/서울 기준) 개선
  * 알림 캐시/동기화 키 사용 방식 정렬로 알림 동작 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->