### PR TITLE
[시간표/hotfix]: 졸업 엑셀 업로드 multipart 요청 오류 수정

### DIFF
--- a/src/utils/ts/apiClient.ts
+++ b/src/utils/ts/apiClient.ts
@@ -242,8 +242,11 @@ export default class APIClient {
       headers.Authorization = `Bearer ${request.authorization}`;
     }
 
-    // json body 사용
-    if (request.method === HTTP_METHOD.POST || request.method === HTTP_METHOD.PUT) {
+    // json body 사용 (FormData는 axios가 multipart boundary를 자동 설정)
+    if (
+      (request.method === HTTP_METHOD.POST || request.method === HTTP_METHOD.PUT) &&
+      !(request.data instanceof FormData)
+    ) {
       headers['Content-Type'] = 'application/json';
     }
 


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : api 요청 시 multipart 요청 오류 수정

## Changes 📝
- `POST /graduation/excel/upload` 요청 시 서버에서 `MultipartException` 발생
본문은 `multipart/form-data`로 전송되지만, 헤더가 `application/json`으로 나가면서 서버(Spring `MultipartResolver`)가 multipart 요청으로 인식하지 못함.


`request.data`가 `FormData` 인스턴스가 아닐 때만 `Content-Type`을`application/json`으로 설정하도록 변경.

## ScreenShot 📷
N/A

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] 로컬 환경 졸업 학점 계산기 엑셀 파일 업로드 요청

## Precaution
N/A
## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * API 요청 시 Content-Type 헤더 처리 개선. FormData를 사용할 때 헤더가 자동으로 설정되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->