### PR TITLE
[공통] SSR 하이드레이션 불일치 수정

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,6 +42,12 @@ yarn log                # Notion 스펙에서 분석 로깅 훅 생성
 7. **토스트:** `showToast(type, message)` 사용. `toast()` 직접 호출 금지.
 8. **iOS 브릿지:** `window.webkit` optional chaining 유지 (`src/utils/ts/iosBridge.ts`).
 9. **분석 로깅:** 주요 사용자 인터랙션마다 `useLogger()` 훅 포함.
+10. **SSR 렌더 결정성:** 렌더 결과는 **현재 시각·브라우저 전용 상태(쿠키/스토리지)·AB 배정**에 의존해선 안 된다. 서버 렌더와 하이드레이션 렌더가 갈리면 hydration mismatch가 난다.
+    - 시각·저장소 파생 값은 `useMount()` 게이트 뒤로 미루거나 `components/ssr/SSRSuspense`로 감싼다. 참조 구현: `IndexTimetable:79`, `PCCafeteriaPage`
+    - `/`·`/store` 등은 nginx가 60초 공유 캐시하므로(`proxy_cache_valid 200 60s`) **서버 시각을 props로 내리는 방식은 답이 아니다** — 캐시된 시각은 이 사용자의 시각이 아니다
+    - `useTokenState()`는 SSR에서 `''`을 반환한다. `??`가 아니라 `||`로 `serverToken` 폴백할 것
+    - 쿼리 키에 토큰이 들어가면(`clubQueryKeys.*`, `callvanQueryKeys.*`) SSR과 클라이언트가 다른 캐시를 본다
+    - 검증: 개발 모드에서 해당 페이지 접속 후 콘솔에 `Hydration failed` 메시지가 없는지 확인. 로그인/비로그인 양쪽을 볼 것
 
 ## PR 리뷰 규칙 (claude-code-action용)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,8 @@ export default [
       ...reactHooks.configs['recommended-latest'].rules,
 
       // SSR 안전성 (CLAUDE.md 규칙 4, 10)
