### PR TITLE
[공통/fix]: _error.tsx falsy error 시 Sentry 캡처 제외

### DIFF
--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -7,7 +7,9 @@ function CustomErrorComponent({ statusCode }: { statusCode: number }) {
 }
 
 CustomErrorComponent.getInitialProps = async (contextData: NextPageContext) => {
-  await Sentry.captureUnderscoreErrorException(contextData);
+  if (contextData.err) {
+    await Sentry.captureUnderscoreErrorException(contextData);
+  }
   return Error.getInitialProps(contextData);
 };
 


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : Sentry 에러 노이즈 제거
- issue : Sentry #7597971115

## Changes 📝

**Root cause**

`next.config.mjs`에 `tunnelRoute: '/monitoring'`으로 설정된 Sentry 터널이 `sentry.io` 연결 시 `ETIMEDOUT (AggregateError)`으로 실패하면, Next.js가 `_error.tsx`를 falsy한 `err`(`undefined`)와 함께 호출합니다.

기존 `_error.tsx`는 `contextData.err` 값을 확인하지 않고 무조건 `captureUnderscoreErrorException`을 호출했기 때문에, Sentry 내부에서 `_error.js called with falsy error (undefined)` 메시지로 노이즈 이벤트가 생성됐습니다.

**Fix**

`contextData.err`가 truthy한 경우에만 `captureUnderscoreErrorException`을 호출하도록 변경하여 실제 에러가 없을 때는 Sentry에 이벤트를 보내지 않습니다.

```tsx
// before
CustomErrorComponent.getInitialProps = async (contextData: NextPageContext) => {
  await Sentry.captureUnderscoreErrorException(contextData);
  return Error.getInitialProps(contextData);
};

// after
CustomErrorComponent.getInitialProps = async (contextData: NextPageContext) => {
  if (contextData.err) {
    await Sentry.captureUnderscoreErrorException(contextData);
  }
  return Error.getInitialProps(contextData);
};
```

## ScreenShot 📷

N/A (로직 수정)

## Test CheckList ✅

- [x] 실제 에러가 있을 때 `_error.tsx`에서 Sentry 이벤트가 정상적으로 캡처되는지 확인
- [x] falsy error로 `_error.tsx`가 호출될 때 Sentry 이벤트가 생성되지 않는지 확인
- [x] `yarn lint` 경고 없음

## Precaution

Sentry 터널(`/monitoring`)의 `ETIMEDOUT` 자체는 stage 서버와 `sentry.io` 간의 네트워크 문제로, 인프라 차원에서 별도 확인이 필요합니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 오류 정보가 있을 때만 예외가 전송되도록 조정해, 불필요한 오류 보고를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->