### PR TITLE
[공통] koin-pr PR 발행 스킬 추가

### DIFF
--- a/.claude/skills/koin-pr/SKILL.md
+++ b/.claude/skills/koin-pr/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: koin-pr
+description: Create KOIN_WEB_RECODE GitHub issues, branches, Korean conventional commits, and pull requests from the current worktree. Use when the user asks to create an issue, organize or split commits, publish changes, open a PR, or verify the auto-picked reviewer and PR checklist using this repository's issue templates, PR template, and GitHub Actions workflows.
+---
+
+# KOIN PR Publish
+
+Publish the current `BCSDLab/KOIN_WEB_RECODE` work through the repository's issue, commit, and PR workflow.
+
+## Read First
+
+Read these files completely before acting:
+
+- `.github/ISSUE_TEMPLATE/NEW_FEATURE.md`
+- `.github/ISSUE_TEMPLATE/BUG_REPORT.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/workflows/PICK_REVIEWER.yml`
+- `.github/workflows/CHECK_PR_MERGED.yml`
+- `.github/workflows/LINT_CHECK.yml`
+- `references/conventions.md`
+
+Follow the body structures in `references/conventions.md` exactly.
+
+## Important difference from other repos' PR skills
+
+This repository has **no body-parsing automation**. Labels are not derived from issue or PR text, and issues do not auto-assign the author. Only two things happen automatically:
+
+- `PICK_REVIEWER.yml` requests a reviewer when a PR is opened (org-shared workflow, not an assignee).
+- `CHECK_PR_MERGED.yml` deletes the head branch and pings Slack when a PR merges — never delete the branch yourself after merge.
+
+Apply labels explicitly with `--label` from the existing label set in `references/conventions.md`. Never invent a label.
+
+## Workflow
+
+1. Confirm repository context with `git rev-parse --show-toplevel`, `git remote -v`, `git status --short --branch`, and `gh repo view --json nameWithOwner,defaultBranchRef`.
+2. Inspect the full diff and separate intended work from unrelated user changes. Never stage unrelated files.
+3. Resolve the work type from `references/conventions.md` (feature, fix, refactor, test, docs, deploy, setting). Support multiple PR checklist items when the diff genuinely spans multiple categories.
+4. Determine the domain bracket (`[캠퍼스]` / `[비즈니스]` / `[유저]` / `[공통]` / `[hotfix]`) per **Domain Classification** in `references/conventions.md`. If the change is genuinely ambiguous between domains, or you cannot tell whether it fits `캠퍼스`/`비즈니스`/`유저` at all, ask the user before proceeding — do not guess.
+5. Reuse an existing issue when the current branch begins with `{type}/#{issue-number}/`, an issue already describes this work, or the user names one. Search with `gh issue list` before creating a new one. Otherwise create the issue first, unless the user explicitly asked for PR-only work on top of an existing issue.
+6. Write the issue body to a temporary Markdown file using the exact structure in `references/conventions.md` (`NEW_FEATURE.md` shape for features, `BUG_REPORT.md` shape for bugs). Title it `[도메인] 설명`.
+7. Create the issue with `gh issue create --title "[도메인] 설명" --body-file ...`. Pass `--label` only for labels that already exist in the repo (`gh label list`) and clearly apply — do not guess a domain label you are not confident about.
+8. Create or reuse a branch named `{type}/#{issue-number}/{english-kebab-case}` (`{type}` = `feature`/`fix`/`refactor`/`test`/`docs`/`chore`; description in English). Base new work on the GitHub default branch, currently `develop` — hotfix branches target `main` instead.
+9. Split changes into logical commits. Use `type: 한국어 설명` (Conventional Commit type, Korean description). Do not add a `Co-Authored-By` trailer or an AI-attribution footer to any commit — this repository's owner has explicitly asked for commits without them.
+10. Run the validation commands required by `references/conventions.md`. Do not check a PR checklist item unless that command actually passed.
+11. Push the current branch with upstream tracking.
+12. Write the PR body to a temporary Markdown file from `.github/PULL_REQUEST_TEMPLATE.md`. Keep the `- Close #ISSUE_NUMBER` line at the top when an issue is linked; drop it only when there genuinely is no issue.
+13. Open a PR against the GitHub default branch (`develop`, or `main` for a hotfix) with `gh pr create`. Title it `[도메인] 설명`, keeping the same domain bracket as the linked issue. Apply labels explicitly, same rule as step 7.
+14. Wait briefly, then check that a reviewer was requested (`gh pr view --json reviewRequests`). If not, inspect the `Pick Reviewer` workflow run before falling back to `gh pr edit --add-reviewer`.
+15. Do not delete the branch after merge — `CHECK_PR_MERGED.yml` handles that automatically.
+
+## Safety Rules
+
+- Check `gh auth status` before GitHub writes.
+- Do not create duplicate issues or PRs. Search by current branch, issue number, and title first.
+- Do not use `git add -A` in a mixed worktree. Stage explicit paths.
+- Do not rewrite published history unless the user explicitly requests it. If required, use `git push --force-with-lease`, never plain `--force`.
+- Do not apply a label unless it already exists in `gh label list` and is a confident match.
+- Do not guess the `[캠퍼스]`/`[비즈니스]`/`[유저]` title bracket when it is genuinely ambiguous — ask the user instead.
+- Preserve user changes outside the publishing scope.
+- Use temporary files for generated issue and PR bodies; do not add them to the repository.
+- Never add `Co-Authored-By` or similar AI-attribution lines to commits or PR bodies.
+
+## Tool Preference
+
+- Use local `git` for branch, staging, commit, and push operations.
+- Use `gh` for issue/PR creation, label application, reviewer checks, and Actions run inspection.
+- When network access is blocked, request approval and continue rather than stopping at a plan.
+
+## Final Report
+
+Report:
+
+- issue URL and selected work type (or "no issue" if intentionally skipped)
+- branch name
+- commit SHAs and messages
+- validation commands and results
+- PR URL and base branch
+- labels applied
+- requested reviewer (or automation failure/fallback used)

