### PR TITLE
[캠퍼스] 팀원 모집 프로필 수정 페이지 구현

### DIFF
--- a/src/api/teamRecruitmentProfile/APIDetail.ts
+++ b/src/api/teamRecruitmentProfile/APIDetail.ts
@@ -1,21 +1,32 @@
 import { APIRequest, HTTP_METHOD } from 'interfaces/APIRequest';
-import { CreateTeamRecruitmentProfileRequest, CreateTeamRecruitmentProfileResponse } from './entity';
+import { TeamRecruitmentProfileResponse, UpsertTeamRecruitmentProfileRequest } from './entity';
 
-export class CreateTeamRecruitmentProfile<R extends CreateTeamRecruitmentProfileResponse> implements APIRequest<R> {
-  method = HTTP_METHOD.POST;
+export class TeamRecruitmentProfileDetail<R extends TeamRecruitmentProfileResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.GET;
 
-  // TODO: 진입점 페이지의 `/team-recruitment-profiles/me` 목업 주석에서 유추한 가정치. API 명세 확정 후 검증 필요
-  path = '/team-recruitment-profiles';
+  path = '/team-recruitment-profiles/me';
 
   response!: R;
 
-  data: CreateTeamRecruitmentProfileRequest;
+  auth = true;
+
+  constructor(public authorization: string) {}
+}
+
+export class UpsertTeamRecruitmentProfile<R extends TeamRecruitmentProfileResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.PUT;
+
+  path = '/team-recruitment-profiles/me';
+
+  response!: R;
+
+  data: UpsertTeamRecruitmentProfileRequest;
 
   auth = true;
 
   constructor(
     public authorization: string,
-    data: CreateTeamRecruitmentProfileRequest,
+    data: UpsertTeamRecruitmentProfileRequest,
   ) {
     this.data = data;
   }

--- a/src/api/teamRecruitmentProfile/entity.ts
+++ b/src/api/teamRecruitmentProfile/entity.ts
@@ -1,22 +1,39 @@
-// TODO: API 명세 확정 후 필드/경로 검증 필요
 import { APIResponse } from 'interfaces/APIResponse';
 
