### PR TITLE
[학교 부서 정보] 피드백 문구 클릭 시 폼 링크 이동 및 모바일 간격/누락 요소 수정

### DIFF
--- a/src/components/Department/CategoryDetail/CategoryDetailDesktop/CategoryDetailDesktop.module.scss
+++ b/src/components/Department/CategoryDetail/CategoryDetailDesktop/CategoryDetailDesktop.module.scss
@@ -74,10 +74,14 @@
     display: flex;
     align-items: center;
     gap: 4px;
+    padding: 0;
+    border: none;
+    background: none;
     font-family: Pretendard, sans-serif;
     font-size: 14px;
     color: #cacaca;
     line-height: 1.6;
+    cursor: pointer;
 
     svg {
       width: 20px;

--- a/src/components/Department/CategoryDetail/CategoryDetailDesktop/index.tsx
+++ b/src/components/Department/CategoryDetail/CategoryDetailDesktop/index.tsx
@@ -8,6 +8,7 @@ export default function CategoryDetailDesktop({
   categoryName,
   departments,
   isLoaded,
+  onFeedbackClick,
   updatedAt,
 }: CategoryDetailViewProps) {
   return (
@@ -30,10 +31,10 @@ export default function CategoryDetailDesktop({
 
         <div className={styles.footer}>
           <p className={styles.footer__updated}>업데이트일: {updatedAt}</p>
-          <p className={styles.footer__notice}>
+          <button type="button" className={styles.footer__notice} onClick={onFeedbackClick}>
             <AlertCircleIcon />
             정보가 정확하지 않나요?
-          </p>
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/Department/CategoryDetail/CategoryDetailMobile/CategoryDetailMobile.module.scss
+++ b/src/components/Department/CategoryDetail/CategoryDetailMobile/CategoryDetailMobile.module.scss
@@ -102,3 +102,37 @@
   flex-direction: column;
   gap: 12px;
 }
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+  margin-top: auto;
+  padding-top: 40px;
+
+  &__updated {
+    font-size: 12px;
+    color: #cacaca;
+    line-height: 1.6;
+  }
+
+  &__notice {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    font-family: inherit;
+    font-size: 10px;
+    color: #cacaca;
+    line-height: 1.6;
+    cursor: pointer;
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}

--- a/src/components/Department/CategoryDetail/CategoryDetailMobile/index.tsx
+++ b/src/components/Department/CategoryDetail/CategoryDetailMobile/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import ArrowBackIcon from 'assets/svg/arrow-back.svg';
 import SearchIcon from 'assets/svg/common/purple-search.svg';
+import AlertCircleIcon from 'assets/svg/department/alert-circle-icon.svg';
 import DepartmentCard from 'components/Department/DepartmentCard';
 import SearchEmptyState from 'components/Department/SearchEmptyState';
 import type { CategoryDetailViewProps } from 'components/Department/CategoryDetail/types';
@@ -12,6 +13,8 @@ export default function CategoryDetailMobile({
   onSearchChange,
   departments,
   isLoaded,
+  onFeedbackClick,
+  updatedAt,
 }: CategoryDetailViewProps) {
   const router = useRouter();
 
@@ -52,6 +55,14 @@ export default function CategoryDetailMobile({
             ))}
           </div>
         )}
+
+        <div className={styles.footer}>
+          <p className={styles.footer__updated}>업데이트일: {updatedAt}</p>
+          <button type="button" className={styles.footer__notice} onClick={onFeedbackClick}>
+            <AlertCircleIcon />
+            정보가 정확하지 않나요?
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Department/CategoryDetail/index.tsx
+++ b/src/components/Department/CategoryDetail/index.tsx
@@ -4,6 +4,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { DepartmentContactCategory } from 'api/departmentContact/entity';
 import { departmentContactQueries } from 'api/departmentContact/queries';
 import { formatUpdatedAt } from 'components/Department/formatUpdatedAt';
+import { BUS_FEEDBACK_FORM } from 'static/bus';
 import { useDebounce } from 'utils/hooks/debounce/useDebounce';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import CategoryDetailDesktop from './CategoryDetailDesktop';
@@ -48,12 +49,17 @@ export default function CategoryDetailPage({ category }: CategoryDetailPageProps
 
   const updatedAt = data?.updated_at ? formatUpdatedAt(data.updated_at) : DEPARTMENT_INFO_UPDATED_AT_FALLBACK;
 
+  const handleFeedbackClick = () => {
+    window.open(BUS_FEEDBACK_FORM);
+  };
+
   const viewProps = {
     categoryName: data?.category_name ?? '',
     searchValue,
     onSearchChange: handleSearchChange,
     departments: data?.departments ?? [],
     isLoaded: !!data,
+    onFeedbackClick: handleFeedbackClick,
     updatedAt,
   };
 

--- a/src/components/Department/CategoryDetail/types.ts
+++ b/src/components/Department/CategoryDetail/types.ts
@@ -6,5 +6,6 @@ export interface CategoryDetailViewProps {
   onSearchChange: (value: string) => void;
   departments: DepartmentContactDepartment[];
   isLoaded: boolean;
+  onFeedbackClick: () => void;
   updatedAt: string;
 }

--- a/src/components/Department/DepartmentDesktop/DepartmentDesktop.module.scss
+++ b/src/components/Department/DepartmentDesktop/DepartmentDesktop.module.scss
@@ -200,10 +200,14 @@
     display: flex;
     align-items: center;
     gap: 4px;
+    padding: 0;
+    border: none;
+    background: none;
     font-family: Pretendard, sans-serif;
     font-size: 14px;
     color: #cacaca;
     line-height: 1.6;
+    cursor: pointer;
 
     svg {
       width: 20px;

--- a/src/components/Department/DepartmentDesktop/index.tsx
+++ b/src/components/Department/DepartmentDesktop/index.tsx
@@ -16,6 +16,7 @@ export default function DepartmentDesktop({
   categories,
   searchResultCategories,
   onCategoryClick,
+  onFeedbackClick,
   updatedAt,
 }: DepartmentViewProps) {
   const searchResults = searchResultCategories.flatMap(({ category, departments }) =>
@@ -87,10 +88,10 @@ export default function DepartmentDesktop({
 
         <div className={styles.footer}>
           <p className={styles.footer__updated}>업데이트일: {updatedAt}</p>
-          <p className={styles.footer__notice}>
+          <button type="button" className={styles.footer__notice} onClick={onFeedbackClick}>
             <AlertCircleIcon />
             정보가 정확하지 않나요?
-          </p>
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/Department/DepartmentMobile/DepartmentMobile.module.scss
+++ b/src/components/Department/DepartmentMobile/DepartmentMobile.module.scss
@@ -56,7 +56,7 @@
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    gap: 40px;
     width: 100%;
     padding: 0 22px 24px;
   }
@@ -185,9 +185,14 @@
     display: flex;
     align-items: center;
     gap: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    font-family: inherit;
     font-size: 10px;
     color: #cacaca;
     line-height: 1.6;
+    cursor: pointer;
 
     svg {
       width: 16px;

--- a/src/components/Department/DepartmentMobile/index.tsx
+++ b/src/components/Department/DepartmentMobile/index.tsx
@@ -19,6 +19,7 @@ export default function DepartmentMobile({
   categories,
   searchResultCategories,
   onCategoryClick,
+  onFeedbackClick,
   updatedAt,
 }: DepartmentViewProps) {
   const router = useRouter();
@@ -99,10 +100,10 @@ export default function DepartmentMobile({
 
         <div className={styles.footer}>
           <p className={styles.footer__updated}>업데이트일: {updatedAt}</p>
-          <p className={styles.footer__notice}>
+          <button type="button" className={styles.footer__notice} onClick={onFeedbackClick}>
             <AlertCircleIcon />
             정보가 정확하지 않나요?
-          </p>
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/Department/index.tsx
+++ b/src/components/Department/index.tsx
@@ -9,6 +9,7 @@ import CircleEllipsisIcon from 'assets/svg/department/circle-ellipsis-icon.svg';
 import GlobalIcon from 'assets/svg/department/global-icon.svg';
 import SchoolIcon from 'assets/svg/department/school-icon.svg';
 import SuitIcon from 'assets/svg/department/suit-icon.svg';
+import { BUS_FEEDBACK_FORM } from 'static/bus';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import { useDebounce } from 'utils/hooks/debounce/useDebounce';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
@@ -82,6 +83,10 @@ export default function DepartmentPage() {
     });
   };
 
+  const handleFeedbackClick = () => {
+    window.open(BUS_FEEDBACK_FORM);
+  };
+
   const isSearching = keyword.length > 0;
   const searchResultCategories = (data?.categories ?? []).filter(({ departments }) => departments.length > 0);
 
@@ -93,6 +98,7 @@ export default function DepartmentPage() {
     categories: DEPARTMENT_CATEGORIES,
     searchResultCategories,
     onCategoryClick: handleCategoryClick,
+    onFeedbackClick: handleFeedbackClick,
     updatedAt,
   };
 

--- a/src/components/Department/types.ts
+++ b/src/components/Department/types.ts
@@ -17,5 +17,6 @@ export interface DepartmentViewProps {
   categories: DepartmentCategoryMenuItem[];
   searchResultCategories: DepartmentContactCategoryGroup[];
   onCategoryClick: (category: DepartmentContactCategory, title: string) => void;
+  onFeedbackClick: () => void;
   updatedAt: string;
 }


### PR DESCRIPTION
## 개요
부서정보 페이지들의 "정보가 정확하지 않나요?" 문구를 클릭 가능한 버튼으로 바꾸고, 버스 페이지와 동일한 피드백 폼 링크로 이동하도록 수정했습니다. 겸사겸사 모바일 상세 페이지에 누락되어 있던 피드백 영역을 추가하고, 목록/상세 페이지의 검색창-하단 요소 간격을 통일했습니다.

## 변경 사항
### 피드백 링크 연결
- `DepartmentDesktop`, `DepartmentMobile`, `CategoryDetailDesktop`: "정보가 정확하지 않나요?" `<p>` → `<button>`으로 변경, 클릭 시 `BUS_FEEDBACK_FORM`(버스 페이지와 동일한 구글 폼)을 새 탭으로 오픈
- `Department/index.tsx`, `CategoryDetail/index.tsx`: `onFeedbackClick` 핸들러 추가 후 하위 뷰로 전달
- `Department/types.ts`, `CategoryDetail/types.ts`: `onFeedbackClick` prop 타입 추가

### 모바일 상세 페이지 누락 요소 추가
- `CategoryDetailMobile`: 목록 페이지(`DepartmentMobile`)에는 있었지만 상세 페이지에는 없던 "업데이트일 + 피드백 버튼" 푸터 영역 추가 (`updatedAt`, `onFeedbackClick` prop 사용)

### 모바일 간격 통일
- `DepartmentMobile.module.scss`: `page__content` gap을 `20px → 40px`로 변경해 상세 페이지(`CategoryDetailMobile`)와 검색창-하단 요소 간격 통일

## 테스트 방법
1. `yarn start` 실행
2. `/department` 페이지에서 데스크탑/모바일 뷰로 "정보가 정확하지 않나요?" 클릭 시 폼 링크 새 탭 오픈 확인
3. 카테고리 상세 페이지(데스크탑/모바일)에서도 동일하게 동작 확인
4. 모바일 목록/상세 페이지의 검색창-하단 요소 간격이 동일한지 확인

## 체크리스트
- [x] yarn lint 통과 (eslint, stylelint)
- [x] SSR 안전성 확인 (해당 없음)
- [x] ROUTES 대신 외부 링크는 window.open 사용 (버스 페이지 컨벤션과 동일)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 부서 및 카테고리 상세 화면에 “정보가 정확하지 않나요?” 피드백 버튼을 추가했습니다.
  * 버튼을 누르면 피드백 양식이 새 창에서 열립니다.
  * 모바일 화면에 최종 업데이트 일자와 안내 영역을 추가했습니다.

* **스타일 개선**
  * 피드백 버튼의 시각적 스타일과 클릭 가능한 상태를 정리했습니다.
  * 모바일 콘텐츠 간격과 하단 영역 레이아웃을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->