### PR TITLE
[캠퍼스] 카테고리 팀원모집 진입점 위치 이동 및 모집하기 라우트 연결

### DIFF
--- a/src/assets/svg/category/team-icon.svg
+++ b/src/assets/svg/category/team-icon.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 3.70802C8.19377 3.57422 7.85555 3.5 7.5 3.5C6.11929 3.5 5 4.61929 5 6C5 6.8178 5.39267 7.54389 5.99976 8" stroke="#B611F5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.375 16.4998C2.61561 16.4998 2 15.8586 2 15.0675C2 13.4583 3.66644 11.849 6.5 11.54" stroke="#B611F5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.5 3.70704C15.8062 3.57325 16.1444 3.49902 16.5 3.49902C17.8807 3.49902 19 4.61831 19 5.99902C19 6.81682 18.6073 7.54291 18.0002 7.99902" stroke="#B611F5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.6248 16.4998C21.3842 16.4998 21.9998 15.8585 21.9998 15.0675C21.9998 13.4583 20.3334 11.8491 17.5 11.54" stroke="#B611F5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 11.5C13.6569 11.5 15 10.1569 15 8.5C15 6.84315 13.6569 5.5 12 5.5C10.3431 5.5 9 6.84315 9 8.5C9 10.1569 10.3431 11.5 12 11.5Z" stroke="#B611F5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 14.5C8.25 14.5 6 16.6429 6 18.7857C6 19.7325 6.67157 20.5 7.5 20.5H16.5C17.3284 20.5 18 19.7325 18 18.7857C18 16.6429 15.75 14.5 12 14.5Z" stroke="#B611F5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -9,6 +9,7 @@ import HomeIcon from 'assets/svg/category/home-icon.svg';
 import InfoIcon from 'assets/svg/category/info-icon.svg';
 import PermanentJobIcon from 'assets/svg/category/permanent-job-icon.svg';
 import StoreIcon from 'assets/svg/category/store-icon.svg';
+import TeamIcon from 'assets/svg/category/team-icon.svg';
 import UserAddIcon from 'assets/svg/category/user-add-icon.svg';
 import ArrowRightIcon from 'assets/svg/common/arrow-right-icon.svg';
 import BusTimeIcon from 'assets/svg/common/bus-time-icon.svg';
@@ -54,14 +55,15 @@ interface CategorySection {
 
 const quickMenus: CategoryItem[] = [
   {
-    title: '시간표',
-    description: '내 강의 정보 확인하기',
-    href: ROUTES.Timetable(),
-    Icon: CalendarIcon,
+    title: '팀원 모집',
+    description: '교내 활동 팀원 구하기',
+    href: ROUTES.Team(),
+    Icon: TeamIcon,
     logging: {
-      team: 'USER',
-      event_label: 'category_timetable',
-      value: '시간표',
+      // TODO: 퀵카드로 승격되면서 전용 event_label이 필요함 - Notion 로깅 스펙 확인 후 교체
+      team: 'CAMPUS',
+      event_label: 'category_etc',
+      value: '팀원 모집',
     },
   },
   {
@@ -121,6 +123,16 @@ const sections: CategorySection[] = [
           value: '주변상점',
         },
       },
+      {
+        title: '시간표',
+        href: ROUTES.Timetable(),
+        Icon: CalendarIcon,
+        logging: {
+          team: 'USER',
+          event_label: 'category_campus',
+          value: '시간표',
+        },
+      },
     ],
   },
   {
@@ -169,16 +181,6 @@ const sections: CategorySection[] = [
           team: 'CAMPUS',
           event_label: 'category_etc',
           value: '채팅',
-        },
-      },
-      {
-        title: '팀원 모집',
-        href: ROUTES.Team(),
-        Icon: UserAddIcon,
-        logging: {
-          team: 'CAMPUS',
-          event_label: 'category_etc',
-          value: '팀원 모집',
         },
       },
       {

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { teamQueries } from 'api/team/queries';
@@ -11,6 +12,7 @@ import Layout from 'components/layout';
 import RecruitmentCard from 'components/Team/components/RecruitmentCard';
 import TeamListHeader from 'components/Team/components/TeamListHeader';
 import SearchBar from 'components/ui/SearchBar';
+import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
@@ -22,6 +24,7 @@ import styles from './TeamListPage.module.scss';
 type TeamListFilter = Omit<TeamRecruitmentListRequest, 'page' | 'limit'>;
 
 export default function TeamListPage() {
+  const router = useRouter();
   const token = useTokenState();
   const isMobile = useMediaQuery();
   const logger = useLogger();
@@ -54,7 +57,15 @@ export default function TeamListPage() {
 
   const handleFilterClick = () => showToast('warning', '필터 기능은 준비 중입니다.');
 
-  const handleRecruitClick = () => showToast('warning', '모집글 작성 기능은 준비 중입니다.');
+  const handleRecruitClick = () => {
+    logger.actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: 'team_recruitment_recruit',
+      value: '모집하기',
+    });
+    router.push(ROUTES.TeamRecruitmentNew());
+  };
 
   return (
     <>

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -17,6 +17,7 @@ import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useInfiniteScroll from 'utils/hooks/ui/useInfiniteScroll';
+import { redirectToLogin } from 'utils/ts/auth';
 import showToast from 'utils/ts/showToast';
 import type { TeamRecruitmentListRequest } from 'api/team/entity';
 import styles from './TeamListPage.module.scss';
@@ -64,6 +65,12 @@ export default function TeamListPage() {
       event_label: 'team_recruitment_recruit',
       value: '모집하기',
     });
+
+    if (!token) {
+      redirectToLogin(router.asPath);
+      return;
+    }
+
     router.push(ROUTES.TeamRecruitmentNew());
   };
 


### PR DESCRIPTION
- Close #1358 

## What is this PR? 🔍

- 기능 : 팀원모집 진입점 위치를 이동시키고 모집하기 라우트를 연결 및 로깅을 추가 했습니다
- issue : #1358 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 카테고리 페이지 상단 퀵카드를 시간표 → 팀원 모집으로 교체 (`team-icon.svg`),
- 시간표는 캠퍼스 섹션 리스트 5번째 항목으로 이동
- 기타 섹션 리스트에서 중복되던 기존 팀원모집 항목 제거
- 팀원모집 목록 페이지(`/team`)의 "모집하기" FAB를 `/team/recruitment/new`로 라우팅 연결
- "모집하기" 클릭 로깅 추가
- 퀵카드로 이동에 따라 추후 팀원모집 로깅 변경시 수정 예정

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="409" height="818" alt="image" src="https://github.com/user-attachments/assets/f36849ea-db4f-411f-bf0f-279731156d48" />

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] 로컬확인
- [x] yarn lint

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * ‘팀원 모집’이 빠른 메뉴에 추가되어 더 쉽게 모집글 작성 화면으로 이동할 수 있습니다.
  * 로그인하지 않은 상태에서 모집글 작성을 선택하면 현재 위치를 유지한 채 로그인 화면으로 이동합니다.
  * 로그인한 사용자는 모집글 작성 페이지로 바로 이동합니다.
  * ‘시간표’ 메뉴가 ‘캠퍼스’ 섹션으로 이동했습니다.
* **개선**
  * 메뉴 구성을 조정해 관련 기능을 더 쉽게 찾을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->