### PR TITLE
[공통] Sentry 노이즈 제거 및 하이드레이션 diff 계측

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -35,6 +35,16 @@ const nextConfig = {
     reactCompiler: true,
     workerThreads: false,
   },
+  async headers() {
+    return [
+      {
+        // 브라우저 프로파일링(Sentry browserProfilingIntegration)은 이 헤더가 없으면
+        // 오류 없이 조용히 아무 데이터도 수집하지 않는다.
+        source: '/:path*',
+        headers: [{ key: 'Document-Policy', value: 'js-profiling' }],
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {
@@ -64,7 +74,13 @@ const nextConfig = {
 export default withSentryConfig(nextConfig, {
   org: process.env.SENTRY_ORG || 'bcsd',
   project: process.env.SENTRY_PROJECT || 'koin-prod',
-  release: { name: process.env.NEXT_PUBLIC_SENTRY_RELEASE },
+  release: {
+    name: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+    // 릴리스에 포함된 커밋을 연결한다. 이슈마다 원인 커밋(Suspect Commits)이 표시되고
+    // 어느 릴리스에서 유입이 시작됐는지 추적할 수 있다.
+    // CI 밖(로컬 빌드 등)에서는 커밋 정보가 없어 실패할 수 있으므로 ignoreMissing 을 켠다.
+    setCommits: { auto: true, ignoreMissing: true },
+  },
   silent: !process.env.CI,
   widenClientFileUpload: true,
   tunnelRoute: '/monitoring',

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,12 +3,27 @@ import * as Sentry from '@sentry/nextjs';
 const environment = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
 const isProduction = environment === 'production';
 
+/** 민감 파일을 탐색하는 봇 요청 경로. 애플리케이션 결함이 아니므로 이슈로 만들지 않는다. */
+const BOT_PROBE_PATTERN = /\/(\.env|\.git|\.aws|wp-admin|wp-login|phpmyadmin|\.well-known\/security)/i;
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: process.env.NODE_ENV === 'production',
   environment,
   release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
 
+  // 미들웨어는 모든 요청을 통과하므로 봇 스캔이 그대로 유입된다.
+  beforeSend(event) {
+    if (event.request?.url && BOT_PROBE_PATTERN.test(event.request.url)) return null;
+    return event;
+  },
+
+  beforeSendLog(log) {
+    if (log.level === 'debug') return null;
+    return log;
+  },
+
+  enableLogs: true,
   tracesSampleRate: isProduction ? 0.7 : 0.1,
   sendDefaultPii: true,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,12 +3,56 @@ import * as Sentry from '@sentry/nextjs';
 const environment = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
 const isProduction = environment === 'production';
 
+/** 민감 파일을 탐색하는 봇 요청 경로. 애플리케이션 결함이 아니므로 이슈로 만들지 않는다. */
+const BOT_PROBE_PATTERN = /\/(\.env|\.git|\.aws|wp-admin|wp-login|phpmyadmin|\.well-known\/security)/i;
+
+interface KoinErrorLike {
+  type?: string;
+  status?: number;
+  code?: string;
+}
+
+function asKoinError(error: unknown): KoinErrorLike | null {
+  if (error == null || typeof error !== 'object') return null;
+  const candidate = error as KoinErrorLike;
+  return candidate.type === 'KOIN_ERROR' ? candidate : null;
+}
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: process.env.NODE_ENV === 'production',
   environment,
   release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
 
+  beforeSend(event, hint) {
+    if (event.request?.url && BOT_PROBE_PATTERN.test(event.request.url)) return null;
+
+    const koinError = asKoinError(hint.originalException);
+    if (koinError) {
+      // 401(토큰 만료) · 404(삭제된 리소스)는 정상 흐름이므로 이슈로 만들지 않는다.
+      if (koinError.status === 401 || koinError.status === 404) return null;
+
+      // KoinError는 Error 인스턴스가 아니라 plain object다. 그대로 두면 Sentry가
+      // "Object captured as exception with keys: ..." 로 묶어 서로 다른 에러가 한 이슈에
+      // 뒤섞이고 스택도 남지 않는다. 상태 코드별로 그룹을 분리한다.
+      event.fingerprint = ['koin-error', String(koinError.status), koinError.code || 'no-code'];
+      event.exception?.values?.forEach((value) => {
+        value.type = `KoinError(${koinError.status ?? 'unknown'})`;
+      });
+    }
+
+    return event;
+  },
+
+  beforeSendLog(log) {
+    if (log.level === 'debug') return null;
+    return log;
+  },
+
+  // plain object로 throw된 에러의 추가 속성을 이벤트에 붙인다 (KoinError 대응)
+  integrations: [Sentry.extraErrorDataIntegration()],
+
+  enableLogs: true,
   tracesSampleRate: isProduction ? 0.7 : 0.1,
   sendDefaultPii: true,
 });

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -3,6 +3,51 @@ import * as Sentry from '@sentry/nextjs';
 const environment = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
 const isProduction = environment === 'production';
 
+/** React 19가 하이드레이션 실패 시 console.error로 출력하는 메시지 패턴 */
+const HYDRATION_ERROR_PATTERN = /Hydration failed|didn't match|Text content does not match|error while hydrating/i;
+
+interface KoinErrorLike {
+  type?: string;
+  status?: number;
+  code?: string;
+}
+
+function asKoinError(error: unknown): KoinErrorLike | null {
+  if (error == null || typeof error !== 'object') return null;
+  const candidate = error as KoinErrorLike;
+  return candidate.type === 'KOIN_ERROR' ? candidate : null;
+}
+
+/**
+ * 하이드레이션 실패 시 React가 출력하는 diff 전문을 경로별로 그룹핑해 보고한다.
+ *
+ * Sentry의 replay hydration breadcrumb에는 diff가 담기지 않아, 어느 컴포넌트가 깨졌는지
+ * 알 수 없었다. consoleLoggingIntegration이 전문을 Logs로 보내주지만 Logs는 그룹핑이
+ * 되지 않으므로, 경로별 이슈는 여기서 따로 만든다.
+ */
+function reportHydrationDiff() {
+  if (typeof window === 'undefined') return;
+
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    const message = args.map((arg) => (arg instanceof Error ? arg.message : String(arg))).join(' ');
+
+    if (HYDRATION_ERROR_PATTERN.test(message)) {
+      Sentry.captureMessage('hydration-diff', {
+        level: 'error',
+        fingerprint: ['hydration', window.location.pathname],
+        extra: {
+          path: window.location.pathname,
+          search: window.location.search,
+          diff: message.slice(0, 8000),
+        },
+      });
+    }
+
+    originalError(...args);
+  };
+}
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: process.env.NODE_ENV === 'production',
@@ -32,8 +77,46 @@ Sentry.init({
       return null;
     }
 
+    const koinError = asKoinError(error);
+    if (koinError) {
+      // 401: 토큰 만료. 미들웨어와 useAutoLogin이 처리하는 정상 흐름이다.
+      // 404: 삭제된 게시글 등에 접근. 페이지에서 안내하므로 알림 대상이 아니다.
+      if (koinError.status === 401 || koinError.status === 404) return null;
+
+      // KoinError는 Error 인스턴스가 아니라 plain object다. 그대로 두면 Sentry가
+      // "Object captured as exception with keys: ..." 로 묶어 서로 다른 에러가 한 이슈에
+      // 뒤섞이고 스택도 남지 않는다. 상태 코드별로 그룹을 분리한다.
+      event.fingerprint = ['koin-error', String(koinError.status), koinError.code || 'no-code'];
+      event.exception?.values?.forEach((value) => {
+        value.type = `KoinError(${koinError.status ?? 'unknown'})`;
+      });
+    }
+
     return event;
   },
+
+  beforeSendLog(log) {
+    if (log.level === 'debug') return null;
+    return log;
+  },
+
+  ignoreErrors: [
+    // Next 라우터가 같은 URL로 이동할 때 발생. 동작에 영향 없다.
+    'attempted to hard navigate to the same URL',
+    // 브라우저 양성 노이즈
+    'ResizeObserver loop',
+    'Non-Error promise rejection captured',
+  ],
+
+  denyUrls: [
+    // 확장 프로그램·인앱 브라우저가 주입한 스크립트
+    /^chrome-extension:\/\//,
+    /^moz-extension:\/\//,
+    /^safari-(web-)?extension:\/\//,
+    // 서드파티 분석 스크립트
+    /googletagmanager\.com/,
+    /google-analytics\.com/,
+  ],
 
   integrations: [
     Sentry.replayIntegration({
@@ -41,6 +124,13 @@ Sentry.init({
       maskAllInputs: false,
       blockAllMedia: false,
     }),
+    // plain object로 throw된 에러의 추가 속성을 이벤트에 붙인다 (KoinError 대응)
+    Sentry.extraErrorDataIntegration(),
+    // console.warn/error 를 Sentry Logs로 전달한다. 하이드레이션 diff 전문이 여기 담긴다.
+    Sentry.consoleLoggingIntegration({ levels: ['warn', 'error'] }),
+    // Degraded UI Performance / Blocking Operation / Rage Click 의 원인 파악용.
+    // next.config.mjs 의 Document-Policy: js-profiling 헤더가 있어야 동작한다.
+    Sentry.browserProfilingIntegration(),
   ],
 
   tracePropagationTargets: [
@@ -48,10 +138,18 @@ Sentry.init({
     ...(process.env.NEXT_PUBLIC_API_PATH ? [process.env.NEXT_PUBLIC_API_PATH] : []),
   ],
 
+  enableLogs: true,
   tracesSampleRate: isProduction ? 0.7 : 1.0,
+  // tracesSampleRate 로 샘플링된 트랜잭션에 대한 상대 비율이다.
+  // UI Profile Hours 는 월 150시간으로, Logs(5TB)와 달리 실제로 한정된 쿼터다.
+  // 월 페이지뷰 약 69만 x 트레이스 0.7 = 48만 트랜잭션이므로 1.0 으로 두면 며칠 만에 소진된다.
+  // 0.1 이면 월 약 4.8만 프로파일(약 67시간)로 여유 있게 들어온다.
+  profilesSampleRate: isProduction ? 0.1 : 1.0,
   replaysSessionSampleRate: isProduction ? 0.3 : 0.0,
   replaysOnErrorSampleRate: 1.0,
   sendDefaultPii: true,
 });
+
+reportHydrationDiff();
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
> Resolves #1304 · 관련 #1302

## 왜 필요한가

[#1302](https://github.com/BCSDLab/KOIN_WEB_RECODE/issues/1302) 조사에서 `/cafeteria`(607건) · `/articles`(20건)의 원인을 **Sentry 데이터만으로 특정할 수 없었습니다.** `replay_hydration_error`는 breadcrumb 기반이라 **React가 출력한 diff가 담기지 않습니다.**

로컬 재현이 실패한 이상 관측을 늘리는 것 외에 방법이 없는데, 지금 상태로 로그를 켜면 노이즈에 묻힙니다. 그래서 **노이즈 제거를 먼저** 합니다.

## 변경 내용

### 1. 에러 그룹핑 복구

`KOIN-PROD-8`을 열어보면 이렇습니다.

```
Error: Object captured as exception with keys: code, message, status, type
__serialized__: { "code": "", "message": "[Filtered]", "status": 401, "type": "KOIN_ERROR" }
```

`KoinError`가 `Error`를 상속하지 않아 **plain object로 throw**되고 있습니다. 그 결과 스택이 남지 않고(`<anonymous>`, `b.getInitialProps` 같은 제목), 서로 다른 에러가 한 이슈에 뒤섞입니다.

- `extraErrorDataIntegration()` — 추가 속성을 이벤트에 보존
- `beforeSend`에서 **상태 코드별 fingerprint** 지정 → `KoinError(500)` 형태로 그룹 분리

### 2. 노이즈 제거

| 대상 | 건수 | 조치 |
|---|---|---|
| `KOIN_ERROR 401` (토큰 만료) | 43 | drop — 미들웨어·`useAutoLogin`이 처리하는 정상 흐름 |
| `KOIN_ERROR 404` (삭제된 게시글) | 52 | drop — 페이지에서 안내함 |
| `GET /store/.env` 등 봇 스캔 | 5 | server·edge에서 drop |
| `attempted to hard navigate to the same URL` | 13 | `ignoreErrors` |
| 확장 프로그램 · GTM/GA 스크립트 | — | `denyUrls` |

### 3. 하이드레이션 diff 계측 (본래 목적)

두 수단을 **함께** 씁니다. 역할이 다릅니다.

| 수단 | 얻는 것 |
|---|---|
| `consoleLoggingIntegration({ levels: ['warn','error'] })` | diff **전문** → Sentry Logs (검색 가능) |
| `console.error` 후킹 + `captureMessage` | **경로별 fingerprint** 이슈 |

Logs는 검색은 되지만 그룹핑이 안 됩니다. `/cafeteria` 607건이 **URL 귀속 문제인지 별개 원인인지** 판정하려면 경로별 이슈가 필요합니다.

> `levels: ['warn','error']`는 CLAUDE.md 규칙 6(`console.log` 금지, warn/error만 허용)과 그대로 맞습니다.

### 4. 미수집 데이터 활성화

무료 플랜에서 놀고 있던 것들입니다.

| 항목 | 이전 | 이후 |
|---|---|---|
| Logs | 0 B / 5 TB | `enableLogs` (client·server·edge) |
| Profiles | 0 / 150시간 | `browserProfilingIntegration` + `Document-Policy` 헤더 |
| Releases | 이름만 | `setCommits: { auto: true }` — Suspect Commits |

**프로파일링 샘플링을 `0.1`로 잡은 이유**: UI Profile Hours는 월 150시간으로 **Logs(5TB)와 달리 실제로 한정된 쿼터**입니다. 월 페이지뷰 약 69만 × 트레이스 0.7 = 48만 트랜잭션이라 `1.0`이면 며칠 만에 소진됩니다. `0.1`이면 월 약 4.8만 프로파일(약 67시간)로 여유가 있습니다. **배포 후 첫 주에 실제 소비량 확인이 필요합니다.**

`Document-Policy: js-profiling` 헤더가 없으면 프로파일링은 **오류 없이 조용히 아무것도 수집하지 않습니다.** `next.config.mjs`의 `headers()`로 부착했고, 실제 응답에 실리는 것을 확인했습니다.

```
/            Document-Policy: js-profiling
/cafeteria   Document-Policy: js-profiling
/store       Document-Policy: js-profiling
```

## 검증

- `yarn lint` · `tsc --noEmit` 통과
- 프로덕션 빌드 성공, `Document-Policy` 헤더 전 경로 실측 확인
- diff 포착 로직 격리 테스트 — 실제 React 19 메시지 3종 포착, 무관한 에러 2종 통과

## 이번 범위에서 제외한 것

- **Session Replay 마스킹** — `maskAllText`/`maskAllInputs`/`blockAllMedia`가 모두 꺼져 있어 쪽지·채팅 등이 녹화될 수 있습니다. 어떤 컴포넌트를 가릴지 팀 판단이 필요해 분리합니다. **해결 전까지 `replaysSessionSampleRate` 상향은 하면 안 됩니다.**
- **`sendDefaultPii` → `dataCollection`** — 공식 문서는 마이그레이션을 안내하나 설치된 10.43.0에는 옵션이 없습니다(`TS2353`). SDK 업그레이드 시점으로 미룹니다.
- **Metrics** — 5TB가 남지만 무엇을 잴지 정하는 게 먼저입니다. 이 PR의 계측 결과를 본 뒤 설계합니다.
- **서버 프로파일링** — `@sentry/profiling-node` 별도 설치 필요. 브라우저 쪽 효과 확인 후 판단.

## 배포 후 확인

1. Logs에 hydration diff가 들어오는지
2. `hydration-diff` 이슈가 **경로별로** 분리되는지 → `/cafeteria` 원인 판정
3. `KOIN-PROD-8`의 401 43건이 사라지는지
4. UI Profile Hours 소비량 (150시간 한도 대비)