-export type TeamRecruitmentActivityRequest = {
+export type TeamRecruitmentProfileActivity = {
+  id: number;
   title: string;
-  start_date: string;
-  end_date: string | null;
+  started_at: string;
+  ended_at: string | null;
   is_ongoing: boolean;
-  content: string;
+  description: string;
 };
 
-export type CreateTeamRecruitmentProfileRequest = {
-  nickname: string;
+export type TeamRecruitmentProfileActivityInput = {
+  title: string;
+  started_at: string;
+  ended_at: string | null;
+  is_ongoing: boolean;
+  description: string;
+};
+
+export interface TeamRecruitmentProfileResponse extends APIResponse {
+  profile_nickname: string;
   department: string;
+  major: string | null;
   student_number: string;
   preferred_role: string;
   skills: string[];
-  activities: TeamRecruitmentActivityRequest[];
-  introduction: string;
+  activities: TeamRecruitmentProfileActivity[];
+  self_introduction: string;
+}
+
+export type UpsertTeamRecruitmentProfileRequest = {
+  profile_nickname: string;
+  preferred_role: string;
+  skills: string[];
+  activities: TeamRecruitmentProfileActivityInput[];
+  self_introduction: string;
 };
 
-export type CreateTeamRecruitmentProfileResponse = APIResponse;
+export type UpsertTeamRecruitmentProfileResponse = TeamRecruitmentProfileResponse;

--- a/src/api/teamRecruitmentProfile/index.ts
+++ b/src/api/teamRecruitmentProfile/index.ts
@@ -1,4 +1,5 @@
 import APIClient from 'utils/ts/apiClient';
-import { CreateTeamRecruitmentProfile } from './APIDetail';
+import { TeamRecruitmentProfileDetail, UpsertTeamRecruitmentProfile } from './APIDetail';
 
-export const createTeamRecruitmentProfile = APIClient.of(CreateTeamRecruitmentProfile);
+export const getTeamRecruitmentProfile = APIClient.of(TeamRecruitmentProfileDetail);
+export const upsertTeamRecruitmentProfile = APIClient.of(UpsertTeamRecruitmentProfile);

--- a/src/api/teamRecruitmentProfile/queries.ts
+++ b/src/api/teamRecruitmentProfile/queries.ts
@@ -1,21 +1,43 @@
 import { isKoinError } from '@bcsdlab/koin';
-import { useMutation } from '@tanstack/react-query';
-import { createTeamRecruitmentProfile } from 'api/teamRecruitmentProfile';
-import { CreateTeamRecruitmentProfileRequest } from 'api/teamRecruitmentProfile/entity';
+import { queryOptions, useMutation } from '@tanstack/react-query';
+import { getTeamRecruitmentProfile, upsertTeamRecruitmentProfile } from 'api/teamRecruitmentProfile';
+import { TeamRecruitmentProfileResponse, UpsertTeamRecruitmentProfileRequest } from 'api/teamRecruitmentProfile/entity';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import showToast from 'utils/ts/showToast';
 
-interface UseCreateTeamRecruitmentProfileMutationOptions {
+export const teamRecruitmentProfileQueryKeys = {
+  all: ['team-recruitment-profile'] as const,
+  me: (token: string) => [...teamRecruitmentProfileQueryKeys.all, 'me', token] as const,
+};
+
+export const teamRecruitmentProfileQueries = {
+  me: (token: string) =>
+    queryOptions<TeamRecruitmentProfileResponse | null>({
+      queryKey: teamRecruitmentProfileQueryKeys.me(token),
+      queryFn: async () => {
+        try {
+          return await getTeamRecruitmentProfile(token);
+        } catch (error) {
+          if (isKoinError(error) && error.status === 404) {
+            return null;
+          }
+          throw error;
+        }
+      },
+    }),
+};
+
+interface UseUpsertTeamRecruitmentProfileMutationOptions {
   onSuccess?: () => void;
 }
 
-export const useCreateTeamRecruitmentProfileMutation = ({
+export const useUpsertTeamRecruitmentProfileMutation = ({
   onSuccess,
-}: UseCreateTeamRecruitmentProfileMutationOptions = {}) => {
+}: UseUpsertTeamRecruitmentProfileMutationOptions = {}) => {
   const token = useTokenState();
 
   return useMutation({
-    mutationFn: (data: CreateTeamRecruitmentProfileRequest) => createTeamRecruitmentProfile(token, data),
+    mutationFn: (data: UpsertTeamRecruitmentProfileRequest) => upsertTeamRecruitmentProfile(token, data),
     onSuccess: () => {
       onSuccess?.();
     },

--- a/src/components/Team/ProfilePage/Steps/ApplicationStep/index.tsx
+++ b/src/components/Team/ProfilePage/Steps/ApplicationStep/index.tsx
@@ -11,6 +11,7 @@ interface ApplicationStepProps {
   onBack: () => void;
   onSubmit: () => void;
   isSubmitting: boolean;
+  submitLabel: string;
 }
 
 const loggingTitle = {
@@ -19,7 +20,7 @@ const loggingTitle = {
   SAVE: 'team_profile_save',
 };
 
-export default function ApplicationStep({ onBack, onSubmit, isSubmitting }: ApplicationStepProps) {
+export default function ApplicationStep({ onBack, onSubmit, isSubmitting, submitLabel }: ApplicationStepProps) {
   const { actionEventClick } = useLogger();
   const { control, register } = useFormContext<ProfileFormValues>();
   const { errors } = useFormState({ control });
@@ -134,7 +135,7 @@ export default function ApplicationStep({ onBack, onSubmit, isSubmitting }: Appl
           이전
         </button>
         <button type="button" className={styles.step__submit} onClick={handleSave} disabled={isSubmitting}>
-          저장
+          {submitLabel}
         </button>
       </div>
     </div>

--- a/src/components/Team/ProfilePage/index.tsx
+++ b/src/components/Team/ProfilePage/index.tsx
@@ -1,37 +1,50 @@
 import { Suspense, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { useCreateTeamRecruitmentProfileMutation } from 'api/teamRecruitmentProfile/queries';
+import { useQuery } from '@tanstack/react-query';
+import { teamRecruitmentProfileQueries, useUpsertTeamRecruitmentProfileMutation } from 'api/teamRecruitmentProfile/queries';
 import LoadingSpinner from 'components/feedback/LoadingSpinner';
 import SubPageHeader from 'components/ui/SubPageHeader';
 import { FormProvider, useForm } from 'react-hook-form';
 import ROUTES from 'static/routes';
+import useTokenState from 'utils/hooks/state/useTokenState';
 import showToast from 'utils/ts/showToast';
 import useProfileStep from './hooks/useProfileStep';
 import ApplicationStep from './Steps/ApplicationStep';
 import BasicInfoStep from './Steps/BasicInfoStep';
 import { PROFILE_STEPS, type ProfileFormValues, type ProfileStepTitle } from './types';
-import type { CreateTeamRecruitmentProfileRequest } from 'api/teamRecruitmentProfile/entity';
+import type { UpsertTeamRecruitmentProfileRequest } from 'api/teamRecruitmentProfile/entity';
 import styles from './ProfilePage.module.scss';
 
-const toRequestBody = (values: ProfileFormValues): CreateTeamRecruitmentProfileRequest => ({
-  nickname: values.nickname.trim(),
-  department: values.department,
-  student_number: values.studentNumber.trim(),
+export type TeamProfileFormMode = 'create' | 'edit';
+
+interface TeamProfileFormProps {
+  mode: TeamProfileFormMode;
+}
+
+const MODE_TEXT: Record<TeamProfileFormMode, { title: string; submitLabel: string; successMessage: string }> = {
+  create: { title: '팀원 모집 프로필 작성', submitLabel: '저장', successMessage: '프로필이 저장되었습니다.' },
+  edit: { title: '팀원 모집 프로필 수정', submitLabel: '수정하기', successMessage: '프로필이 수정되었습니다.' },
+};
+
+const toRequestBody = (values: ProfileFormValues): UpsertTeamRecruitmentProfileRequest => ({
+  profile_nickname: values.nickname.trim(),
   preferred_role: values.preferredRole.trim(),
   skills: values.skills.map((skill) => skill.value.trim()).filter((skill) => skill.length > 0),
   activities: values.activities.map((activity) => ({
     title: activity.title.trim(),
-    start_date: activity.startDate,
+    started_at: activity.startDate,
     // `<input type="date">`를 비우면 ''이 들어오므로 null로 정규화한다.
-    end_date: activity.isOngoing ? null : activity.endDate || null,
+    ended_at: activity.isOngoing ? null : activity.endDate || null,
     is_ongoing: activity.isOngoing,
-    content: activity.content.trim(),
+    description: activity.content.trim(),
   })),
-  introduction: values.introduction.trim(),
+  self_introduction: values.introduction.trim(),
 });
 
-export default function TeamProfileForm() {
+export default function TeamProfileForm({ mode }: TeamProfileFormProps) {
   const router = useRouter();
+  const token = useTokenState();
+  const isEditMode = mode === 'edit';
   const { currentStep, nextStep, goBack, isReady } = useProfileStep<ProfileStepTitle>(PROFILE_STEPS, '기본 정보');
 
   const methods = useForm<ProfileFormValues>({
@@ -47,10 +60,37 @@ export default function TeamProfileForm() {
     },
   });
 
-  const { mutate: createProfile, isPending } = useCreateTeamRecruitmentProfileMutation({
+  const { data: existingProfile } = useQuery({
+    ...teamRecruitmentProfileQueries.me(token),
+    enabled: isEditMode && !!token,
+  });
+
+  useEffect(() => {
+    if (!existingProfile) return;
+
+    methods.reset({
+      nickname: existingProfile.profile_nickname,
+      department: existingProfile.department,
+      studentNumber: existingProfile.student_number,
+      preferredRole: existingProfile.preferred_role,
+      skills: existingProfile.skills.map((skill) => ({ value: skill })),
+      activities: existingProfile.activities.map((activity) => ({
+        id: String(activity.id),
+        title: activity.title,
+        startDate: activity.started_at,
+        endDate: activity.ended_at,
+        isOngoing: activity.is_ongoing,
+        content: activity.description,
+        status: 'saved',
+      })),
+      introduction: existingProfile.self_introduction,
+    });
+  }, [existingProfile, methods]);
+
+  const { mutate: upsertProfile, isPending } = useUpsertTeamRecruitmentProfileMutation({
     onSuccess: () => {
       // TODO: 완료 모달/오버레이 디자인 확정 후 교체
-      showToast('success', '프로필이 저장되었습니다.');
+      showToast('success', MODE_TEXT[mode].successMessage);
       router.push(ROUTES.TeamProfile());
     },
   });
@@ -75,7 +115,7 @@ export default function TeamProfileForm() {
         showToast('warning', '작성 중인 활동 이력을 완료해주세요.');
         return;
       }
-      createProfile(toRequestBody(values));
+      upsertProfile(toRequestBody(values));
     },
     (errors) => {
       // 1단계 필드가 비어 있으면 에러가 화면에 보이지 않으므로 1단계로 되돌린다.
@@ -90,14 +130,19 @@ export default function TeamProfileForm() {
 
   return (
     <div className={styles.container}>
-      <SubPageHeader title="팀원 모집 프로필 작성" />
+      <SubPageHeader title={MODE_TEXT[mode].title} />
 
       <FormProvider {...methods}>
         <Suspense fallback={<LoadingSpinner size="50px" />}>
           {currentStep === '기본 정보' ? (
             <BasicInfoStep onNext={() => nextStep('지원서 작성')} />
           ) : (
-            <ApplicationStep onBack={goBack} onSubmit={handleSubmit} isSubmitting={isPending} />
+            <ApplicationStep
+              onBack={goBack}
+              onSubmit={handleSubmit}
+              isSubmitting={isPending}
+              submitLabel={MODE_TEXT[mode].submitLabel}
+            />
           )}
         </Suspense>
       </FormProvider>

--- a/src/pages/team/profile/create/index.tsx
+++ b/src/pages/team/profile/create/index.tsx
@@ -11,7 +11,7 @@ function TeamProfileCreatePage() {
         <meta name="description" content="팀원 모집 프로필을 작성할 수 있습니다." />
       </Head>
 
-      <TeamProfileForm />
+      <TeamProfileForm mode="create" />
     </>
   );
 }

--- a/src/pages/team/profile/edit/index.tsx
+++ b/src/pages/team/profile/edit/index.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import Head from 'next/head';
+import Layout from 'components/layout';
+import TeamProfileForm from 'components/Team/ProfilePage';
+
+function TeamProfileEditPage() {
+  return (
+    <>
+      <Head>
+        <title>팀원 모집 프로필 수정 | KOIN</title>
+        <meta name="description" content="팀원 모집 프로필을 수정할 수 있습니다." />
+      </Head>
+
+      <TeamProfileForm mode="edit" />
+    </>
+  );
+}
+
+TeamProfileEditPage.getLayout = (page: ReactNode) => <Layout hideLayout>{page}</Layout>;
+
+export default TeamProfileEditPage;

--- a/src/pages/team/profile/index.tsx
+++ b/src/pages/team/profile/index.tsx
@@ -1,6 +1,8 @@
 import type { FunctionComponent, ReactNode, SVGProps } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { useQuery } from '@tanstack/react-query';
+import { teamRecruitmentProfileQueries } from 'api/teamRecruitmentProfile/queries';
 import SleepMascotIcon from 'assets/svg/common/sleep-bbico.svg';
 import ChevronRightIcon from 'assets/svg/Team/chevron-right-icon.svg';
 import ListEndIcon from 'assets/svg/Team/list-end-icon.svg';
@@ -9,13 +11,8 @@ import UserIcon from 'assets/svg/Team/profile-avatar-icon.svg';
 import Layout from 'components/layout';
 import SubPageHeader from 'components/ui/SubPageHeader';
 import ROUTES from 'static/routes';
+import useTokenState from 'utils/hooks/state/useTokenState';
 import styles from './TeamProfilePage.module.scss';
-
-interface TeamRecruitmentProfileSummary {
-  nickname: string;
-  department: string;
-  studentNumber: string;
-}
 
 interface MenuCardProps {
   icon: FunctionComponent<SVGProps<SVGSVGElement>>;
@@ -38,18 +35,14 @@ function MenuCard({ icon: Icon, title, description }: MenuCardProps) {
   );
 }
 
-// TODO: /team-recruitment-profiles/me API 연동 후 React Query로 교체
-const MOCK_HAS_PROFILE = true;
-const MOCK_PROFILE: TeamRecruitmentProfileSummary = {
-  nickname: 'BCSD',
-  department: '컴퓨터공학부',
-  studentNumber: '2023100000',
-};
-
 function TeamProfilePage() {
   const router = useRouter();
-  const hasProfile = MOCK_HAS_PROFILE;
-  const profile = MOCK_PROFILE;
+  const token = useTokenState();
+  const { data: profile } = useQuery({
+    ...teamRecruitmentProfileQueries.me(token),
+    enabled: !!token,
+  });
+  const hasProfile = Boolean(profile);
 
   return (
     <>
@@ -62,21 +55,21 @@ function TeamProfilePage() {
         <SubPageHeader title="팀원 모집 프로필" />
 
         <div className={styles.page__content}>
-          {hasProfile ? (
+          {profile ? (
             <div className={styles.summaryCard}>
               <span className={styles.summaryCard__avatar}>
                 <UserIcon aria-hidden />
               </span>
               <div className={styles.summaryCard__body}>
-                <p className={styles.summaryCard__nickname}>{profile.nickname}</p>
+                <p className={styles.summaryCard__nickname}>{profile.profile_nickname}</p>
                 <ul className={styles.summaryCard__meta}>
                   <li>{profile.department}</li>
-                  <li>{profile.studentNumber}</li>
+                  <li>{profile.student_number}</li>
                 </ul>
                 <button
                   type="button"
                   className={styles.summaryCard__button}
-                  onClick={() => router.push(ROUTES.TeamProfileCreate())}
+                  onClick={() => router.push(ROUTES.TeamProfileEdit())}
                 >
                   프로필 수정하기
                 </button>

--- a/src/static/routes.ts
+++ b/src/static/routes.ts
@@ -69,6 +69,8 @@ const ROUTES = {
   TeamProfile: () => '/team/profile',
   TeamProfileCreate: ({ step }: ROUTESParams<'step'> = {}) =>
     `/team/profile/create${step ? `?step=${encodeURIComponent(step)}` : ''}`,
+  TeamProfileEdit: ({ step }: ROUTESParams<'step'> = {}) =>
+    `/team/profile/edit${step ? `?step=${encodeURIComponent(step)}` : ''}`,
   TeamDetail: ({ postId }: { postId: string }) => `/team/recruitment/${postId}`,
   TeamNotifications: () => '/team/notifications',
   TeamChat: ({ recruitmentId, chatRoomId }: { recruitmentId: string; chatRoomId: string }) =>


### PR DESCRIPTION
- Close #1347

## What is this PR? 🔍

- 기능 : 팀원 모집 프로필 수정 페이지
- issue : #1347
- ⚠️ Stacked PR: `#1343` (작성 페이지, `feature/#1342/team-recruitment-profile-form`) 위에서 분기했습니다. base가 `develop`이 아니라 `#1343`의 브랜치입니다. `#1343`이 먼저 머지된 뒤 이 PR의 base를 `develop`으로 옮기고 다시 확인해주세요.

## Changes 📝

- 확인된 API 명세(`GET`/`PUT /team-recruitment-profiles/me`)에 맞춰 `teamRecruitmentProfile` API 계층 재작성 — 생성/수정이 동일한 upsert 엔드포인트이며, 요청 필드는 `profile_nickname/preferred_role/skills/activities(started_at/ended_at/is_ongoing/description)/self_introduction`만 사용(학과·학번은 별도 학적 API로 처리하므로 제외)
- `ProfilePage` 컴포넌트에 `mode: 'create' | 'edit'` prop 추가 — 헤더 타이틀·제출 버튼 문구·완료 토스트만 모드별로 분기하고 나머지 폼 로직과 mutation은 공용으로 재사용
- 수정 모드 진입 시 `GET /team-recruitment-profiles/me`로 기존 프로필을 불러와 폼을 prefill
- `ROUTES.TeamProfileEdit` (`/team/profile/edit`) 라우트 및 페이지 추가
- 진입점 페이지(`/team/profile`)의 mock 데이터를 실제 조회 쿼리로 교체하고 "프로필 수정하기" 버튼을 새 수정 폼으로 연결

## ScreenShot 📷

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->

## Test CheckList ✅

- [ ] `/team/profile`에서 프로필이 있는 경우 "프로필 수정하기" 클릭 시 `/team/profile/edit`로 이동하는지 확인
- [ ] 수정 폼 진입 시 기존 닉네임/학과/학번/선호 역할/기술/활동 이력/자기소개가 모두 prefill되는지 확인
- [ ] 수정 폼 2단계에서 제출 버튼 문구가 "수정하기"로 노출되는지 확인
- [ ] 수정 완료 시 성공 토스트 및 진입점 페이지 이동이 정상 동작하는지 확인
- [ ] 작성 폼(`/team/profile/create`)의 기존 동작이 회귀 없이 그대로 동작하는지 확인 (헤더 "작성", 버튼 "저장")
- [ ] 모바일 뷰포트에서 레이아웃이 Figma와 일치하는지 확인

## Precaution

- API 명세가 확정되며 작성 페이지(#1343)에서 추측 경로로 구현했던 부분(별도 생성 엔드포인트, `department`/`student_number` 요청 포함 등)도 이번에 함께 수정했습니다.
- 완료 후 노출되는 모달/오버레이 디자인은 아직 미확정이라 작성 폼과 동일하게 토스트 + 진입점 페이지 이동으로 처리했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
