### PR TITLE
[팀원 모집] API 연동 마감 (인증·에러 처리·스텁 해제)

### DIFF
--- a/src/api/teamRecruitmentProfile/queries.ts
+++ b/src/api/teamRecruitmentProfile/queries.ts
@@ -40,7 +40,6 @@ export const useUpsertTeamRecruitmentProfileMutation = ({
   return useMutation({
     mutationFn: (data: UpsertTeamRecruitmentProfileRequest) => upsertTeamRecruitmentProfile(token, data),
     onSuccess: () => {
-      // 저장 직후 프로필 화면으로 돌아가도 staleTime(60초) 동안 갱신 전 캐시를 보지 않도록 먼저 무효화한다.
       queryClient.invalidateQueries({ queryKey: teamRecruitmentProfileQueryKeys.me(token) });
       onSuccess?.();
     },

--- a/src/api/teamRecruitmentProfile/queries.ts
+++ b/src/api/teamRecruitmentProfile/queries.ts
@@ -1,5 +1,5 @@
-import { isKoinError } from '@bcsdlab/koin';
-import { queryOptions, useMutation } from '@tanstack/react-query';
+import { isKoinError, sendClientError } from '@bcsdlab/koin';
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTeamRecruitmentProfile, upsertTeamRecruitmentProfile } from 'api/teamRecruitmentProfile';
 import { TeamRecruitmentProfileResponse, UpsertTeamRecruitmentProfileRequest } from 'api/teamRecruitmentProfile/entity';
 import useTokenState from 'utils/hooks/state/useTokenState';
@@ -35,18 +35,22 @@ export const useUpsertTeamRecruitmentProfileMutation = ({
   onSuccess,
 }: UseUpsertTeamRecruitmentProfileMutationOptions = {}) => {
   const token = useTokenState();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (data: UpsertTeamRecruitmentProfileRequest) => upsertTeamRecruitmentProfile(token, data),
     onSuccess: () => {
+      // 저장 직후 프로필 화면으로 돌아가도 staleTime(60초) 동안 갱신 전 캐시를 보지 않도록 먼저 무효화한다.
+      queryClient.invalidateQueries({ queryKey: teamRecruitmentProfileQueryKeys.me(token) });
       onSuccess?.();
     },
     onError: (error) => {
       if (isKoinError(error)) {
         showToast('error', error.message || '프로필 저장에 실패했습니다.');
-      } else {
-        showToast('error', '프로필 저장에 실패했습니다.');
+        return;
       }
+      showToast('error', '프로필 저장에 실패했습니다.');
+      sendClientError(error);
     },
   });
 };

--- a/src/components/Team/ProfilePage/Steps/BasicInfoStep/index.tsx
+++ b/src/components/Team/ProfilePage/Steps/BasicInfoStep/index.tsx
@@ -1,4 +1,4 @@
-import { isKoinError } from '@bcsdlab/koin';
+import { isKoinError, sendClientError } from '@bcsdlab/koin';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { getUserAcademicInfo, updateAcademicInfo } from 'api/auth';
 import { deptQueries } from 'api/dept/queries';
@@ -59,9 +59,10 @@ export default function BasicInfoStep({ mode, onNext }: BasicInfoStepProps) {
     onError: (error) => {
       if (isKoinError(error)) {
         showToast('error', error.message || '회원정보를 불러오지 못했습니다.');
-      } else {
-        showToast('error', '회원정보를 불러오지 못했습니다.');
+        return;
       }
+      showToast('error', '회원정보를 불러오지 못했습니다.');
+      sendClientError(error);
     },
   });
 
@@ -90,9 +91,10 @@ export default function BasicInfoStep({ mode, onNext }: BasicInfoStepProps) {
     onError: (error) => {
       if (isKoinError(error)) {
         showToast('error', error.message || '학적 정보 수정에 실패했습니다.');
-      } else {
-        showToast('error', '학적 정보 수정에 실패했습니다.');
+        return;
       }
+      showToast('error', '학적 정보 수정에 실패했습니다.');
+      sendClientError(error);
     },
   });
 