+      // bare 참조는 no-restricted-globals 가, window/globalThis 경유는
+      // no-restricted-properties 가 잡는다. 둘 다 없으면 한쪽으로 우회된다.
       'no-restricted-globals': [
         'error',
         {
@@ -71,6 +73,21 @@ export default [
           name: 'sessionStorage',
           message: 'SSR 안전을 위해 utils/ts/env 의 isomorphicSessionStorage 를 사용하세요.',
         },
+      ],
+      'no-restricted-properties': [
+        'error',
+        ...['window', 'globalThis'].flatMap((object) => [
+          {
+            object,
+            property: 'localStorage',
+            message: 'SSR 안전을 위해 utils/ts/env 의 isomorphicLocalStorage 를 사용하세요.',
+          },
+          {
+            object,
+            property: 'sessionStorage',
+            message: 'SSR 안전을 위해 utils/ts/env 의 isomorphicSessionStorage 를 사용하세요.',
+          },
+        ]),
       ],
 
       'import/order': [
@@ -116,6 +133,15 @@ export default [
       'linebreak-style': 'off',
       'import/prefer-default-export': 'off',
       'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
+  },
+  {
+    // isomorphicLocalStorage / isomorphicSessionStorage 의 구현체.
+    // 저장소에 직접 접근하는 유일한 정당한 지점이므로 SSR 안전성 규칙에서 제외한다.
+    files: ['src/utils/ts/env.ts'],
+    rules: {
+      'no-restricted-globals': 'off',
+      'no-restricted-properties': 'off',
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,19 @@ export default [
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs['recommended-latest'].rules,
 
+      // SSR 안전성 (CLAUDE.md 규칙 4, 10)
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'localStorage',
+          message: 'SSR 안전을 위해 utils/ts/env 의 isomorphicLocalStorage 를 사용하세요.',
+        },
+        {
+          name: 'sessionStorage',
+          message: 'SSR 안전을 위해 utils/ts/env 의 isomorphicSessionStorage 를 사용하세요.',
+        },
+      ],
+
       'import/order': [
         'error',
         {

--- a/src/components/Callvan/components/CallvanPageLayout/index.tsx
+++ b/src/components/Callvan/components/CallvanPageLayout/index.tsx
@@ -11,6 +11,7 @@ import SearchIcon from 'assets/svg/Callvan/search.svg';
 import CallvanFilterPanel from 'components/Callvan/components/CallvanFilterPanel';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
+import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import styles from './CallvanPageLayout.module.scss';
 
@@ -46,7 +47,9 @@ export default function CallvanPageLayout({
     enabled: !!token,
   });
 
-  const hasUnreadNotifications = notifications?.some((n) => !n.is_read) ?? false;
+  // 알림 쿼리 키에 토큰이 들어가 SSR(token='')과 클라이언트가 다른 캐시를 본다.
+  const isMounted = useMount();
+  const hasUnreadNotifications = isMounted && (notifications?.some((n) => !n.is_read) ?? false);
 
   const hasActiveFilter =
     statuses.length > 0 ||

--- a/src/components/Club/ClubDetailPage/hooks/useClubdetail.ts
+++ b/src/components/Club/ClubDetailPage/hooks/useClubdetail.ts
@@ -6,8 +6,11 @@ import { clubQueries } from 'api/club/queries';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import showToast from 'utils/ts/showToast';
 
-export default function useClubDetail(clubId: number) {
-  const token = useTokenState();
+export default function useClubDetail(clubId: number, serverToken?: string | null) {
+  const clientToken = useTokenState();
+  // 쿼리 키에 토큰이 들어가는데 useTokenState()는 SSR에서 ''을 반환한다.
+  // serverToken으로 폴백해 서버와 클라이언트가 같은 키를 쓰게 한다. (`??`는 ''을 못 거른다)
+  const token = clientToken || serverToken || '';
   const queryClient = useQueryClient();
 
   const { data: clubDetail } = useSuspenseQuery(clubQueries.detail(Number(clubId), token));

--- a/src/components/Club/ClubDetailPage/hooks/useClubdetail.ts
+++ b/src/components/Club/ClubDetailPage/hooks/useClubdetail.ts
@@ -3,14 +3,19 @@ import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-q
 import { putClubInroduction } from 'api/club';
 import { ClubIntroductionData } from 'api/club/entity';
 import { clubQueries } from 'api/club/queries';
+import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import showToast from 'utils/ts/showToast';
 
 export default function useClubDetail(clubId: number, serverToken?: string | null) {
   const clientToken = useTokenState();
+  const isMounted = useMount();
   // 쿼리 키에 토큰이 들어가는데 useTokenState()는 SSR에서 ''을 반환한다.
-  // serverToken으로 폴백해 서버와 클라이언트가 같은 키를 쓰게 한다. (`??`는 ''을 못 거른다)
-  const token = clientToken || serverToken || '';
+  // 하이드레이션 중에만 serverToken 으로 폴백해 서버와 같은 키를 쓰고,
+  // 마운트 이후에는 클라이언트 상태만 신뢰한다. 토큰 갱신 실패로 setToken('') 이
+  // 호출된 뒤에도 SSR 시점의 만료 토큰으로 되돌아가는 것을 막는다.
+  const hydrationFallbackToken = isMounted ? null : serverToken;
+  const token = clientToken || hydrationFallbackToken || '';
   const queryClient = useQueryClient();
 
   const { data: clubDetail } = useSuspenseQuery(clubQueries.detail(Number(clubId), token));

--- a/src/components/IndexComponents/IndexCafeteria/index.tsx
+++ b/src/components/IndexComponents/IndexCafeteria/index.tsx
@@ -13,6 +13,7 @@ import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
+import useMount from 'utils/hooks/state/useMount';
 import { isomorphicLocalStorage } from 'utils/ts/env';
 import styles from './IndexCafeteria.module.scss';
 
@@ -23,12 +24,16 @@ function IndexCafeteria() {
   const logger = useLogger();
   const { dinings } = useDinings(diningTime.generateDiningDate());
 
+  // 응답이 공유 캐시되므로 서버가 렌더한 시각은 이 사용자의 시각이 아니다.
+  // 시각 파생 값은 마운트 이후에만 그린다.
+  const isMounted = useMount();
+  const diningType = isMounted ? diningTime.getType() : null;
+  const dayLabel = isMounted ? (diningTime.isTodayDining() ? '오늘' : '내일') : '';
+
   const [selectedPlace, setSelectedPlace] = useState<DiningPlace>('A코너');
   const [isTooltipOpen, openTooltip, closeTooltip] = useBooleanState(false);
 
-  const selectedDining = dinings.find(
-    (dining) => dining.place === selectedPlace && dining.type === diningTime.getType(),
-  );
+  const selectedDining = dinings.find((dining) => dining.place === selectedPlace && dining.type === diningType);
 
   const handleMoreClick = () => {
     logger.actionEventClick({
@@ -64,7 +69,7 @@ function IndexCafeteria() {
     <section className={styles.template}>
       <h2 className={styles.header}>
         <button type="button" className={styles.header__title} onClick={handleMoreClick}>
-          {`${diningTime.isTodayDining() ? '오늘' : '내일'} 식단`}
+          {`${dayLabel} 식단`}
         </button>
         <button type="button" className={styles.header__more} onClick={handleMoreClick}>
           더보기
@@ -113,7 +118,7 @@ function IndexCafeteria() {
             </button>
           ))}
         </div>
-        <div className={styles.type}>{DINING_TYPE_MAP[diningTime.getType()]}</div>
+        <div className={styles.type}>{diningType ? DINING_TYPE_MAP[diningType] : ''}</div>
         <button
           type="button"
           className={cn({
@@ -124,7 +129,7 @@ function IndexCafeteria() {
         >
           {isMobile && (
             <div className={styles.menus__type}>
-              {DINING_TYPE_MAP[diningTime.getType()]}
+              {diningType ? DINING_TYPE_MAP[diningType] : ''}
               {selectedDining?.soldout_at && <span className={styles.menus__chip}>품절</span>}
             </div>
           )}

--- a/src/components/Store/StorePage/components/DesktopStoreList/index.tsx
+++ b/src/components/Store/StorePage/components/DesktopStoreList/index.tsx
@@ -11,6 +11,7 @@ import ROUTES from 'static/routes';
 import { StorePageType } from 'static/store';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useParamsHandler from 'utils/hooks/routing/useParamsHandler';
+import useMount from 'utils/hooks/state/useMount';
 import getDayOfWeek from 'utils/ts/getDayOfWeek';
 import styles from './DesktopStoreList.module.scss';
 
@@ -29,6 +30,11 @@ export default function DesktopStoreList(storeListProps: StoreListProps) {
   const { storeListData, storeType } = storeListProps;
   const logger = useLogger();
   const pickTopicJosa = getJosaPicker('은');
+
+  // getDayOfWeek()는 new Date()에 의존한다. 응답이 공유 캐시되므로 자정을 넘기면
+  // 서버는 어제 요일, 클라이언트는 오늘 요일을 그린다.
+  const isMounted = useMount();
+  const dayOfWeek = isMounted ? getDayOfWeek() : null;
 
   const { searchParams } = useParamsHandler();
   const { data: categories } = useSuspenseQuery(storeQueries.categories());
@@ -96,8 +102,9 @@ export default function DesktopStoreList(storeListProps: StoreListProps) {
           <div className={styles['store-list__open-time']}>
             운영시간
             <span>
-              {store.open[getDayOfWeek()] &&
-                getOpenCloseTime(store.open[getDayOfWeek()].open_time, store.open[getDayOfWeek()].close_time)}
+              {dayOfWeek !== null &&
+                store.open[dayOfWeek] &&
+                getOpenCloseTime(store.open[dayOfWeek].open_time, store.open[dayOfWeek].close_time)}
             </span>
           </div>
           <div className={styles['store-item']}>

--- a/src/pages/callvan/notifications/index.tsx
+++ b/src/pages/callvan/notifications/index.tsx
@@ -74,7 +74,8 @@ export default function CallvanNotificationsPage() {
     return null;
   }
 
-  const hasNotifications = notifications && notifications.length > 0;
+  // 알림 쿼리 키에 토큰이 들어가 SSR(token='')과 클라이언트가 다른 캐시를 본다.
+  const hasNotifications = mounted && notifications && notifications.length > 0;
 
   return (
     <div className={styles['notification-page']}>

--- a/src/pages/callvan/notifications/index.tsx
+++ b/src/pages/callvan/notifications/index.tsx
@@ -75,7 +75,9 @@ export default function CallvanNotificationsPage() {
   }
 
   // 알림 쿼리 키에 토큰이 들어가 SSR(token='')과 클라이언트가 다른 캐시를 본다.
-  const hasNotifications = mounted && notifications && notifications.length > 0;
+  // 마운트 전에는 조회 결과를 알 수 없으므로 "알림 없음"과 구분한다.
+  const isResolved = mounted && notifications !== undefined;
+  const hasNotifications = isResolved && notifications.length > 0;
 
   return (
     <div className={styles['notification-page']}>
@@ -113,21 +115,22 @@ export default function CallvanNotificationsPage() {
       </div>
 
       <div className={styles['notification-page__content']}>
-        {!hasNotifications ? (
-          <NotificationEmptyState />
-        ) : (
-          <div className={styles['notification-page__list']}>
-            {notifications.map((notification, index) => (
-              <div key={notification.id}>
-                <NotificationCard
-                  notification={notification}
-                  onCardClick={() => handleCardClick(notification.id, notification.is_read)}
-                />
-                {index < notifications.length - 1 && <div className={styles['notification-page__divider']} />}
-              </div>
-            ))}
-          </div>
-        )}
+        {isResolved
+          && (hasNotifications ? (
+            <div className={styles['notification-page__list']}>
+              {notifications.map((notification, index) => (
+                <div key={notification.id}>
+                  <NotificationCard
+                    notification={notification}
+                    onCardClick={() => handleCardClick(notification.id, notification.is_read)}
+                  />
+                  {index < notifications.length - 1 && <div className={styles['notification-page__divider']} />}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <NotificationEmptyState />
+          ))}
       </div>
 
       {isDeleteModalOpen && (

--- a/src/pages/clubs/[id]/index.tsx
+++ b/src/pages/clubs/[id]/index.tsx
@@ -101,23 +101,30 @@ export const getServerSideProps = withCacheControl(async (context: GetServerSide
       initialClubId: clubId,
       initialTab,
       initialEventId: numericEventId,
+      serverToken: token ?? null,
     },
   };
 });
 
 interface ClubDetailPageProps {
+  serverToken: string | null;
   initialClubId: number;
   initialTab: TabType;
   initialEventId: number;
 }
 
-export default function ClubDetailPage({ initialClubId, initialTab, initialEventId }: ClubDetailPageProps) {
+export default function ClubDetailPage({
+  initialClubId,
+  initialTab,
+  initialEventId,
+  serverToken,
+}: ClubDetailPageProps) {
   const router = useRouter();
   const logger = useLogger();
   const isMobile = useMediaQuery();
   const navigate = (path: string) => router.push(path);
 
-  const { clubDetail, clubIntroductionEditStatus } = useClubDetail(initialClubId);
+  const { clubDetail, clubIntroductionEditStatus } = useClubDetail(initialClubId, serverToken);
   const { data: clubRecruitmentData } = useSuspenseQuery(clubQueries.recruitment(initialClubId));
   const { mutateAsync: deleteRecruitment } = useDeleteRecruitment();
   const { mutateAsync: deleteEvent } = useDeleteEvent();

--- a/src/pages/clubs/index.tsx
+++ b/src/pages/clubs/index.tsx
@@ -114,7 +114,8 @@ function ClubListPage({ initialQuery, serverToken }: InferGetServerSidePropsType
   const isMobile = useMediaQuery();
   const portalManager = useModalPortal();
 
-  const token = clientToken ?? serverToken ?? null;
+  // useTokenState()는 SSR에서 ''을 반환하므로 `??`로는 serverToken 폴백이 동작하지 않는다.
+  const token = clientToken || serverToken || null;
 
   const { searchParams, setParams: setSearchParams } = useParamsHandler();
 

--- a/src/pages/clubs/index.tsx
+++ b/src/pages/clubs/index.tsx
@@ -22,6 +22,7 @@ import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useModalPortal from 'utils/hooks/layout/useModalPortal';
 import useParamsHandler from 'utils/hooks/routing/useParamsHandler';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
+import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import {
   createQueryParser,
@@ -107,6 +108,7 @@ export const getServerSideProps = withCacheControl(async (context: GetServerSide
 function ClubListPage({ initialQuery, serverToken }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const logger = useLogger();
   const clientToken = useTokenState();
+  const isMounted = useMount();
   const router = useRouter();
   const navigate = (path: string) => {
     router.push(path);
@@ -115,7 +117,9 @@ function ClubListPage({ initialQuery, serverToken }: InferGetServerSidePropsType
   const portalManager = useModalPortal();
 
   // useTokenState()는 SSR에서 ''을 반환하므로 `??`로는 serverToken 폴백이 동작하지 않는다.
-  const token = clientToken || serverToken || null;
+  // 하이드레이션 중에만 폴백하고, 마운트 이후에는 클라이언트 상태만 신뢰한다.
+  const hydrationFallbackToken = isMounted ? null : serverToken;
+  const token = clientToken || hydrationFallbackToken || null;
 
   const { searchParams, setParams: setSearchParams } = useParamsHandler();
 

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -13,6 +13,7 @@ import CourseTable, {
 } from 'components/Course/components/CourseTable';
 import useCourseSearchForm from 'components/Course/hooks/useCourseSearchForm';
 import useSelectedCourses, { getCourseKey } from 'components/Course/hooks/useSelectedCourses';
+import SSRSuspense from 'components/ssr/SSRSuspense';
 import useTimetableFrameList from 'components/TimetablePage/hooks/useTimetableFrameList';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
@@ -181,9 +182,11 @@ function CoursePage() {
 CoursePageWrapper.getLayout = (page: React.ReactNode) => page;
 
 export default function CoursePageWrapper() {
+  // 토큰(useTimetableFrameList)과 sessionStorage(useSelectedCourses)에 의존하므로
+  // SSRSuspense로 마운트 이후로 미룬다.
   return (
-    <Suspense fallback={<div className={styles.page}>로딩 중...</div>}>
+    <SSRSuspense fallback={<div className={styles.page}>로딩 중...</div>}>
       <CoursePage />
-    </Suspense>
+    </SSRSuspense>
   );
 }

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,5 +1,4 @@
 import type { ComponentType, ReactNode, SVGProps } from 'react';
-import { Suspense } from 'react';
 import Link from 'next/link';
 import LoginIcon from 'assets/svg/common/login-icon.svg';
 import LogoutIcon from 'assets/svg/common/logout-icon.svg';
@@ -8,6 +7,7 @@ import UserIcon from 'assets/svg/common/user-2-icon.svg';
 import AuthenticateUserModal from 'components/AuthenticateUserModal';
 import HomeLayout from 'components/layout/HomeLayout';
 import { LoggedInTimetablePreview, ProfileTimetableGrid } from 'components/ProfilePage/TimetablePreview';
+import Suspense from 'components/ssr/SSRSuspense';
 import IconBox from 'components/ui/IconBox';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
@@ -184,6 +184,7 @@ function ProfilePageContent() {
 }
 
 function ProfilePage() {
+  // useUser()가 SSR에서는 항상 로그아웃으로 해소된다. Suspense는 SSRSuspense.
   return (
     <Suspense fallback={null}>
       <ProfilePageContent />

--- a/src/utils/hooks/abTest/useABTestView.ts
+++ b/src/utils/hooks/abTest/useABTestView.ts
@@ -1,28 +1,34 @@
 import { useEffect } from 'react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { abTestQueries } from 'api/abTest/queries';
 import useMount from 'utils/hooks/state/useMount';
 import { isomorphicLocalStorage } from 'utils/ts/env';
 
 /**
  * AB 배정은 클라이언트 전용이다.
+ *
  * 배정 결과는 호출마다 달라질 수 있는데 응답 HTML이 공유 캐시되므로, 서버에서 배정하면
- * 그 변형이 다른 사용자에게 그대로 전달된다. 서버·하이드레이션 렌더는 'default'로 고정한다.
+ * 그 변형이 다른 사용자에게 그대로 전달된다. 또 배정 키에 브라우저에만 있는
+ * access_history_id 가 들어가 SSR과 클라이언트가 서로 다른 배정을 받는다.
+ *
+ * 따라서 렌더 결과만 고정하는 것으로는 부족하고 `요청 자체`를 마운트 이후로 미뤄야 한다.
+ * useSuspenseQuery 는 enabled 를 무시하므로 useQuery 를 쓴다.
  */
 export const useABTestView = (title: string, authorization?: string) => {
   const isMounted = useMount();
   const accessHistoryId = isMounted ? isomorphicLocalStorage.getItem('access_history_id') : null;
 
-  const { data: abTestView } = useSuspenseQuery(abTestQueries.assign(title, authorization, accessHistoryId));
+  const { data: abTestView } = useQuery({
+    ...abTestQueries.assign(title, authorization, accessHistoryId),
+    enabled: isMounted,
+  });
 
   // 최초 편입 시
   useEffect(() => {
-    if (abTestView.access_history_id) {
+    if (abTestView?.access_history_id) {
       isomorphicLocalStorage.setItem('access_history_id', abTestView.access_history_id.toString());
     }
-  }, [abTestView.access_history_id]);
+  }, [abTestView?.access_history_id]);
 
-  if (!isMounted) return 'default';
-
-  return abTestView.variable_name || 'default';
+  return abTestView?.variable_name || 'default';
 };

--- a/src/utils/hooks/abTest/useABTestView.ts
+++ b/src/utils/hooks/abTest/useABTestView.ts
@@ -1,16 +1,28 @@
+import { useEffect } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { abTestQueries } from 'api/abTest/queries';
+import useMount from 'utils/hooks/state/useMount';
 import { isomorphicLocalStorage } from 'utils/ts/env';
 
+/**
+ * AB 배정은 클라이언트 전용이다.
+ * 배정 결과는 호출마다 달라질 수 있는데 응답 HTML이 공유 캐시되므로, 서버에서 배정하면
+ * 그 변형이 다른 사용자에게 그대로 전달된다. 서버·하이드레이션 렌더는 'default'로 고정한다.
+ */
 export const useABTestView = (title: string, authorization?: string) => {
-  const accessHistoryId = isomorphicLocalStorage.getItem('access_history_id');
+  const isMounted = useMount();
+  const accessHistoryId = isMounted ? isomorphicLocalStorage.getItem('access_history_id') : null;
 
   const { data: abTestView } = useSuspenseQuery(abTestQueries.assign(title, authorization, accessHistoryId));
 
   // 최초 편입 시
-  if (abTestView.access_history_id) {
-    isomorphicLocalStorage.setItem('access_history_id', abTestView.access_history_id.toString());
-  }
+  useEffect(() => {
+    if (abTestView.access_history_id) {
+      isomorphicLocalStorage.setItem('access_history_id', abTestView.access_history_id.toString());
+    }
+  }, [abTestView.access_history_id]);
+
+  if (!isMounted) return 'default';
 
   return abTestView.variable_name || 'default';
 };


### PR DESCRIPTION
> Resolves #1302

## 요약

SSR 렌더와 하이드레이션 렌더의 입력이 달라 하이드레이션이 깨지던 지점을 수정합니다.
Sentry 기준 prod **6,526건 / 1,618명** 영향(`KOIN-PROD-1`).

## 원인과 수정

### 1. 시각 의존 렌더

응답이 nginx 공유 캐시(`proxy_cache_valid 200 60s`) 대상이라 **서버가 렌더한 시각이 이 사용자의 시각이 아닙니다.** 캐시된 HTML이 식사 경계(09:00/13:30/18:30)나 자정을 넘겨 재사용되면 불일치가 발생합니다.

| 파일 | 수정 |
|---|---|
| `IndexCafeteria` | 식단 라벨·타입을 `useMount()` 게이트 뒤로 |
| `DesktopStoreList` | `getDayOfWeek()` 기반 운영시간을 게이트 뒤로 |

<details>
<summary>서버 시각을 props로 내리는 방식을 택하지 않은 이유</summary>

공유 캐시가 걸려 있어 serverNow를 심어도 그건 "최대 60초 전, 다른 요청의 시각"입니다. 하이드레이션 결정성은 얻지만 콘텐츠는 여전히 틀리고, 마운트 후 실시각으로 보정하는 effect가 어차피 또 필요합니다. 복잡도만 늘고 클라이언트 보정은 없앨 수 없습니다.

`suppressHydrationWarning`도 반려했습니다. 텍스트 노드 한 단계에만 적용되고 경고를 끌 뿐 DOM 패치를 보장하지 않으며, `{오늘|내일} 식단`은 분기 자체가 갈립니다.
</details>

### 2. 로그인 상태 의존 렌더

`useTokenState()`가 SSR에서 `''`을 반환해 **서버는 비로그인, 클라이언트는 로그인 상태로 렌더**됩니다. 로그인 사용자에게 상시 발생합니다.

| 페이지 | 서버 | 클라이언트 | 수정 |
|---|---|---|---|
| `/profile` | `로그인을 해주세요.` | 사용자명 | `Suspense` → `SSRSuspense` |
| `/course` | placeholder | 시간표 | `Suspense` → `SSRSuspense` |
| `/clubs` | `총 0개` | `총 35개` | `??` → `\|\|` |
| `/clubs/[id]` | 좋아요 안함 | 좋아요 | `serverToken` 전달 |
| `/callvan` | 알림 점 없음 | 알림 점 | `useMount()` 게이트 |
| `/callvan/notifications` | 빈 영역 | 알림 목록 | `useMount()` 게이트 |

**`/clubs`는 폴백 로직 자체에 버그가 있었습니다.**

```ts
- const token = clientToken ?? serverToken ?? null;
+ const token = clientToken || serverToken || null;
```

`useTokenState()`는 `''`을 반환하는데 `??`는 `null`/`undefined`만 걸러내므로 **`serverToken` 폴백이 한 번도 동작하지 않았습니다.** 서버가 "총 0개의 동아리"라는 틀린 값을 렌더하고 있었고, 이번 수정으로 SSR 콘텐츠도 정상화됩니다.

기존에 이미 쓰이던 패턴(`components/ssr/SSRSuspense`, `IndexTimetable`의 `isClient ? … : …`)을 그대로 적용했습니다. 새 패턴을 만들지 않았습니다.

### 3. AB 테스트 (하이드레이션 외 문제 포함)

`useABTestView`가 **렌더 중에 `localStorage`를 읽고 쓰고** 있었습니다(React 렌더 부작용). 더 중요한 건 **AB 배정이 담긴 HTML이 공유 캐시되어 서버가 배정한 변형이 다른 사용자에게 전달**된다는 점입니다. 배정을 클라이언트 전용으로 바꾸고 쓰기를 effect로 옮겼습니다.

### 4. 재발 방지

- ESLint `no-restricted-globals` — `localStorage`/`sessionStorage` 직접 접근 금지 (`isomorphic*` 유도)
- `CLAUDE.md` 필수 준수 규칙 10번 — SSR 렌더 결정성

## 검증

로컬 재현 하네스로 **전 라우트(59개) × 인증(2) × 뷰포트(2) × 모드(3)** 매트릭스를 반복 실행했습니다. 캐시 상황을 재현하기 위해 클라이언트 시계를 식사 경계 너머로 이동시키고, 익명 SSR HTML을 인증 브라우저에 서빙하는 모드를 사용했습니다.

| 매트릭스 | 수정 전 | 수정 후 |
|---|---|---|
| 전수 스윕 | FAIL 7 | **FAIL 0** (PASS 90) |
| 심층 | FAIL 12 | **FAIL 0** (PASS 70) |

- dev 서버 · **프로덕션 빌드**(`reactCompiler` 활성) 양쪽에서 0건
- stage API · prod API 양쪽 데이터로 확인
- `yarn lint` · `tsc --noEmit` 통과

## 이 PR로 해결되지 않는 것

리뷰어가 배포 후 지표를 볼 때 오해하지 않도록 명시합니다.

- **`/cafeteria`(607건) · `/articles`(20건)는 재현되지 않았습니다.** `/cafeteria`는 `SSRSuspense`가 이미 본문 SSR을 막고 있어 구조적으로 불일치가 불가능함을 확인했습니다(prod 데이터로 렌더해도 SSR DOM 텍스트가 187자). 원인이 다른 곳에 있으며 별도 계측으로 추적할 예정입니다.
- `/bus/shuttle`(146건) · `/bus/route`(72건)는 현재 릴리스 배포(7/23) 이전에 멈춰 이미 해결된 상태입니다.
- 테스트 계정에 데이터가 없어 열지 못한 동적 라우트가 있습니다(미판정으로 기록, 통과로 집계하지 않음).

따라서 **`/`(3,414건) · `/store` · `/course`는 감소가 기대되지만 `/cafeteria` 계열 800여 건은 이번 수정으로 줄지 않을 수 있습니다.**

## 배포 후 확인

1. stage 배포 → `KOIN-STAGE-7` 유입 관찰
2. prod 배포 → `KOIN-PROD-1` **resolve 처리** (Sentry가 regression을 자동 감지하므로 조용한 재발을 놓치지 않음)
3. `/course`의 Rage Click 감소 여부도 함께 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 페이지 첫 로드 시 알림, 식사 유형, 날짜별 매장 운영시간이 잘못 표시될 수 있는 문제를 개선했습니다.
  * 로그인 상태에 따라 클럽 상세 정보와 페이지 콘텐츠가 일관되게 표시됩니다.
  * 강의 및 프로필 페이지의 초기 로딩 과정이 안정적으로 동작합니다.
  * A/B 테스트 적용 전후 화면이 자연스럽게 연결되도록 개선해 새로고침 시 화면 불일치를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->