### PR TITLE
[공통] 페이지 단위 SEO 메타데이터 인프라 추가

### DIFF
--- a/src/components/seo/Seo/index.tsx
+++ b/src/components/seo/Seo/index.tsx
@@ -1,0 +1,56 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import {
+  DEFAULT_DESCRIPTION,
+  DEFAULT_OG_IMAGE,
+  DEFAULT_TITLE,
+  SITE_NAME,
+  TWITTER_CARD_TYPE,
+  buildAbsoluteUrl,
+} from 'static/seo';
+
+interface SeoProps {
+  title?: string;
+  description?: string;
+  url?: string;
+  image?: string;
+  type?: 'website' | 'article';
+  noindex?: boolean;
+  imageAlt?: string;
+}
+
+export default function Seo({
+  title,
+  description = DEFAULT_DESCRIPTION,
+  url,
+  image = DEFAULT_OG_IMAGE,
+  type = 'website',
+  noindex = false,
+  imageAlt,
+}: SeoProps) {
+  const router = useRouter();
+  const resolvedTitle = title || DEFAULT_TITLE;
+  const canonicalUrl = buildAbsoluteUrl(url ?? router.asPath?.split('?')[0]);
+
+  return (
+    <Head>
+      <title>{resolvedTitle}</title>
+      <meta name="description" content={description} key="description" />
+      <link rel="canonical" href={canonicalUrl} key="canonical" />
+      {noindex && <meta name="robots" content="noindex, nofollow" key="robots" />}
+
+      <meta property="og:site_name" content={SITE_NAME} key="og:site_name" />
+      <meta property="og:type" content={type} key="og:type" />
+      <meta property="og:title" content={resolvedTitle} key="og:title" />
+      <meta property="og:description" content={description} key="og:description" />
+      <meta property="og:url" content={canonicalUrl} key="og:url" />
+      <meta property="og:image" content={image} key="og:image" />
+      {imageAlt && <meta property="og:image:alt" content={imageAlt} key="og:image:alt" />}
+
+      <meta name="twitter:card" content={TWITTER_CARD_TYPE} key="twitter:card" />
+      <meta name="twitter:title" content={resolvedTitle} key="twitter:title" />
+      <meta name="twitter:description" content={description} key="twitter:description" />
+      <meta name="twitter:image" content={image} key="twitter:image" />
+    </Head>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import './index.scss';
 import { GoogleAnalytics, GoogleTagManager } from '@next/third-parties/google';
@@ -11,6 +10,7 @@ import Toast from 'components/feedback/Toast';
 import Layout from 'components/layout';
 import MaintenancePage from 'components/Maintenance';
 import PortalProvider from 'components/modal/Modal/PortalProvider';
+import Seo from 'components/seo/Seo';
 import ROUTES from 'static/routes';
 import { COOKIE_KEY } from 'static/url';
 import useAutoLogin from 'utils/hooks/auth/useAutoLogin';
@@ -79,7 +79,7 @@ export default function App({ Component, pageProps }: AppPropsWithAuth) {
   const getLayout = Component.getLayout || ((page) => <Layout>{page}</Layout>);
 
   const pageTitle = React.useMemo(() => {
-    if (!Component.title) return 'KOIN';
+    if (!Component.title) return undefined;
     return typeof Component.title === 'function' ? Component.title(router.asPath) : Component.title;
   }, [Component, router.asPath]);
 
@@ -141,9 +141,7 @@ export default function App({ Component, pageProps }: AppPropsWithAuth) {
           {GA_ID && <GoogleAnalytics gaId={GA_ID} />}
 
           <PortalProvider>
-            <Head>
-              <title>{pageTitle}</title>
-            </Head>
+            <Seo title={pageTitle} />
             <AutoLogin />
             {getLayout(<Component {...pageProps} />)}
             <Toast />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,20 +8,10 @@ export default function Document() {
       <Head>
         <link rel="preconnect" href="https://static.koreatech.in" crossOrigin="anonymous" />
 
-        {/* 기본 메타 */}
+        {/* 기본 메타 (페이지 단위 메타는 components/seo/Seo 가 처리) */}
         <meta charSet="utf-8" />
         <meta name="theme-color" content="#000000" />
         <meta name="author" content="BCSD Lab" />
-        <meta name="description" content="보다 편하게, 한국기술교육대학교 생활에 필요한 서비스를 만날 수 있습니다." />
-
-        {/* Open Graph */}
-        <meta property="og:title" content="코인 - 한기대 커뮤니티" />
-        <meta
-          property="og:description"
-          content="보다 편하게, 한국기술교육대학교 생활에 필요한 서비스를 만날 수 있습니다."
-        />
-        <meta property="og:image" content="https://static.koreatech.in/assets/img/facebook_showcase_image.png" />
-        <meta property="og:image:width" content="1200" />
 
         {/* 국제화/번역 제어 */}
         <meta name="google" content="notranslate" />

--- a/src/static/seo.ts
+++ b/src/static/seo.ts
@@ -1,0 +1,15 @@
+import { KOIN_BASE_URL } from 'static/url';
+
+export const SITE_NAME = '코인';
+export const DEFAULT_TITLE = '코인 - 한기대 커뮤니티';
+export const DEFAULT_DESCRIPTION =
+  '보다 편하게, 한국기술교육대학교 생활에 필요한 서비스를 만날 수 있습니다.';
+export const DEFAULT_OG_IMAGE = 'https://static.koreatech.in/assets/img/facebook_showcase_image.png';
+export const TWITTER_CARD_TYPE = 'summary_large_image';
+
+export const buildAbsoluteUrl = (path?: string) => {
+  if (!path) return KOIN_BASE_URL;
+  if (/^https?:\/\//.test(path)) return path;
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${KOIN_BASE_URL}${normalized}`;
+};


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 페이지 단위 SEO 메타데이터 인프라 도입 (공통 `<Seo>` 컴포넌트 + `_document` 정리)
- issue : #1256

## Changes 📝
- src/static/seo.ts — SEO 상수 + buildAbsoluteUrl(path) 헬퍼 (canonical/og:url은 KOIN_BASE_URL 기반, stage/prod 자동 분기)
- src/components/seo/Seo/index.tsx — title, description, url, image, type, noindex, imageAlt props 지원. 모든 meta에 key 부여로 페이지 단위 override 가능

### 수정 파일
- _document.tsx — 페이지별 메타 제거, 셸 전용 항목만 유지
- _app.tsx — <Head><title></title></Head> → <Seo />. Component.title fallback 'KOIN' → undefined 로 변경해 DEFAULT_TITLE 적용

### 호환성
- 기존 Component.title 패턴 유지, 후속 PR에서 페이지별 <Seo> 도입 시 자동 우선 적용
- 모든 페이지 <title>: 'KOIN' → '코인 - 한기대 커뮤니티' 로 일괄 개선

## ScreenShot 📷
N/A

## Test CheckList ✅

- [x] `yarn lint:eslint`
- [x] `yarn tsc --noEmit`

## Precaution
- 인프라만 도입, 페이지별 메타 적용은 후속 PR에서 진행
- 단독 머지 시 <Seo> 미적용 페이지는 default 값으로 노출 (기존과 동일 수준)
## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 페이지 메타데이터 설정 컴포넌트 추가
  * 페이지 제목, 설명, 이미지 메타데이터 관리 지원
  * Open Graph 및 Twitter 카드 태그 자동 생성
  * 검색 엔진 인덱싱 제어 옵션 추가
  * URL 기반 절대 경로 자동 생성 기능 포함

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_WEB_RECODE/pull/1257)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->