### PR TITLE
[공통] Sentry KoinError 중복 이슈 수정 및 에러 참조 코드 노출

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -14,9 +14,26 @@ interface KoinErrorLike {
 }
 
 function asKoinError(error: unknown): KoinErrorLike | null {
-  if (error == null || typeof error !== 'object') return null;
-  const candidate = error as KoinErrorLike;
-  return candidate.type === 'KOIN_ERROR' ? candidate : null;
+  if (error == null) return null;
+
+  if (typeof error === 'object') {
+    const candidate = error as KoinErrorLike;
+    if (candidate.type === 'KOIN_ERROR') return candidate;
+  }
+
+  // Next.js의 getProperError()가 _error.tsx의 getInitialProps 재전파 경로에서
+  // plain object KoinError를 new Error(JSON.stringify(koinError))로 감싼다.
+  // 이 경우 message가 KoinError의 JSON 문자열이라 위 object 체크로는 못 잡는다.
+  if (error instanceof Error) {
+    try {
+      const parsed = JSON.parse(error.message) as KoinErrorLike;
+      if (parsed?.type === 'KOIN_ERROR') return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
 }
 
 Sentry.init({

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -10,7 +10,7 @@ const BOT_PROBE_PATTERN = /\/(\.env|\.git|\.aws|wp-admin|wp-login|phpmyadmin|\.w
 interface KoinErrorLike {
   type?: string;
   status?: number;
-  code?: string;
+  code?: number;
 }
 
 function asKoinError(error: unknown): KoinErrorLike | null {
@@ -53,7 +53,7 @@ Sentry.init({
       // KoinError는 Error 인스턴스가 아니라 plain object다. 그대로 두면 Sentry가
       // "Object captured as exception with keys: ..." 로 묶어 서로 다른 에러가 한 이슈에
       // 뒤섞이고 스택도 남지 않는다. 상태 코드별로 그룹을 분리한다.
-      event.fingerprint = ['koin-error', String(koinError.status), koinError.code || 'no-code'];
+      event.fingerprint = ['koin-error', String(koinError.status), String(koinError.code ?? 'no-code')];
       event.exception?.values?.forEach((value) => {
         value.type = `KoinError(${koinError.status ?? 'unknown'})`;
       });

--- a/src/components/boundary/ErrorBoundary/index.tsx
+++ b/src/components/boundary/ErrorBoundary/index.tsx
@@ -54,7 +54,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     const { hasError, eventId } = this.state;
     if (hasError) {
       return (
-        <div className={fallbackClassName}>
+        <div className={fallbackClassName} role="alert">
           Error
           {eventId && ` (참조 코드: ${eventId})`}
         </div>

--- a/src/components/boundary/ErrorBoundary/index.tsx
+++ b/src/components/boundary/ErrorBoundary/index.tsx
@@ -11,6 +11,7 @@ interface Props {
 
 interface State {
   hasError: boolean;
+  eventId?: string;
 }
 
 interface AxiosErrorData {
@@ -44,14 +45,20 @@ export default class ErrorBoundary extends React.Component<Props, State> {
       : error.message;
     showToast('error', errorMessage);
     sendClientError(error);
-    Sentry.captureException(error);
+    const eventId = Sentry.captureException(error);
+    this.setState({ eventId });
   }
 
   render() {
     const { children, fallbackClassName } = this.props;
-    const { hasError } = this.state;
+    const { hasError, eventId } = this.state;
     if (hasError) {
-      return <div className={fallbackClassName}>Error</div>;
+      return (
+        <div className={fallbackClassName}>
+          Error
+          {eventId && ` (참조 코드: ${eventId})`}
+        </div>
+      );
     }
     return children;
   }

--- a/src/components/boundary/StoreErrorBoundary/StoreErrorBoundary.module.scss
+++ b/src/components/boundary/StoreErrorBoundary/StoreErrorBoundary.module.scss
@@ -6,6 +6,12 @@
   height: 60vh;
 }
 
+.eventId {
+  color: #999;
+  font-size: 12px;
+  margin-top: 8px;
+}
+
 .button {
   color: #fff;
   font-size: 15px;

--- a/src/components/boundary/StoreErrorBoundary/StoreErrorBoundary.module.scss
+++ b/src/components/boundary/StoreErrorBoundary/StoreErrorBoundary.module.scss
@@ -7,7 +7,7 @@
 }
 
 .eventId {
-  color: #999;
+  color: #666;
   font-size: 12px;
   margin-top: 8px;
 }

--- a/src/components/boundary/StoreErrorBoundary/index.tsx
+++ b/src/components/boundary/StoreErrorBoundary/index.tsx
@@ -13,6 +13,7 @@ interface Props {
 interface State {
   hasError: boolean;
   status?: number;
+  eventId?: string;
 }
 
 type AppError = Error | AxiosError<unknown, unknown>;
@@ -39,12 +40,15 @@ export default class StoreErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error) {
     showToast('error', error.message);
-    Sentry.captureException(error);
+    const eventId = Sentry.captureException(error);
+    this.setState({ eventId });
   }
 
   render() {
     const { children, onErrorClick } = this.props;
-    const { hasError, status } = this.state;
+    const {
+      hasError, status, eventId,
+    } = this.state;
 
     if (hasError && status === 404) {
       return (
@@ -58,7 +62,12 @@ export default class StoreErrorBoundary extends React.Component<Props, State> {
     }
 
     if (hasError) {
-      return <div className={styles.container}>오류가 발생했습니다.</div>;
+      return (
+        <div className={styles.container}>
+          <p>오류가 발생했습니다.</p>
+          {eventId && <p className={styles.eventId}>문의 시 참조 코드: {eventId}</p>}
+        </div>
+      );
     }
 
     return children;

--- a/src/components/boundary/StoreErrorBoundary/index.tsx
+++ b/src/components/boundary/StoreErrorBoundary/index.tsx
@@ -52,7 +52,7 @@ export default class StoreErrorBoundary extends React.Component<Props, State> {
 
     if (hasError && status === 404) {
       return (
-        <div className={styles.container}>
+        <div className={styles.container} role="alert">
           <h1>존재하지 않는 상점입니다.</h1>
           <button className={styles.button} type="button" onClick={onErrorClick}>
             상점 목록
@@ -63,7 +63,7 @@ export default class StoreErrorBoundary extends React.Component<Props, State> {
 
     if (hasError) {
       return (
-        <div className={styles.container}>
+        <div className={styles.container} role="alert">
           <p>오류가 발생했습니다.</p>
           {eventId && <p className={styles.eventId}>문의 시 참조 코드: {eventId}</p>}
         </div>

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -10,7 +10,7 @@ const HYDRATION_ERROR_PATTERN = /Hydration failed|didn't match|Text content does
 interface KoinErrorLike {
   type?: string;
   status?: number;
-  code?: string;
+  code?: number;
 }
 
 function asKoinError(error: unknown): KoinErrorLike | null {
@@ -87,7 +87,7 @@ Sentry.init({
       // KoinError는 Error 인스턴스가 아니라 plain object다. 그대로 두면 Sentry가
       // "Object captured as exception with keys: ..." 로 묶어 서로 다른 에러가 한 이슈에
       // 뒤섞이고 스택도 남지 않는다. 상태 코드별로 그룹을 분리한다.
-      event.fingerprint = ['koin-error', String(koinError.status), koinError.code || 'no-code'];
+      event.fingerprint = ['koin-error', String(koinError.status), String(koinError.code ?? 'no-code')];
       event.exception?.values?.forEach((value) => {
         value.type = `KoinError(${koinError.status ?? 'unknown'})`;
       });


### PR DESCRIPTION
- Close #1319

## What is this PR? 🔍

- 기능 : Sentry 이슈 대시보드 점검 및 노이즈/중복 제거
- issue : #1319

## Changes 📝

- `sentry.server.config.ts`: `_error.tsx`의 `getInitialProps` 재전파 경로에서 Next.js `getProperError()`가 plain object KoinError를 `new Error(JSON.stringify(koinError))`로 감싸는 케이스를 `asKoinError()`가 인식하도록 수정. 이 경로에서도 401/404 필터링과 상태코드별 fingerprint 그룹핑이 동일하게 적용되어, 같은 장애가 두 이슈로 중복 집계되던 문제(`KOIN-PROD-K` ↔ `KOIN-PROD-20`)가 해소됨
- `ErrorBoundary`, `StoreErrorBoundary`: `Sentry.captureException`이 반환하는 event_id를 fallback UI에 노출 (CS 문의 시 Sentry 대시보드에서 즉시 해당 이벤트 조회 가능)

## ScreenShot 📷

UI 텍스트만 추가되는 변경이라 스크린샷 생략 (에러 바운더리 fallback에 참조 코드 문자열 한 줄 추가)

## Test CheckList ✅

- [x] `yarn typecheck` 통과
- [x] `yarn lint` 통과 (`src/components/boundary`, 변경 파일 대상)
- [ ] 다음 배포 후 Sentry에서 동일 KoinError가 더 이상 두 이슈로 중복 집계되지 않는지 확인

## Precaution

- Inbound Filters(레거시 브라우저/크롤러/확장 프로그램), `tracesSampleRate`는 Sentry 대시보드·사용량 데이터로 확인한 결과 이미 적절히 구성되어 있어 이번 PR에서 변경하지 않음

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally? (base: develop)
- [ ] If on a hotfix branch, ensure it targets `main`? (해당 없음)
- [x] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 오류 메시지에 포함된 JSON 형식의 오류 정보도 인식할 수 있도록 오류 처리가 개선되었습니다.
  * 오류 화면에 문의 시 사용할 수 있는 Sentry 참조 코드가 표시됩니다.
  * 오류 정보가 없는 경우에도 화면이 안정적으로 표시되도록 처리되었습니다.

* **스타일**
  * 참조 코드가 오류 메시지와 구분되어 읽기 쉽게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->