### PR TITLE
[공지사항/fix]: MobileArticleDetailFooter hotArticles undefined TypeError 수정

### DIFF
--- a/src/components/Articles/components/MobileArticleDetailFooter/index.tsx
+++ b/src/components/Articles/components/MobileArticleDetailFooter/index.tsx
@@ -7,7 +7,7 @@ import styles from './MobileArticleDetailFooter.module.scss';
 interface MobileArticleDetailFooterProps {
   prevId: number;
   nextId: number;
-  hotArticles: HotArticle[];
+  hotArticles?: HotArticle[];
 }
 
 const formatTag = (boardId: number) => convertArticlesTag(boardId).replace(/^\[|\]$/g, '');
@@ -42,7 +42,7 @@ export default function MobileArticleDetailFooter({ prevId, nextId, hotArticles 
           인기있는 공지
         </h2>
         <div className={styles.popular__list}>
-          {hotArticles.slice(0, 4).map((article) => (
+          {(hotArticles ?? []).slice(0, 4).map((article) => (
             <Link className={styles.notice} href={ROUTES.ArticlesDetail({ id: String(article.id) })} key={article.id}>
               <span className={styles.notice__tag}>{formatTag(article.board_id)}</span>
               <span className={styles.notice__title}>{article.title}</span>

--- a/src/pages/articles/[id]/index.tsx
+++ b/src/pages/articles/[id]/index.tsx
@@ -45,7 +45,7 @@ export const getStaticProps: GetStaticProps<
 
   try {
     const article = await withStaticFetchRetry(() => getArticle(id));
-    const hotArticles = await withStaticFetchRetry(() => getHotArticles()).catch(() => []);
+    const hotArticles = (await withStaticFetchRetry(() => getHotArticles()).catch(() => [])) ?? [];
     const serverTime = new Date();
 
     const articleWithNew: ArticleResponseWithNew = {
@@ -70,7 +70,7 @@ export default function ArticlesDetailPage({
   hotArticles,
 }: {
   article: ArticleResponseWithNew;
-  hotArticles: HotArticle[];
+  hotArticles?: HotArticle[];
 }) {
   return (
     <ArticlesPageLayout>


### PR DESCRIPTION
- Close #

## What is this PR? 🔍

- 기능 : 공지사항 상세 페이지 모바일 푸터 에러 수정
- issue : Sentry #7597992626

## Changes 📝

**Root Cause**

클라이언트 사이드 네비게이션 중 `/articles/[id]` 페이지의 ISR 생성 JSON에서 `hotArticles`가 `undefined`로 전달되는 경우 발생.

`getStaticProps`에서 `getHotArticles()`가 reject 없이 `null`/`undefined`를 resolve하면 `.catch(() => [])` 가 적용되지 않아 `undefined`가 props로 전달됨.
`MobileArticleDetailFooter`에서 `undefined.slice(0, 4)` 호출 → `TypeError: Cannot read properties of undefined (reading 'slice')`

**재현 경로** (breadcrumbs 기준)
1. `/articles/17837` 방문
2. 다음 글 버튼으로 `/articles/17838` 이동
3. 이전 글 버튼으로 `/articles/17837` 이동
4. 이전 글 버튼으로 `/articles/17836` 이동 → 에러 발생

**수정 내용**

- `getStaticProps`: `(await ...).catch(() => [])) ?? []` 로 null/undefined resolve 케이스까지 방어
- `MobileArticleDetailFooter`: prop 타입을 `hotArticles?: HotArticle[]`로 변경, `(hotArticles ?? []).slice(0, 4)` 로 런타임 방어 추가

## ScreenShot 📷

N/A (런타임 에러 수정)

## Test CheckList ✅

- [ ] 공지사항 상세 페이지에서 이전/다음 글 버튼으로 여러 번 네비게이션 후 에러 미발생 확인
- [ ] `hotArticles`가 빈 배열일 때 인기있는 공지 섹션이 정상 렌더링 확인
- [ ] 모바일 환경에서 공지사항 상세 페이지 정상 표시 확인

## Precaution

stage 환경에서 동일 재현 경로로 에러가 더 이상 발생하지 않는지 확인 필요

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`