--- a/src/components/Team/ProfilePage/index.tsx
+++ b/src/components/Team/ProfilePage/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'api/teamRecruitmentProfile/queries';
 import LoadingSpinner from 'components/feedback/LoadingSpinner';
 import SubmitConfirmModal from 'components/Team/components/SubmitConfirmModal';
+import useTeamAuthGuard from 'components/Team/hooks/useTeamAuthGuard';
 import SubPageHeader from 'components/ui/SubPageHeader';
 import { FormProvider, useForm } from 'react-hook-form';
 import ROUTES from 'static/routes';
@@ -65,6 +66,7 @@ export default function TeamProfileForm({ mode }: TeamProfileFormProps) {
   const router = useRouter();
   const token = useTokenState();
   const { actionEventClick } = useLogger();
+  const { isAuthReady } = useTeamAuthGuard();
   const isEditMode = mode === 'edit';
   const buildStepHref = (step: ProfileStepTitle) =>
     isEditMode ? ROUTES.TeamProfileEdit({ step }) : ROUTES.TeamProfileCreate({ step });
@@ -178,6 +180,10 @@ export default function TeamProfileForm({ mode }: TeamProfileFormProps) {
     });
     setPendingValues(null);
   };
+
+  // 인증 확인 전 렌더를 막는다. 게이트는 반드시 이 컴포넌트의 모든 훅 호출 뒤,
+  // return 직전에 두어야 렌더마다 훅 개수가 달라지지 않는다.
+  if (!isAuthReady) return null;
 
   return (
     <div className={styles.container}>

--- a/src/components/Team/ProfilePage/index.tsx
+++ b/src/components/Team/ProfilePage/index.tsx
@@ -181,8 +181,6 @@ export default function TeamProfileForm({ mode }: TeamProfileFormProps) {
     setPendingValues(null);
   };
 
-  // 인증 확인 전 렌더를 막는다. 게이트는 반드시 이 컴포넌트의 모든 훅 호출 뒤,
-  // return 직전에 두어야 렌더마다 훅 개수가 달라지지 않는다.
   if (!isAuthReady) return null;
 
   return (

--- a/src/components/Team/hooks/useTeamAuthGuard.ts
+++ b/src/components/Team/hooks/useTeamAuthGuard.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import useMount from 'utils/hooks/state/useMount';
+import useTokenState from 'utils/hooks/state/useTokenState';
+import { redirectToLogin } from 'utils/ts/auth';
+
+/**
+ * 팀원 모집 화면 공용 인증 가드.
+ *
+ * 미로그인 상태면 로그인 페이지로 보내고 원래 경로를 복귀 지점으로 저장한다.
+ * `isAuthReady`가 false인 동안에는 컴포넌트를 렌더하지 않아야 한다.
+ * `useSuspenseInfiniteQuery`는 `enabled` 옵션이 없으므로, 빈 토큰 요청을 막는 방법은 렌더 게이트뿐이다.
+ * 게이트(`if (!isAuthReady) return null;`)는 반드시 해당 컴포넌트의 모든 훅 호출 이후에 두어야 한다.
+ */
+export default function useTeamAuthGuard(): { isAuthReady: boolean } {
+  const router = useRouter();
+  const token = useTokenState();
+  const mounted = useMount();
+
+  useEffect(() => {
+    if (mounted && !token) {
+      redirectToLogin(router.asPath);
+    }
+  }, [mounted, token, router.asPath]);
+
+  return { isAuthReady: mounted && !!token };
+}

--- a/src/components/Team/hooks/useTeamAuthGuard.ts
+++ b/src/components/Team/hooks/useTeamAuthGuard.ts
@@ -4,14 +4,6 @@ import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import { redirectToLogin } from 'utils/ts/auth';
 
-/**
- * 팀원 모집 화면 공용 인증 가드.
- *
- * 미로그인 상태면 로그인 페이지로 보내고 원래 경로를 복귀 지점으로 저장한다.
- * `isAuthReady`가 false인 동안에는 컴포넌트를 렌더하지 않아야 한다.
- * `useSuspenseInfiniteQuery`는 `enabled` 옵션이 없으므로, 빈 토큰 요청을 막는 방법은 렌더 게이트뿐이다.
- * 게이트(`if (!isAuthReady) return null;`)는 반드시 해당 컴포넌트의 모든 훅 호출 이후에 두어야 한다.
- */
 export default function useTeamAuthGuard(): { isAuthReady: boolean } {
   const router = useRouter();
   const token = useTokenState();

--- a/src/pages/team/my-applications/MyApplicationsPage.module.scss
+++ b/src/pages/team/my-applications/MyApplicationsPage.module.scss
@@ -135,3 +135,14 @@
 .scrollTrigger {
   height: 1px;
 }
+
+.errorFallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 22px;
+  color: #727272;
+  font-size: 14px;
+  line-height: 1.6;
+  text-align: center;
+}

--- a/src/pages/team/my-applications/index.tsx
+++ b/src/pages/team/my-applications/index.tsx
@@ -9,9 +9,12 @@ import { teamQueries } from 'api/team/queries';
 import EmptyRecruitment from 'assets/svg/common/sleep-bbico.svg';
 import ChatIcon from 'assets/svg/Team/chat-bubble.svg';
 import FilterIcon from 'assets/svg/Team/filter.svg';
+import ErrorBoundary from 'components/boundary/ErrorBoundary';
+import LoadingSpinner from 'components/feedback/LoadingSpinner';
 import Layout from 'components/layout';
 import MyApplicationFilterPanel from 'components/Team/components/MyApplicationFilterPanel';
 import RecruitmentCard from 'components/Team/components/RecruitmentCard';
+import useTeamAuthGuard from 'components/Team/hooks/useTeamAuthGuard';
 import formatApplicationStatus from 'components/Team/utils/formatApplicationStatus';
 import SubPageHeader from 'components/ui/SubPageHeader';
 import ROUTES from 'static/routes';
@@ -124,6 +127,7 @@ function ApplicationsListSection({ requestParams, onFilterOpen, onChatClick }: A
 export default function MyApplicationsPage() {
   const logger = useLogger();
   const router = useRouter();
+  const { isAuthReady } = useTeamAuthGuard();
 
   const [isFilterOpen, openFilter, closeFilter] = useBooleanState(false);
   const [requestParams, setRequestParams] = useState<MyTeamRecruitmentApplicationListRequest>({
@@ -157,6 +161,11 @@ export default function MyApplicationsPage() {
       );
     };
 
+  // 인증 확인 전 렌더를 막는다: ApplicationsListSection의 useSuspenseInfiniteQuery는 enabled 옵션이 없어
+  // 렌더 게이트 외에는 빈 토큰 요청을 막을 방법이 없다.
+  // 게이트는 반드시 이 컴포넌트의 모든 훅 호출 뒤에 두어야 훅 개수가 렌더마다 달라지지 않는다.
+  if (!isAuthReady) return null;
+
   return (
     <>
       <Head>
@@ -171,9 +180,16 @@ export default function MyApplicationsPage() {
       />
 
       <main className={styles.page}>
-        <Suspense fallback={null}>
-          <ApplicationsListSection requestParams={requestParams} onFilterOpen={openFilter} onChatClick={handleChatClick} />
-        </Suspense>
+        {/* ErrorBoundary에 리셋 경로가 없으므로, 필터가 바뀌면 key로 리마운트해 폴백에 갇히지 않게 한다. */}
+        <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
+          <Suspense fallback={<LoadingSpinner size="50px" />}>
+            <ApplicationsListSection
+              requestParams={requestParams}
+              onFilterOpen={openFilter}
+              onChatClick={handleChatClick}
+            />
+          </Suspense>
+        </ErrorBoundary>
       </main>
 
       {isFilterOpen && (

--- a/src/pages/team/my-applications/index.tsx
+++ b/src/pages/team/my-applications/index.tsx
@@ -161,9 +161,6 @@ export default function MyApplicationsPage() {
       );
     };
 
-  // 인증 확인 전 렌더를 막는다: ApplicationsListSection의 useSuspenseInfiniteQuery는 enabled 옵션이 없어
-  // 렌더 게이트 외에는 빈 토큰 요청을 막을 방법이 없다.
-  // 게이트는 반드시 이 컴포넌트의 모든 훅 호출 뒤에 두어야 훅 개수가 렌더마다 달라지지 않는다.
   if (!isAuthReady) return null;
 
   return (
@@ -180,7 +177,6 @@ export default function MyApplicationsPage() {
       />
 
       <main className={styles.page}>
-        {/* ErrorBoundary에 리셋 경로가 없으므로, 필터가 바뀌면 key로 리마운트해 폴백에 갇히지 않게 한다. */}
         <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
           <Suspense fallback={<LoadingSpinner size="50px" />}>
             <ApplicationsListSection

--- a/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
+++ b/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
@@ -116,3 +116,14 @@
 .scrollTrigger {
   height: 1px;
 }
+
+.errorFallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 22px;
+  color: #727272;
+  font-size: 14px;
+  line-height: 1.6;
+  text-align: center;
+}

--- a/src/pages/team/my-created-posts/index.tsx
+++ b/src/pages/team/my-created-posts/index.tsx
@@ -8,6 +8,8 @@ import { teamQueries } from 'api/team/queries';
 import EmptyRecruitment from 'assets/svg/common/sleep-bbico.svg';
 import ChatIcon from 'assets/svg/Team/chat-bubble.svg';
 import FilterIcon from 'assets/svg/Team/filter.svg';
+import ErrorBoundary from 'components/boundary/ErrorBoundary';
+import LoadingSpinner from 'components/feedback/LoadingSpinner';
 import Layout from 'components/layout';
 import MyCreatedPostFilterPanel from 'components/Team/components/MyCreatedPostFilterPanel';
 import RecruitmentCard from 'components/Team/components/RecruitmentCard';
@@ -245,15 +247,18 @@ export default function MyCreatedPostsPage() {
       />
 
       <main className={styles.page}>
-        <Suspense fallback={null}>
-          <CreatedPostsListSection
-            requestParams={requestParams}
-            onFilterOpen={openFilter}
-            onApplicantClick={handleApplicantClick}
-            onCloseClick={handleCloseClick}
-            onChatClick={handleChatClick}
-          />
-        </Suspense>
+        {/* ErrorBoundary에 리셋 경로가 없으므로, 필터가 바뀌면 key로 리마운트해 폴백에 갇히지 않게 한다. */}
+        <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
+          <Suspense fallback={<LoadingSpinner size="50px" />}>
+            <CreatedPostsListSection
+              requestParams={requestParams}
+              onFilterOpen={openFilter}
+              onApplicantClick={handleApplicantClick}
+              onCloseClick={handleCloseClick}
+              onChatClick={handleChatClick}
+            />
+          </Suspense>
+        </ErrorBoundary>
       </main>
 
       {isFilterOpen && (

--- a/src/pages/team/my-created-posts/index.tsx
+++ b/src/pages/team/my-created-posts/index.tsx
@@ -247,7 +247,6 @@ export default function MyCreatedPostsPage() {
       />
 
       <main className={styles.page}>
-        {/* ErrorBoundary에 리셋 경로가 없으므로, 필터가 바뀌면 key로 리마운트해 폴백에 갇히지 않게 한다. */}
         <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
           <Suspense fallback={<LoadingSpinner size="50px" />}>
             <CreatedPostsListSection

--- a/src/pages/team/profile/index.tsx
+++ b/src/pages/team/profile/index.tsx
@@ -16,7 +16,6 @@ import useLogger from 'utils/hooks/analytics/useLogger';
 import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import { redirectToLogin } from 'utils/ts/auth';
-import showToast from 'utils/ts/showToast';
 import styles from './TeamProfilePage.module.scss';
 
 interface MenuCardProps {
@@ -97,7 +96,7 @@ function TeamProfilePage() {
       event_label: 'team_recruitment_profile_applied',
       value: '내가 지원한 모집글',
     });
-    showToast('warning', '준비 중인 기능입니다.');
+    router.push(ROUTES.TeamMyApplications());
   };
 
   return (


### PR DESCRIPTION
## 개요

팀원 모집 API가 stage에 배포 완료됨에 따라, 프로필 / 프로필 작성·수정 / 내가 작성한 모집글 / 내가 지원한 모집글 4개 화면의 잔여 작업을 마감했습니다.

**조사 결과:** API 연결은 사실상 이미 완료되어 있었고, 실제 수정 대상은 ① 스텁 1곳, ② 인증 가드 부재, ③ Suspense 쿼리 에러 처리 부재, ④ sendClientError 누락 3곳이었습니다.

## 변경 사항

### 신규 파일
- `src/components/Team/hooks/useTeamAuthGuard.ts` — 팀원 모집 화면 공용 인증 가드 훅 (렌더 게이트 + 미로그인 리다이렉트)

### 수정 파일

**인증 가드 & 라우팅 (3개)**
- `src/pages/team/profile/index.tsx` — "내가 지원한 모집글" 스텁 제거 → ROUTES.TeamMyApplications() 연결
- `src/pages/team/my-applications/index.tsx` — useTeamAuthGuard() 렌더 게이트 추가 (비로그인 요청 차단)
- `src/components/Team/ProfilePage/index.tsx` — useTeamAuthGuard() 게이트 추가 (create/edit 동시 커버)

**에러 처리 (4개)**
- `src/pages/team/my-applications/index.tsx` — ErrorBoundary 래핑 + LoadingSpinner fallback
- `src/pages/team/my-created-posts/index.tsx` — ErrorBoundary 래핑 + LoadingSpinner fallback
- `src/api/teamRecruitmentProfile/queries.ts` — onError 정본 패턴 적용 + 프로필 저장 성공 시 캐시 무효화
- `src/components/Team/ProfilePage/Steps/BasicInfoStep/index.tsx` — loadUserInfo/saveAcademicInfo onError에 sendClientError 추가

**스타일 (2개)**
- `src/pages/team/my-applications/MyApplicationsPage.module.scss` — errorFallback 클래스 추가
- `src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss` — errorFallback 클래스 추가

## 테스트 방법

### 1. 비로그인 상태 인증 가드 검증
비로그인 → /team/my-applications 직접 진입 → 로그인 페이지로 이동 → 로그인 후 원래 경로로 복귀 → 네트워크 탭에 401 요청 없음

### 2. 스텁 해제 & 페이지 이동
로그인 상태 → /team/profile → "내가 지원한 모집글" 클릭 → /team/my-applications로 이동 → 지원 목록 정상 렌더

### 3. 에러 처리 검증
목록 API 강제 실패 → ErrorBoundary fallback UI 표시 → 에러 토스트 + Sentry 로깅

### 4. 프로필 저장 & 캐시
프로필 저장 실패(400) → 오류 메시지 토스트
프로필 저장 성공 → 캐시 무효화 후 /team/profile로 이동

## 체크리스트
- [x] yarn lint 통과 (ESLint + Stylelint)
- [x] yarn typecheck 통과
- [x] SSR 안전성 확인 (4개 화면 모두 CSR, getServerSideProps 없음 → CLAUDE.md 규칙 10 예외)
- [x] 에러 핸들링 패턴 적용 (isKoinError → showToast / else sendClientError)
- [x] 분석 로깅 포함 (기존 logger.actionEventClick 호출 전부 유지)

## 참고사항

### 범위 명시
- 지원자 관리 화면 (별도 작업)
- 모집글 상세 페이지 (별도 작업)
- notifications 뮤테이션 onError 3곳 (범위 외)

### P0 준수 사항
1. if (!isAuthReady) return null; 게이트는 모든 훅 호출 완료 후 return ( 직전에 배치
2. requireAuth 신규 추가 없음
3. ErrorBoundary는 필터 변경 시 리마운트되도록 key={JSON.stringify(requestParams)} 적용

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 팀 페이지의 로그인 상태를 확인한 뒤 인증된 사용자에게만 콘텐츠를 표시합니다.
  * 지원 현황 및 작성 게시글 목록에 로딩 표시와 오류 대체 화면을 제공합니다.
  * 프로필 저장 후 최신 사용자 정보가 자동으로 갱신됩니다.
  * 프로필 오류를 자동으로 보고하고, 지원 현황 페이지로 바로 이동할 수 있습니다.

* **버그 수정**
  * 인증되지 않은 사용자가 팀 페이지에 접근할 때 로그인 화면으로 안내합니다.
  * 프로필 및 목록 조회 오류 시 적절한 안내 메시지를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->