### PR TITLE
[캠퍼스] 내가 지원한 모집글 화면 데스크탑 UI 구현

### DIFF
--- a/src/components/Team/components/RecruitmentCard/RecruitmentCard.module.scss
+++ b/src/components/Team/components/RecruitmentCard/RecruitmentCard.module.scss
@@ -1,3 +1,5 @@
+@use "src/utils/scss/media" as media;
+
 .card {
   position: relative;
   display: flex;
@@ -7,9 +9,14 @@
   min-height: 109px;
   padding: 16px 20px;
   box-sizing: border-box;
+  border: 1px solid #e1e1e1;
   border-radius: 16px;
   background: #fff;
   color: #1f1f1f;
+
+  @include media.media-breakpoint(mobile) {
+    border: none;
+  }
 
   &__overlayLink {
     position: absolute;
@@ -86,13 +93,18 @@
     color: #ec2d30;
 
     &--closed {
-      color: #b611f5;
+      color: #175c8e;
+
+      @include media.media-breakpoint(mobile) {
+        color: #b611f5;
+      }
     }
   }
 
   &__title {
     overflow: hidden;
     color: #1f1f1f;
+    font-size: 16px;
     font-weight: 600;
     line-height: 160%;
     text-overflow: ellipsis;
@@ -146,7 +158,11 @@
       }
 
       &--full {
-        color: #b611f5;
+        color: #175c8e;
+
+        @include media.media-breakpoint(mobile) {
+          color: #b611f5;
+        }
       }
     }
   }

--- a/src/pages/team/my-applications/MyApplicationsPage.module.scss
+++ b/src/pages/team/my-applications/MyApplicationsPage.module.scss
@@ -22,7 +22,8 @@
   background: #fff;
 
   @include media.media-breakpoint(mobile) {
-    display: block;
+    flex-direction: column;
+    justify-content: flex-start;
     padding: 0;
     min-height: calc(100dvh - 56px);
     background: #f8f8fa;
@@ -37,6 +38,7 @@
   max-width: 1136px;
 
   @include media.media-breakpoint(mobile) {
+    flex: 1;
     gap: 0;
     max-width: none;
   }
@@ -93,6 +95,15 @@
     padding: 0;
     border: none;
     border-radius: 40px;
+  }
+
+  // 데스크탑 Figma 디자인은 텍스트만 있는 버튼이라 필터 아이콘을 쓰지 않는다.
+  svg {
+    display: none;
+
+    @include media.media-breakpoint(mobile) {
+      display: block;
+    }
   }
 
   &__label {

--- a/src/pages/team/my-applications/MyApplicationsPage.module.scss
+++ b/src/pages/team/my-applications/MyApplicationsPage.module.scss
@@ -1,25 +1,77 @@
+@use "src/utils/scss/media" as media;
+
+.mobileHeader {
+  display: none;
+
+  @include media.media-breakpoint(mobile) {
+    display: block;
+  }
+}
+
 .header {
   background: #f8f8fa;
 }
 
 .page {
   display: flex;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 100dvh;
+  padding: 64px 24px 96px;
+  background: #fff;
+
+  @include media.media-breakpoint(mobile) {
+    display: block;
+    padding: 0;
+    min-height: calc(100dvh - 56px);
+    background: #f8f8fa;
+  }
+}
+
+.inner {
+  display: flex;
   flex-direction: column;
-  min-height: calc(100dvh - 56px);
-  background: #f8f8fa;
+  gap: 60px;
+  width: 100%;
+  max-width: 1136px;
+
+  @include media.media-breakpoint(mobile) {
+    gap: 0;
+    max-width: none;
+  }
+}
+
+.title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 500;
+  line-height: normal;
+  color: #175c8e;
+
+  @include media.media-breakpoint(mobile) {
+    display: none;
+  }
 }
 
 .summaryRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 22px 12px;