--- a/.claude/skills/koin-pr/references/conventions.md
+++ b/.claude/skills/koin-pr/references/conventions.md
@@ -1,0 +1,273 @@
+# KOIN_WEB_RECODE GitHub Conventions
+
+## Repository
+
+- Repository: `BCSDLab/KOIN_WEB_RECODE`
+- Default PR base: read with `gh repo view --json defaultBranchRef`; currently `develop`. Hotfix branches target `main` instead.
+- Issue templates (legacy `.md` templates, not YAML forms — no automatic label from frontmatter):
+  - `.github/ISSUE_TEMPLATE/NEW_FEATURE.md`
+  - `.github/ISSUE_TEMPLATE/BUG_REPORT.md`
+- PR template: `.github/PULL_REQUEST_TEMPLATE.md`
+- Automation:
+  - `.github/workflows/PICK_REVIEWER.yml` — requests a reviewer on PR open (org-shared `BCSDLab/.github` workflow). Does not assign anyone, does not touch labels.
+  - `.github/workflows/CHECK_PR_MERGED.yml` — deletes the head branch and posts a Slack notification when a PR merges. Never delete the branch manually.
+  - `.github/workflows/LINT_CHECK.yml` — runs ESLint and `tsc --noEmit` on PRs targeting `main`/`develop` (develop push itself is gated by `deploy.yml`'s verify job instead).
+
+There is no workflow that reads issue or PR body text to apply labels or assignees. Apply labels yourself with `gh issue create --label` / `gh pr create --label`, only from the set in **Labels** below, only when confident.
+
+## Work Type Mapping
+
+| Work type | Issue template | Commit type | Closest existing label |
+| --- | --- | --- | --- |
+| feature | `NEW_FEATURE.md` | `feat` | `✨ Feature` |
+| fix | `BUG_REPORT.md` | `fix` | `🐞 BugFix` |
+| refactor | `NEW_FEATURE.md` (repurposed) | `refactor` | `🔨 Refactor` |
+| test | `NEW_FEATURE.md` (repurposed) | `test` | `✅ Test` |
+| docs | `NEW_FEATURE.md` (repurposed) | `docs` | `📃 Docs` |
+| deploy | — (no issue needed) | `chore` | `🌏 Deploy` |
+| setting | `NEW_FEATURE.md` (repurposed) | `chore` | `⚙ Setting` |
+
+Choose:
+
+- `feature` for user-visible behavior, new pages, new UI, or new API integration.
+- `fix` for broken or unexpected behavior — use the bug issue template.
+- `refactor` when behavior stays the same and structure improves.
+- `test` for test code or test infrastructure.
+- `docs` for documentation-only changes.
+- `deploy` for deployment workflow or release infrastructure changes made through this skill (still gets an issue and branch like any other change). The periodic `[배포] YYYY.MM.DD ... 배포` release-cut PRs (`develop` → `main`) seen in history are a separate manual release process, not something this skill creates.
+- `setting` for dependencies, tooling, project configuration, or development environment changes.
+
+For mixed work, pick one primary type for the commit prefixes and issue, but apply every label that clearly applies.
+
+## Labels
+
+Only apply labels that exist in this repository (`gh label list`). Work-type labels:
+
+```text
+✨ Feature   기능 개발
+🐞 BugFix    버그 수정
+🔨 Refactor  코드 리팩토링
+✅ Test      Test 관련
+📃 Docs      문서 작성 및 수정
+🌏 Deploy    배포 관련 사항
+⚙ Setting   개발 환경 세팅
+```
+
+Domain labels — apply only when the change clearly and entirely belongs to one domain, never as a guess:
+
+```text
+👤 User       유저, 시간표 도메인
+💼 Business   주변상점, 복덕방 도메인
+🎓 Campus     학교식단, 버스, 커뮤니티 도메인
+📬 API        서버 API 통신
+🖌 UI         UI 개발
+❗QA issue    QA 이슈
+📊DA          데이터 분석
+🕸️ platform   플랫폼
+```
+
+## Domain Classification
+
+Both the issue title and the PR title carry a domain bracket. There are exactly five values:
+
+| Bracket | Scope |
+| --- | --- |
+| `[캠퍼스]` | 식단, 버스, 게시물(공지·분실물), 교내 시설물, 부서정보, 팀원 모집 등 — 대부분의 학교/캠퍼스 생활 기능 |
+| `[비즈니스]` | 주변상점, 사장님(업주) 관련 기능 |
+| `[유저]` | 회원가입, 로그인, 유저 프로필 등 인증/인가 관련 + 시간표 |
+| `[공통]` | 위 세 도메인 어디에도 명확히 속하지 않는 작업 (전역 설정, 배포, 공용 유틸/컴포넌트, 여러 도메인에 걸친 변경 등) |
+| `[hotfix]` | `main`을 베이스로 하는 hotfix 브랜치/PR. 도메인 대괄호 대신 이 값을 쓴다 |
+
+Classification procedure:
+
+1. If the branch targets `main` as a hotfix, use `[hotfix]` regardless of domain — skip the rest of this procedure.
+2. Otherwise, check whether the change clearly and entirely matches `캠퍼스`, `비즈니스`, or `유저` per the table above.
+3. If it clearly matches exactly one of those three, use that bracket.
+4. If it clearly matches none of the three (e.g. pure `.claude/` skill config, CI/deploy config, a shared UI primitive with no domain owner), use `[공통]` — no need to ask.
+5. If it is genuinely ambiguous between two domains, or you cannot tell whether it belongs to `캠퍼스`/`비즈니스`/`유저` at all, **ask the user** which bracket to use instead of guessing. Do not silently default to `[공통]` in this case.
+
+This bracket is independent of the GitHub domain labels (`🎓 Campus` / `💼 Business` / `👤 User`) in **Labels** below — apply both when they agree; the label is optional and separate from the title text.
+
+## Titles
+
+Both issue and PR titles use the same shape:
+
+```text
+[도메인] 설명
+```
+
+e.g. `[캠퍼스] 팀원 모집 기본 구조 및 메인 UI 골격 구현`, `[유저] 로그인/회원가입 리디자인 적용`, `[비즈니스] 주변상점 리뷰 신고 기능 추가`, `[공통] Sentry 운영 모니터링 기반 추가`, `[hotfix] 배포 직후 stale buildId 오류 수정`.
+
+Do not use a Conventional Commit prefix (`feat:`, `fix:`) as an issue or PR title — that style is reserved for commit messages only.
+
+When a PR closes an issue, keep the same domain bracket as the issue; the description after the bracket may be phrased slightly differently to fit the PR's actual final scope, but the bracket itself must match.
+
+## Branches
+
+One pattern only:
+
+```text
+{type}/#{issue-number}/{english-kebab-case}
+```
+
+`{type}` is one of `feature`, `fix`, `refactor`, `test`, `docs`, `chore` (use `chore` for both `deploy` and `setting` work types). The description segment is in **English**, kebab-case, concise.
+
+Examples:
+
+```text
+feature/#1328/team-recruitment-profile-entry
+fix/#1324/graduation-calculator-entry-removal
+chore/#1319/sentry-koin-error-dedup
+```
+
+This skill creates the issue first (see **Issue Creation** below) if one does not already exist, so an issue number is always available before branching. If the current branch already starts with `{type}/#{issue-number}/`, reuse that issue instead of creating another one.
+
+## Issue Creation
+
+Write feature issue bodies with the exact `NEW_FEATURE.md` structure:
+
+```markdown
+## Feature Name
+
+팀원 모집 기본 화면 및 관련 기능을 구현합니다.
+
+## Progress
+
+- [ ] 팀원 모집 기본 화면 구현
+- [ ] 알림 화면 구현
+
+## Design Screenshot
+
+## Precautions
+
+- 현재 일부 화면의 디자인이 완료되지 않아, 확정된 디자인을 기준으로 우선 작업합니다.
+```
+
+Write bug issue bodies with the exact `BUG_REPORT.md` structure:
+
+```markdown
+## Describe the bug
+
+로그인 실패 메시지가 표시되지 않습니다.
+
+## To Reproduce
+
+1. 잘못된 비밀번호로 로그인
+2. 로그인 버튼 클릭
+
+## Expected behavior
+
+오류 메시지가 표시되어야 합니다.
+
+## Screenshot
+
+## Environment
+
+**Desktop:**
+- OS: macOS
+- Browser: Chrome
+- Version: 128
+
+**Smartphone:**
+- Device: iPhone 15
+- OS: iOS 18
+- Browser: Safari
+- Version: 18.0
+```
+
+Include at least one Progress item for feature issues, and fill every required section for bug issues.
+
+Create with:
+
+```bash
+gh issue create --title "[도메인] 설명" --body-file /tmp/issue-body.md --label "✨ Feature"
+```
+
+Do not pass `--assignee`; this repository does not auto-assign issue authors, and this skill does not either unless the user asks.
+
+## Commits
+
+- Use `type: 한국어 설명`.
+- Split by logical behavior or independently reviewable concern.
+- Keep generated files with the source change that requires them.
+- Keep broad formatting or dependency churn separate when it is intentional.
+- Do not make an empty cleanup commit solely to increase commit count.
+- Never add a `Co-Authored-By` trailer or any AI-attribution line.
+
+Examples:
+
+```text
+feat: 팀원 모집 프로필 진입점 페이지 구현
+fix: 프로필 카드 아바타 아이콘 교체
+chore: 팀원 모집 아이콘 자산 추가
+```
+
+## Validation
+
+Always run:
+
+```bash
+yarn lint
+yarn typecheck
+```
+
+Also run `yarn build` when changes affect:
+
+- routing, layouts, `getServerSideProps`, or server/client boundaries
+- dependencies or the Yarn PnP lockfile/cache (`.pnp.cjs`, `.yarn/cache`)
+- Next.js, TypeScript, or build configuration
+
+A `yarn build` failure caused by missing `NEXT_PUBLIC_API_PATH` (prerender hitting `localhost:80`) is an environment limitation, not a code defect — do not block on it, but do not silently check the checklist item either; note it in the report instead. If dependencies changed, commit the resulting `.pnp.cjs` and `.yarn/cache` changes (Zero-Install) alongside the change that needed them.
+
+Never check a PR checklist item for a command that was not run successfully.
+
+## PR Creation
+
+Start from `.github/PULL_REQUEST_TEMPLATE.md` and write the completed body to a temporary Markdown file. Preserve this structure:
+
+```markdown
+- Close #1332
+
+## What is this PR? 🔍
+
+- 기능 : 팀원 모집 프로필 진입점 페이지
+- issue : #1332
+
+## Changes 📝
+
+- `/team/profile` 페이지 및 `ProfileMenuCard` 컴포넌트 추가
+- 프로필 있음/없음 두 상태에 대한 Figma 디자인 반영
+
+## ScreenShot 📷
+
+<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->
+
+## Test CheckList ✅
+
+- [ ] 프로필 없음 상태에서 빈 상태 카드가 노출되는지 확인
+- [ ] 프로필 있음 상태에서 닉네임/학과/학번이 노출되는지 확인
+- [ ] 모바일 뷰포트에서 레이아웃이 Figma와 일치하는지 확인
+
+## Precaution
+
+- 데스크탑 디자인은 아직 없어 모바일 전용으로 구현했습니다.
+
+## ✔️ Please check if the PR fulfills these requirements
+
+- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
+- [ ] If on a hotfix branch, ensure it targets `main`?
+- [x] There are no warning message when you run `yarn lint`
+```
+
+Drop the `- Close #ISSUE_NUMBER` line only when there genuinely is no linked issue. Only check the hotfix line when the branch actually targets `main`. Only check the `yarn lint` line when it was actually run and passed.
+
+Use `[도메인] 설명` as the PR title per **Titles** above, keeping the same domain bracket as the linked issue. Open against the repository default branch (`develop`), or `main` for a hotfix.
+
+## Verification
+
+After PR creation:
+
+1. Wait briefly for the `Pick Reviewer` workflow.
+2. Inspect with `gh pr view --json reviewRequests,labels,url`.
+3. If no reviewer was requested, inspect the recent `Pick Reviewer` Actions run before applying a manual fallback (`gh pr edit --add-reviewer <login>`).
+4. Report whether automation or a manual fallback produced the final state.


### PR DESCRIPTION
- Close #1335

## What is this PR? 🔍

- 기능 : 이슈 생성 → 브랜치 → 커밋 → PR 생성을 이 저장소 컨벤션에 맞춰 자동화하는 `koin-pr` Claude Code 스킬
- issue : #1335

## Changes 📝

- `.claude/skills/koin-pr/SKILL.md` — 워크플로우, 세이프티 룰, 도구 우선순위 정의
- `.claude/skills/koin-pr/references/conventions.md` — 이슈/PR 템플릿, 라벨, 워크타입 매핑, 도메인 분류(`[캠퍼스]`/`[비즈니스]`/`[유저]`/`[공통]`/`[hotfix]`), 브랜치명(`{type}/#{이슈번호}/{영어-설명}`) 규칙 문서화
- 라벨/담당자 자동화가 없는 이 저장소의 실제 워크플로우(`PICK_REVIEWER.yml`, `CHECK_PR_MERGED.yml`, `LINT_CHECK.yml`)를 조사해 반영

## ScreenShot 📷

<!-- 스킬 문서 변경으로 스크린샷 대상 없음 -->

## Test CheckList ✅

- [x] 이 PR 자체를 `koin-pr` 스킬 워크플로우로 발행해 문서화된 절차가 실제로 동작하는지 확인

## Precaution

- 코드 변경 없이 `.claude/skills/` 문서만 추가하는 PR입니다.
- 기존 `github-pr-creation` 스킬은 `koin-pipeline`/`pr-creator` 에이전트가 이름으로 직접 참조하고 있어 그대로 두었고, 이 스킬은 별도 이름(`koin-pr`)으로 추가했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
