### PR TITLE
fix: 게시글 style 속성이 화이트리스트에 막히던 문제 수정

### DIFF
--- a/src/utils/ts/sanitize.ts
+++ b/src/utils/ts/sanitize.ts
@@ -8,6 +8,31 @@ const getWindow = (): Window & typeof globalThis => {
 
 const DOMPurify = createDOMPurify(getWindow());
 
+const BLOCKED_CSS_PROPERTIES = ['position'];
+
+// url()로 스크립트를 실행하거나 외부 스타일시트를 불러오는 벡터 
+// css 인젝션 방지
+const DANGEROUS_CSS_PATTERNS = [/javascript\s*:/i, /@import/i];
+
+const filterDangerousCss = (styleValue: string): string =>
+  styleValue
+    .split(';')
+    .map((declaration) => declaration.trim())
+    .filter((declaration) => {
+      if (!declaration) return false;
+      const [rawProperty] = declaration.split(':');
+      if (!rawProperty) return false;
+      const property = rawProperty.trim().toLowerCase();
+      if (BLOCKED_CSS_PROPERTIES.includes(property)) return false;
+      return !DANGEROUS_CSS_PATTERNS.some((pattern) => pattern.test(declaration));
+    })
+    .join('; ');
+
+DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
+  if (data.attrName !== 'style') return;
+  data.attrValue = filterDangerousCss(data.attrValue);
+});
+
 const ALLOWED_TAGS = [
   'p', 'br', 'hr', 'div', 'span',
   'b', 'i', 'u', 'strong', 'em', 'del', 'strike',
@@ -18,7 +43,7 @@ const ALLOWED_TAGS = [
   'a', 'img',
 ];
 
-const ALLOWED_ATTR = ['href', 'src', 'alt', 'title'];
+const ALLOWED_ATTR = ['href', 'src', 'alt', 'title', 'style'];
 
 export function sanitizeHtml(content: string): string {
   return DOMPurify.sanitize(content, { ALLOWED_TAGS, ALLOWED_ATTR });


### PR DESCRIPTION
- Close #1307 

## What is this PR? 🔍

- 기능 : 백엔드에서 내려주던 style 속성이 화이트리스트 방식에 막히던 문제를 해결했습니다
- issue : #1307 

## Changes 📝
- 게시글/이벤트 본문 stored XSS 방지를 위해 태그·속성 화이트리스트를 적용했는데(#1300),
`style` 속성이 화이트리스트에 없어서 백엔드가 내려주던 인라인 스타일이 전부 제거되고
게시글 서식이 깨지는 문제가 있었습니다.
- AI를 통해 스테이징 게시글 452개를 스캔한 결과:
  - 436개(96%)에 `style` 속성이 있음
  - 사용되는 CSS 속성이 150개 이상 (`font-family`, `margin`, `padding`, `color`,
    `line-height`, `display`, `flex`, `border*`, `background-image` 등)
- 화이트리스트 방식으로 제한하기에는 양이 너무 많다고 판단하여 style 태그를 화이트리스트에 추가하되 그 안의 속성은 블랙리스트 방식로 제한하여 위험한 패턴만 걸러내는 방향으로 수정하였습니다.

- `ALLOWED_ATTR`에 `style` 추가
- `DOMPurify.addHook('uponSanitizeAttribute', ...)`로 `style` 값만 별도 필터링
  - `position` 속성 제거 — `position:fixed` + 큰 `z-index`/`opacity:0` 조합으로
    클릭재킹 오버레이를 만들 수 있어 값과 무관하게 차단
  - `javascript:` 스킴 제거 — `url()`(예: `background-image`)을 통한 스크립트
    실행 시도 차단
  - `@import` 제거 — 외부 스타일시트 로딩(추적/리소스 남용) 차단
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--
- [x] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] yarn lint
- [x] yarn build

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **보안 강화**
  * HTML 정제 과정에서 위험한 CSS 선언(`position`, `javascript:`, `@import`)을 제거합니다.
  * 스타일 속성에 대한 추가 정제를 적용해 안전하지 않은 콘텐츠 노출을 방지합니다.
* **기능 개선**
  * 정제된 HTML에서 안전한 `style` 속성을 사용할 수 있습니다.
  * 기존 HTML 표시 기능과의 호환성을 유지하면서 스타일 적용을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->