+
+  @include media.media-breakpoint(mobile) {
+    padding: 20px 22px 12px;
+  }
 }
 
 .totalCount {
   color: #727272;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.6;
+
+  @include media.media-breakpoint(mobile) {
+    font-size: 12px;
+  }
 }
 
 .filterButton {
@@ -28,16 +80,30 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  width: 76px;
-  height: 36px;
-  border-radius: 40px;
+  height: 42px;
+  padding: 12px 24px;
+  border: 1px solid #175c8e;
+  border-radius: 8px;
   background: #fff;
   cursor: pointer;
 
+  @include media.media-breakpoint(mobile) {
+    width: 76px;
+    height: 36px;
+    padding: 0;
+    border: none;
+    border-radius: 40px;
+  }
+
   &__label {
-    color: #4b4b4b;
-    font-size: 12px;
+    color: #175c8e;
+    font-size: 14px;
     line-height: 1.6;
+
+    @include media.media-breakpoint(mobile) {
+      color: #4b4b4b;
+      font-size: 12px;
+    }
   }
 }
 
@@ -45,7 +111,10 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  padding: 0 22px;
+
+  @include media.media-breakpoint(mobile) {
+    padding: 0 22px;
+  }
 }
 
 .list {
@@ -61,29 +130,57 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 20px;
+
+  @include media.media-breakpoint(mobile) {
+    gap: 12px;
+  }
 
   svg {
-    width: 98px;
-    height: 75px;
+    display: none;
+
+    @include media.media-breakpoint(mobile) {
+      display: block;
+      width: 98px;
+      height: 75px;
+    }
   }
 
   &__text {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2px;
+    gap: 12px;
+
+    @include media.media-breakpoint(mobile) {
+      gap: 2px;
+    }
   }
 
   &__title {
-    font-weight: 500;
-    line-height: 1.6;
+    font-size: 22px;
+    font-weight: 600;
+    line-height: normal;
+    color: #000;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 16px;
+      font-weight: 500;
+      line-height: 1.6;
+    }
   }
 
   &__subtitle {
-    color: #4b4b4b;
-    font-size: 14px;
+    font-size: 16px;
+    font-weight: 500;
     line-height: 1.6;
+    color: #727272;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 14px;
+      font-weight: 400;
+      color: #4b4b4b;
+    }
   }
 
   &__button {
@@ -92,31 +189,48 @@
     justify-content: center;
     box-sizing: border-box;
     height: 42px;
-    padding: 8px 12px;
-    border: 1px solid #c358fc;
-    border-radius: 999px;
-    background: #fafafa;
-    color: #980ac9;
-    font-weight: 500;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 8px;
+    background: #175c8e;
+    color: #fff;
+    font-weight: 600;
     line-height: 1.6;
-    box-shadow:
-      0 1px 2px rgb(0 0 0 / 4%),
-      0 4px 5px rgb(0 0 0 / 8%);
+
+    @include media.media-breakpoint(mobile) {
+      padding: 8px 12px;
+      border: 1px solid #c358fc;
+      border-radius: 999px;
+      background: #fafafa;
+      color: #980ac9;
+      font-weight: 500;
+      box-shadow:
+        0 1px 2px rgb(0 0 0 / 4%),
+        0 4px 5px rgb(0 0 0 / 8%);
+    }
   }
 }
 
 .applicationStatus {
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 1.6;
+
+  @include media.media-breakpoint(mobile) {
+    font-size: 10px;
+  }
 
   &--pending {
     color: #727272;
   }
 
   &--accepted {
-    color: #980ac9;
+    color: #175c8e;
+
+    @include media.media-breakpoint(mobile) {
+      color: #980ac9;
+    }
   }
 
   &--rejected {
@@ -130,6 +244,24 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+
+  svg {
+    width: 35px;
+    height: 35px;
+
+    path {
+      stroke: #175c8e;
+    }
+
+    @include media.media-breakpoint(mobile) {
+      width: 24px;
+      height: 24px;
+
+      path {
+        stroke: #b611f5;
+      }
+    }
+  }
 }
 
 .scrollTrigger {

--- a/src/pages/team/my-applications/index.tsx
+++ b/src/pages/team/my-applications/index.tsx
@@ -170,22 +170,28 @@ export default function MyApplicationsPage() {
         <meta name="description" content="내가 지원한 팀원 모집 게시글과 지원 상태를 확인할 수 있습니다." />
       </Head>
 
-      <SubPageHeader
-        title="내가 지원한 모집글"
-        onBack={() => router.replace(ROUTES.TeamProfile())}
-        className={styles.header}
-      />
+      <div className={styles.mobileHeader}>
+        <SubPageHeader
+          title="내가 지원한 모집글"
+          onBack={() => router.replace(ROUTES.TeamProfile())}
+          className={styles.header}
+        />
+      </div>
 
       <main className={styles.page}>
-        <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
-          <Suspense fallback={<LoadingSpinner size="50px" />}>
-            <ApplicationsListSection
-              requestParams={requestParams}
-              onFilterOpen={openFilter}
-              onChatClick={handleChatClick}
-            />
-          </Suspense>
-        </ErrorBoundary>
+        <div className={styles.inner}>
+          <h1 className={styles.title}>내가 지원한 모집글</h1>
+
+          <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
+            <Suspense fallback={<LoadingSpinner size="50px" />}>
+              <ApplicationsListSection
+                requestParams={requestParams}
+                onFilterOpen={openFilter}
+                onChatClick={handleChatClick}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        </div>
       </main>
 
       {isFilterOpen && (


### PR DESCRIPTION
- Close #1370

## What is this PR? 🔍

- 기능 : 내가 지원한 모집글 화면(`/team/my-applications`) 데스크탑 UI
- issue : #1370

## Changes 📝

- 페이지를 1136px 폭 중앙 정렬 레이아웃으로 재구성하고, 데스크탑 타이틀(32px, blue)·모바일 앱바 헤더를 분기 처리
- "총 N개의 모집글" + 필터 버튼 행 데스크탑 스타일 적용 (아웃라인 블루 버튼)
- `RecruitmentCard`에 데스크탑 테두리(#e1e1e1)와 마감/가득참 색상(블루) 추가 — 카테고리 배지 색상은 기존과 동일하게 유지
- 지원 상태 뱃지(`applicationStatus`) 데스크탑 폰트 크기/색상 조정 (승인 상태 블루)
- 채팅 진입 아이콘 데스크탑 크기(35px)·색상(블루) 적용
- 빈 상태를 Figma 기준으로 재구성 (데스크탑은 마스코트 없이 타이틀 22px + 채워진 블루 버튼)
- 모두 CSS `media.media-breakpoint(mobile)` 오버라이드 방식으로 구현해 모바일 UI/동작은 변경 없음

## ScreenShot 📷

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->

## Test CheckList ✅

- [ ] 데스크탑 뷰포트에서 지원 목록(거절/승인/대기 상태 포함) 카드가 Figma와 일치하는지 확인
- [ ] 승인 상태 + 채팅 가능 조건에서 채팅 아이콘이 정상 노출되는지 확인
- [ ] 데스크탑 뷰포트에서 빈 상태가 Figma와 일치하는지 확인
- [ ] 모바일 뷰포트에서 기존 UI/동작이 그대로 유지되는지 확인 (`RecruitmentCard`를 공유하는 `/team`, `/team/my-created-posts` 모바일 화면 포함)

## Precaution

- 이 PR은 #1368/PR #1369(팀원 모집 프로필 작성 페이지 데스크탑 UI) 브랜치 위에 stacked PR로 올라갑니다. #1369가 먼저 머지되어야 합니다.
- `RecruitmentCard`는 `/team`, `/team/my-created-posts`에서도 공용으로 쓰이는 컴포넌트라, 데스크탑 스타일 변경이 해당 페이지들의 데스크탑 뷰에도 함께 적용됩니다(기존에 전용 데스크탑 디자인이 없던 페이지들이라 회귀는 아닙니다).
- 필터 패널(`MyApplicationFilterPanel`)은 데스크탑 전용 디자인이 제공되지 않아 기존 바텀시트 UI를 그대로 유지했습니다.
- 실 로그인 세션·API 응답 없이는 목록을 확인하기 어려워, 로컬 검증은 목업 데이터로 렌더링하는 임시 테스트 페이지로 확인 후 제거했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일 개선**
  - 팀 모집 카드의 제목 크기와 상태·정보 색상을 화면 크기에 맞게 조정했습니다.
  - 모바일 화면에서는 카드 테두리를 제거하고 가독성에 맞는 색상을 적용했습니다.

- **화면 개선**
  - 내 지원서 페이지를 데스크톱과 모바일 환경에 맞게 반응형으로 개선했습니다.
  - 데스크톱에서 콘텐츠가 중앙에 정렬되고, 제목·필터·지원 상태·채팅 버튼이 화면 크기에 따라 적절히 표시됩니다.
  - 모바일 헤더와 빈 상태 화면의 아이콘, 안내 문구, 버튼 스타일을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->