### PR TITLE
[유저/hotfix] 시간표 미사용자 홈 접근 시 500 오류 수정

### DIFF
--- a/src/api/timetable/queries.ts
+++ b/src/api/timetable/queries.ts
@@ -25,6 +25,7 @@ type MySemesterQueryParams = {
 
 type FrameListQueryParams = {
   fallbackOnError?: boolean;
+  hasUserSemester?: boolean;
   userType?: TimetableUserType;
 };
 
@@ -72,11 +73,15 @@ export const timetableQueries = {
       queryFn: () => getLectureList(semester),
     }),
 
-  frameList: (token: string, semester: Semester, { fallbackOnError = false, userType }: FrameListQueryParams = {}) =>
+  frameList: (
+    token: string,
+    semester: Semester,
+    { fallbackOnError = false, hasUserSemester = true, userType }: FrameListQueryParams = {},
+  ) =>
     queryOptions({
       queryKey: timetableQueryKeys.frameList(semester),
       queryFn: async () => {
-        if (!canUseStudentTimetableQuery(token, userType)) {
+        if (!hasUserSemester || !canUseStudentTimetableQuery(token, userType)) {
           return createDefaultTimetableFrameList();
         }
 

--- a/src/components/TimetablePage/hooks/useTimetableFrameList.ts
+++ b/src/components/TimetablePage/hooks/useTimetableFrameList.ts
@@ -2,10 +2,15 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Semester } from 'api/timetable/entity';
 import { timetableQueries } from 'api/timetable/queries';
 import { useTokenStore } from 'utils/zustand/auth';
+import useSemesterCheck from './useMySemester';
 
 function useTimetableFrameList(token: string, semester: Semester) {
   const { userType } = useTokenStore();
-  const { data } = useSuspenseQuery(timetableQueries.frameList(token, semester, { fallbackOnError: true, userType }));
+  const { data: mySemester } = useSemesterCheck(token);
+  const hasUserSemester = mySemester?.semesters.length !== 0;
+  const { data } = useSuspenseQuery(
+    timetableQueries.frameList(token, semester, { fallbackOnError: true, hasUserSemester, userType }),
+  );
 
   return { data };
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,11 @@ import { articleQueries } from 'api/articles/queries';
 import { bannerQueries } from 'api/banner/queries';
 import { clubQueries } from 'api/club/queries';
 import { storeQueries } from 'api/store/queries';
-import { timetableQueries } from 'api/timetable/queries';
+import {
+  createDefaultTimetableFrameList,
+  timetableQueries,
+  timetableQueryKeys,
+} from 'api/timetable/queries';
 import IndexArticles from 'components/IndexComponents/IndexArticles';
 import IndexBus from 'components/IndexComponents/IndexBus';
 import IndexCafeteria from 'components/IndexComponents/IndexCafeteria';
@@ -21,6 +25,7 @@ import { getRecentSemester } from 'utils/timetable/semester';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
 import { clearServerAuthCookies, isServerAuthError } from 'utils/ts/ssrAuth';
 import { withCacheControl } from 'utils/ts/withCacheControl';
+import type { Semester } from 'api/timetable/entity';
 import styles from './IndexPage.module.scss';
 
 export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
@@ -32,6 +37,10 @@ export const getServerSideProps = withCacheControl(async (context: GetServerSide
     token = '';
     userType = '';
     clearServerAuthCookies(context);
+  };
+
+  const setDefaultTimetableFrameList = (semester: Semester = getRecentSemester()) => {
+    queryClient.setQueryData(timetableQueryKeys.frameList(semester), createDefaultTimetableFrameList());
   };
 
   const fetchMySemester = async () => {
@@ -63,26 +72,32 @@ export const getServerSideProps = withCacheControl(async (context: GetServerSide
     queryClient.prefetchQuery(articleQueries.lostItemStat()),
   ]);
 
-  const userSemester = mySemester?.semesters?.[0] || getRecentSemester();
+  const userSemester = mySemester?.semesters?.[0];
 
   const bannerCategoryId = Number(banners.banner_categories[0].id);
   const bannersList = await queryClient.fetchQuery(bannerQueries.list(bannerCategoryId));
 
   if (token && userType === 'STUDENT') {
-    try {
-      const timetableFrameList = await queryClient.fetchQuery(
-        timetableQueries.frameList(token, userSemester, { userType }),
-      );
-      const mainFrame = timetableFrameList.find((frame) => frame.is_main);
-      const activeMainFrameId = mainFrame?.id;
-      if (typeof activeMainFrameId === 'number') {
-        await queryClient.prefetchQuery(timetableQueries.lectureInfo(token, activeMainFrameId));
-      }
-    } catch (error) {
-      if (isServerAuthError(error)) {
-        resetAuthContext();
-      } else if (!(isKoinError(error) && error.status === 403)) {
-        throw error;
+    if (!userSemester) {
+      setDefaultTimetableFrameList();
+    } else {
+      try {
+        const timetableFrameList = await queryClient.fetchQuery(
+          timetableQueries.frameList(token, userSemester, { userType }),
+        );
+        const mainFrame = timetableFrameList.find((frame) => frame.is_main);
+        const activeMainFrameId = mainFrame?.id;
+        if (typeof activeMainFrameId === 'number') {
+          await queryClient.prefetchQuery(timetableQueries.lectureInfo(token, activeMainFrameId));
+        }
+      } catch (error) {
+        if (isServerAuthError(error)) {
+          resetAuthContext();
+        } else if (isKoinError(error) && (error.status === 403 || error.status === 404)) {
+          setDefaultTimetableFrameList(userSemester);
+        } else {
+          throw error;
+        }
       }
     }
   }

--- a/src/pages/timetable/index.tsx
+++ b/src/pages/timetable/index.tsx
@@ -17,13 +17,13 @@ import DefaultPage from 'components/TimetablePage/MainTimetablePage/DefaultPage'
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
-import { getRecentSemester } from 'utils/timetable/semester';
+import { getRecentSemester, getSemesterFromQuery, resolveTimetableSemester } from 'utils/timetable/semester';
 import { isomorphicSessionStorage } from 'utils/ts/env';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
 import { clearServerAuthCookies, isServerAuthError } from 'utils/ts/ssrAuth';
 import { withCacheControl } from 'utils/ts/withCacheControl';
 import { useSemester } from 'utils/zustand/semester';
-import type { Term } from 'api/timetable/entity';
+import type { TimetableFrameListResponse } from 'api/timetable/entity';
 import styles from './TimetablePage.module.scss';
 
 const MobilePage = dynamic(
@@ -31,28 +31,54 @@ const MobilePage = dynamic(
   { ssr: true },
 );
 
+const prefetchBaseTimetableData = async (queryClient: QueryClient) => {
+  await Promise.all([
+    queryClient.prefetchQuery(timetableQueries.semesterInfo()),
+    queryClient.prefetchQuery(deptQueries.list()),
+  ]);
+};
+
+const setDefaultTimetableFrameList = (queryClient: QueryClient, semester = getRecentSemester()) => {
+  queryClient.setQueryData(timetableQueryKeys.frameList(semester), createDefaultTimetableFrameList());
+};
+
 async function prefetchTimetableData(
   queryClient: QueryClient,
   context: GetServerSidePropsContext,
   token: string,
-  year: number,
-  term: Term,
+  query: GetServerSidePropsContext['query'],
   validatedFrameId: number | null,
 ): Promise<void> {
   try {
     const mySemesterData = await queryClient.fetchQuery(timetableQueries.mySemester(token));
     const userSemester = mySemesterData?.semesters?.[0];
-    const semester = year && term ? { year, term } : userSemester || getRecentSemester();
+    const semester = resolveTimetableSemester(query.year, query.term, userSemester);
 
-    const timetableFrameList = await queryClient.fetchQuery(timetableQueries.frameList(token, semester));
+    if (!semester) {
+      setDefaultTimetableFrameList(queryClient);
+      await prefetchBaseTimetableData(queryClient);
+      return;
+    }
+
+    let timetableFrameList: TimetableFrameListResponse;
+
+    try {
+      timetableFrameList = await queryClient.fetchQuery(timetableQueries.frameList(token, semester));
+    } catch (error) {
+      if (!(isKoinError(error) && error.status === 404)) {
+        throw error;
+      }
+
+      setDefaultTimetableFrameList(queryClient, semester);
+      await prefetchBaseTimetableData(queryClient);
+      return;
+    }
 
     const mainFrame = timetableFrameList.find((frame) => frame.is_main);
-    const currentFrameId = validatedFrameId ?? mainFrame?.id ?? null;
+    const hasValidatedFrame = validatedFrameId !== null && timetableFrameList.some((frame) => frame.id === validatedFrameId);
+    const currentFrameId = hasValidatedFrame ? validatedFrameId : (mainFrame?.id ?? null);
 
-    const prefetchPromises = [
-      queryClient.prefetchQuery(timetableQueries.semesterInfo()),
-      queryClient.prefetchQuery(deptQueries.list()),
-    ];
+    const prefetchPromises = [prefetchBaseTimetableData(queryClient)];
 
     if (currentFrameId !== null) {
       prefetchPromises.push(queryClient.prefetchQuery(timetableQueries.lectureInfo(token, currentFrameId)));
@@ -64,22 +90,21 @@ async function prefetchTimetableData(
     const isForbiddenError = isKoinError(error) && error.status === 403;
     if (!isAuthError && !isForbiddenError) throw error;
     if (isAuthError) clearServerAuthCookies(context);
-    queryClient.setQueryData(timetableQueryKeys.frameList(getRecentSemester()), createDefaultTimetableFrameList());
+    setDefaultTimetableFrameList(queryClient, getSemesterFromQuery(query.year, query.term) ?? getRecentSemester());
+    await prefetchBaseTimetableData(queryClient);
   }
 }
 
 export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
   const queryClient = new QueryClient();
   const { token, query } = parseServerSideParams(context);
-  const year = Number(query.year);
-  const term = query.term as Term;
   const frameId = Number(query.timetableFrameId);
   const validatedFrameId = isValidTimetableFrameId(frameId) ? frameId : null;
 
   if (token) {
-    await prefetchTimetableData(queryClient, context, token, year, term, validatedFrameId);
+    await prefetchTimetableData(queryClient, context, token, query, validatedFrameId);
   } else {
-    queryClient.setQueryData(timetableQueryKeys.frameList(getRecentSemester()), createDefaultTimetableFrameList());
+    setDefaultTimetableFrameList(queryClient);
     cacheControl.enablePublicCache();
   }
 

--- a/src/pages/timetable/modify/index.tsx
+++ b/src/pages/timetable/modify/index.tsx
@@ -6,10 +6,9 @@ import { timetableQueries } from 'api/timetable/queries';
 import { SSRLayout } from 'components/layout';
 import ModifyTimetablePage from 'components/TimetablePage/ModifyTimetablePage';
 import { COOKIE_KEY } from 'static/url';
-import { getRecentSemester } from 'utils/timetable/semester';
+import { resolveTimetableSemester } from 'utils/timetable/semester';
 import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
 import { clearServerAuthCookies, isServerAuthError } from 'utils/ts/ssrAuth';
-import type { Term } from 'api/timetable/entity';
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const queryClient = new QueryClient();
@@ -21,17 +20,20 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   if (token && userType === 'STUDENT') {
     try {
       const mySemesterData = await queryClient.fetchQuery(timetableQueries.mySemester(token, { userType }));
-      const year = Number(query.year);
-      const term = query.term as Term;
       const userSemester = mySemesterData?.semesters?.[0];
-      const semester = year && term ? { year, term } : userSemester || getRecentSemester();
+      const semester = resolveTimetableSemester(query.year, query.term, userSemester);
 
-      await Promise.all([
-        queryClient.prefetchQuery(timetableQueries.lectureInfo(token, timetableFrameId)),
-        queryClient.prefetchQuery(timetableQueries.lectureList(semester)),
-      ]);
+      const prefetchPromises = [queryClient.prefetchQuery(timetableQueries.lectureInfo(token, timetableFrameId))];
+
+      if (semester) {
+        prefetchPromises.push(queryClient.prefetchQuery(timetableQueries.lectureList(semester)));
+      }
+
+      await Promise.all(prefetchPromises);
     } catch (error) {
-      if (!isServerAuthError(error) && !(isKoinError(error) && error.status === 403)) throw error;
+      if (!isServerAuthError(error) && !(isKoinError(error) && error.status === 403)) {
+        throw error;
+      }
       if (isServerAuthError(error)) clearServerAuthCookies(context);
     }
   }

--- a/src/utils/timetable/semester.ts
+++ b/src/utils/timetable/semester.ts
@@ -1,5 +1,32 @@
 import { Semester, Term } from 'api/timetable/entity';
 
+type QueryValue = string | string[] | undefined;
+
+const TERMS = new Set<string>(['1학기', '여름학기', '2학기', '겨울학기']);
+
+export function isTimetableTerm(term: QueryValue): term is Term {
+  return typeof term === 'string' && TERMS.has(term);
+}
+
+export function getSemesterFromQuery(year: QueryValue, term: QueryValue): Semester | null {
+  if (typeof year !== 'string' || !isTimetableTerm(term)) return null;
+
+  const parsedYear = Number(year);
+  if (!Number.isInteger(parsedYear)) return null;
+
+  return {
+    year: parsedYear,
+    term,
+  };
+}
+
+export function resolveTimetableSemester(year: QueryValue, term: QueryValue, userSemester?: Semester): Semester | null {
+  const querySemester = getSemesterFromQuery(year, term);
+  if (querySemester) return querySemester;
+  if (userSemester) return userSemester;
+  return null;
+}
+
 export function getRecentSemester(): Semester {
   const date = new Date();
   const year = date.getFullYear();
@@ -8,30 +35,30 @@ export function getRecentSemester(): Semester {
   if (month < 2) {
     return {
       year: year - 1,
-      term: '겨울학기' as Term,
+      term: '겨울학기',
     };
   }
   if (month < 6) {
     return {
       year,
-      term: '1학기' as Term,
+      term: '1학기',
     };
   }
   if (month < 8) {
     return {
       year,
-      term: '여름학기' as Term,
+      term: '여름학기',
     };
   }
   if (month < 13) {
     return {
       year,
-      term: '2학기' as Term,
+      term: '2학기',
     };
   }
 
   return {
     year,
-    term: '1학기' as Term,
+    term: '1학기',
   };
 }


### PR DESCRIPTION
- Close #1270

## What is this PR? 🔍

- 기능 : 시간표를 사용하지 않은 학생 사용자의 홈/시간표 SSR 500 오류를 방지합니다.
- issue : #1270

## Changes 📝

- 홈 SSR에서 사용자 시간표 학기가 없는 경우 `/v3/timetables/frame` API를 호출하지 않고 기본 시간표 데이터를 주입하도록 수정했습니다.
- `/timetable` SSR에서 존재하지 않는 학기 404는 기본 시간표 fallback으로 처리하고, 실제 frame 목록에 없는 `timetableFrameId`는 main frame으로 보정하도록 수정했습니다.
- `/timetable/modify` SSR에서 query 학기를 검증하고, 사용할 학기가 없으면 강의 목록 prefetch를 생략하도록 수정했습니다.
- 시간표 query/hook에 사용자의 등록 학기 존재 여부를 반영해 클라이언트에서도 불필요한 frame API 호출을 막았습니다.
- query 학기 파싱 유틸을 추가해 `as Term` 타입 단언 없이 학기를 안전하게 판별하도록 정리했습니다.

## ScreenShot 📷

- UI 변경 없음

## Test CheckList ✅

- [x] `yarn tsc --noEmit`
- [x] `yarn lint:eslint`
- [x] 시간표 미사용자 케이스에서 기본 시간표 데이터로 fallback되는 SSR 흐름 확인

## Precaution

- `yarn lint:eslint` 실행 시 기존 Browserslist outdated 안내가 출력됩니다.
- hotfix 제목이지만 현재 브랜치는 원격 기본 브랜치인 `develop`에서 분기했으므로 PR base도 `develop`입니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?\n- [ ] If on a hotfix branch, ensure it targets `main`?\n- [ ] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 사용자가 등록한 학기가 없을 때 기본 타임테이블이 올바르게 표시되도록 개선

* **Performance**
  * 타임테이블 페이지 로딩 시 서버사이드 데이터 프리페칭 로직 최적화
  * 불필요한 API 호출 감소로 페이지 로딩 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->