### PR TITLE
[캠퍼스] 내가 작성한 모집글 화면 데스크탑 UI 구현

### DIFF
--- a/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
+++ b/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
@@ -1,25 +1,77 @@
+@use "src/utils/scss/media" as media;
+
+.mobileHeader {
+  display: none;
+
+  @include media.media-breakpoint(mobile) {
+    display: block;
+  }
+}
+
 .header {
   background: #f8f8fa;
 }
 
 .page {
   display: flex;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 100dvh;
+  padding: 64px 24px 96px;
+  background: #fff;
+
+  @include media.media-breakpoint(mobile) {
+    display: block;
+    padding: 0;
+    min-height: calc(100dvh - 56px);
+    background: #f8f8fa;
+  }
+}
+
+.inner {
+  display: flex;
   flex-direction: column;
-  min-height: calc(100dvh - 56px);
-  background: #f8f8fa;
+  gap: 60px;
+  width: 100%;
+  max-width: 1136px;
+
+  @include media.media-breakpoint(mobile) {
+    gap: 0;
+    max-width: none;
+  }
+}
+
+.title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 500;
+  line-height: normal;
+  color: #175c8e;
+
+  @include media.media-breakpoint(mobile) {
+    display: none;
+  }
 }
 
 .summaryRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 22px 12px;
+
+  @include media.media-breakpoint(mobile) {
+    padding: 20px 22px 12px;
+  }
 }
 
 .totalCount {
   color: #727272;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.6;
+
+  @include media.media-breakpoint(mobile) {
+    font-size: 12px;
+  }
 }
 
 .filterButton {
@@ -28,16 +80,30 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  width: 76px;
-  height: 36px;
-  border-radius: 40px;
+  height: 42px;
+  padding: 12px 24px;
+  border: 1px solid #175c8e;
+  border-radius: 8px;
   background: #fff;
   cursor: pointer;
 
+  @include media.media-breakpoint(mobile) {
+    width: 76px;
+    height: 36px;
+    padding: 0;
+    border: none;
+    border-radius: 40px;
+  }
+
   &__label {
-    color: #4b4b4b;
-    font-size: 12px;
+    color: #175c8e;
+    font-size: 14px;
     line-height: 1.6;
+
+    @include media.media-breakpoint(mobile) {
+      color: #4b4b4b;
+      font-size: 12px;
+    }
   }
 }
 
@@ -45,7 +111,10 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  padding: 0 22px;
+
+  @include media.media-breakpoint(mobile) {
+    padding: 0 22px;
+  }
 }
 
 .list {
@@ -61,32 +130,80 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 20px;
+
+  @include media.media-breakpoint(mobile) {
+    gap: 12px;
+  }
 
   svg {
-    width: 98px;
-    height: 75px;
+    display: none;
+
+    @include media.media-breakpoint(mobile) {
+      display: block;
+      width: 98px;
+      height: 75px;
+    }
   }
 
   &__text {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2px;
+    gap: 12px;
+
+    @include media.media-breakpoint(mobile) {
+      gap: 2px;
+    }
   }
 
   &__title {
-    font-weight: 500;
-    line-height: 1.6;
+    font-size: 22px;
+    font-weight: 600;
+    line-height: normal;
+    color: #000;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 16px;
+      font-weight: 500;
+      line-height: 1.6;
+    }
   }
 
   &__subtitle {
-    color: #4b4b4b;
-    font-size: 14px;
+    font-size: 16px;
+    font-weight: 500;
     line-height: 1.6;
+    color: #727272;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 14px;
+      font-weight: 400;
+      color: #4b4b4b;
+    }
+  }
+
+  &__button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    height: 42px;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 8px;
+    background: #175c8e;
+    color: #fff;
+    font-weight: 600;
+    line-height: 1.6;
+
+    @include media.media-breakpoint(mobile) {
+      display: none;
+    }
   }
 }
 
+// 모바일: 카드 하단 별도 행에 배치되는 전체폭 액션 버튼(actionSlot).
 .actionButton {
   display: flex;
   flex: 1;
@@ -103,6 +220,30 @@
   cursor: pointer;
 }
 
+// 데스크탑: 카드 상단 행(rightSlot)에 뱃지와 나란히 배치되는 액션 버튼 묶음.
+.desktopActions {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.desktopActionButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 33px;
+  padding: 6px 16px;
+  border: 1px solid #175c8e;
+  border-radius: 8px;
+  background: #fff;
+  color: #175c8e;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.6;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
 .chatButton {
   position: relative;
   z-index: 2;
@@ -111,6 +252,24 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+
+  svg {
+    width: 35px;
+    height: 35px;
+
+    path {
+      stroke: #175c8e;
+    }
+
+    @include media.media-breakpoint(mobile) {
+      width: 24px;
+      height: 24px;
+
+      path {
+        stroke: #b611f5;
+      }
+    }
+  }
 }
 
 .scrollTrigger {

--- a/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
+++ b/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
@@ -22,7 +22,8 @@
   background: #fff;
 
   @include media.media-breakpoint(mobile) {
-    display: block;
+    flex-direction: column;
+    justify-content: flex-start;
     padding: 0;
     min-height: calc(100dvh - 56px);
     background: #f8f8fa;
@@ -37,6 +38,7 @@
   max-width: 1136px;
 
   @include media.media-breakpoint(mobile) {
+    flex: 1;
     gap: 0;
     max-width: none;
   }
@@ -93,6 +95,15 @@
     padding: 0;
     border: none;
     border-radius: 40px;
+  }
+
+  // 데스크탑 Figma 디자인은 텍스트만 있는 버튼이라 필터 아이콘을 쓰지 않는다.
+  svg {
+    display: none;
+
+    @include media.media-breakpoint(mobile) {
+      display: block;
+    }
   }
 
   &__label {

--- a/src/pages/team/my-created-posts/index.tsx
+++ b/src/pages/team/my-created-posts/index.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useState } from 'react';
 import type { ReactNode } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useMutation, useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { teamMutations } from 'api/team/mutations';
@@ -17,6 +18,7 @@ import SubmitConfirmModal from 'components/Team/components/SubmitConfirmModal';
 import SubPageHeader from 'components/ui/SubPageHeader';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
+import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
 import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
@@ -47,6 +49,7 @@ function CreatedPostsListSection({
 }: CreatedPostsListSectionProps) {
   const logger = useLogger();
   const token = useTokenState();
+  const isMobile = useMediaQuery();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfiniteQuery(
     teamQueries.infiniteMyCreated(token, requestParams),
   );
@@ -96,43 +99,82 @@ function CreatedPostsListSection({
               <p className={styles.empty__title}>작성한 모집글이 없어요.</p>
               <p className={styles.empty__subtitle}>직접 모집글을 작성하여 팀원을 모집해보세요.</p>
             </div>
+            <Link href={ROUTES.TeamRecruitmentNew()} className={styles.empty__button}>
+              모집글 작성하기
+            </Link>
           </div>
         )}
 
         {recruitments.length > 0 && (
           <div className={styles.list}>
-            {recruitments.map((recruitment) => (
-              <RecruitmentCard
-                key={recruitment.id}
-                recruitment={recruitment}
-                rightSlot={
-                  recruitment.team_chat_available &&
-                  recruitment.team_chat_room_id !== null && (
-                    <button
-                      type="button"
-                      className={styles.chatButton}
-                      aria-label="팀 채팅방으로 이동"
-                      onClick={onChatClick(recruitment)}
-                    >
-                      <ChatIcon />
-                    </button>
-                  )
-                }
-                actionSlot={
-                  <>
-                    <button type="button" className={styles.actionButton} onClick={handleApplicantClick(recruitment)}>
-                      지원자 관리
-                    </button>
+            {recruitments.map((recruitment) => {
+              const canChat = recruitment.team_chat_available && recruitment.team_chat_room_id !== null;
+              const chatButton = canChat && (
+                <button
+                  type="button"
+                  className={styles.chatButton}
+                  aria-label="팀 채팅방으로 이동"
+                  onClick={onChatClick(recruitment)}
+                >
+                  <ChatIcon />
+                </button>
+              );
 
-                    {recruitment.can_close && (
-                      <button type="button" className={styles.actionButton} onClick={handleCloseClick(recruitment)}>
-                        모집 마감
-                      </button>
-                    )}
-                  </>
-                }
-              />
-            ))}
+              // 데스크탑은 뱃지와 같은 상단 행에 관리 버튼·채팅 버튼을 함께 배치하고(rightSlot),
+              // 모바일은 채팅 버튼만 상단에 두고 관리 버튼은 카드 하단 별도 행(actionSlot)에 배치한다.
+              return (
+                <RecruitmentCard
+                  key={recruitment.id}
+                  recruitment={recruitment}
+                  rightSlot={
+                    isMobile ? (
+                      chatButton
+                    ) : (
+                      <div className={styles.desktopActions}>
+                        <button
+                          type="button"
+                          className={styles.desktopActionButton}
+                          onClick={handleApplicantClick(recruitment)}
+                        >
+                          지원자 관리
+                        </button>
+
+                        {recruitment.can_close && (
+                          <button
+                            type="button"
+                            className={styles.desktopActionButton}
+                            onClick={handleCloseClick(recruitment)}
+                          >
+                            모집마감
+                          </button>
+                        )}
+
+                        {chatButton}
+                      </div>
+                    )
+                  }
+                  actionSlot={
+                    isMobile && (
+                      <>
+                        <button
+                          type="button"
+                          className={styles.actionButton}
+                          onClick={handleApplicantClick(recruitment)}
+                        >
+                          지원자 관리
+                        </button>
+
+                        {recruitment.can_close && (
+                          <button type="button" className={styles.actionButton} onClick={handleCloseClick(recruitment)}>
+                            모집 마감
+                          </button>
+                        )}
+                      </>
+                    )
+                  }
+                />
+              );
+            })}
 
             <div ref={scrollTriggerRef} className={styles.scrollTrigger} />
           </div>
@@ -240,24 +282,30 @@ export default function MyCreatedPostsPage() {
         <meta name="description" content="내가 작성한 팀원 모집 게시글과 지원자 현황을 확인할 수 있습니다." />
       </Head>
 
-      <SubPageHeader
-        title="내가 작성한 모집글"
-        onBack={() => router.replace(ROUTES.TeamProfile())}
-        className={styles.header}
-      />
+      <div className={styles.mobileHeader}>
+        <SubPageHeader
+          title="내가 작성한 모집글"
+          onBack={() => router.replace(ROUTES.TeamProfile())}
+          className={styles.header}
+        />
+      </div>
 
       <main className={styles.page}>
-        <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
-          <Suspense fallback={<LoadingSpinner size="50px" />}>
-            <CreatedPostsListSection
-              requestParams={requestParams}
-              onFilterOpen={openFilter}
-              onApplicantClick={handleApplicantClick}
-              onCloseClick={handleCloseClick}
-              onChatClick={handleChatClick}
-            />
-          </Suspense>
-        </ErrorBoundary>
+        <div className={styles.inner}>
+          <h1 className={styles.title}>내가 작성한 모집글</h1>
+
+          <ErrorBoundary key={JSON.stringify(requestParams)} fallbackClassName={styles.errorFallback}>
+            <Suspense fallback={<LoadingSpinner size="50px" />}>
+              <CreatedPostsListSection
+                requestParams={requestParams}
+                onFilterOpen={openFilter}
+                onApplicantClick={handleApplicantClick}
+                onCloseClick={handleCloseClick}
+                onChatClick={handleChatClick}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        </div>
       </main>
 
       {isFilterOpen && (


### PR DESCRIPTION
- Close #1373

## What is this PR? 🔍

- 기능 : 내가 작성한 모집글 화면(`/team/my-created-posts`) 데스크탑 UI
- issue : #1373

## Changes 📝

- 페이지를 1136px 폭 중앙 정렬 레이아웃으로 재구성하고, 데스크탑 타이틀(32px, blue)·모바일 앱바 헤더를 분기 처리
- "총 N개의 모집글" + 필터 버튼 행 데스크탑 스타일 적용 (아웃라인 블루 버튼, `my-applications`와 동일한 컨벤션)
- 지원자 관리 / 모집마감 버튼을 데스크탑에서는 카드 상단 뱃지와 같은 행(`rightSlot`)에 채팅 아이콘과 함께 배치 — 모바일은 기존처럼 카드 하단 별도 전체폭 행(`actionSlot`) 유지
- 채팅 아이콘 데스크탑 크기(35px)·색상(블루) 적용
- 빈 상태를 Figma 기준으로 재구성하고, 데스크탑 전용 "모집글 작성하기" 버튼 추가 (`ROUTES.TeamRecruitmentNew()`)
- 모두 `useMediaQuery`/CSS `media.media-breakpoint(mobile)` 분기로 구현해 모바일 UI/동작은 변경 없음

## ScreenShot 📷

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->

## Test CheckList ✅

- [ ] 데스크탑 뷰포트에서 모집중/모집완료 카드의 액션 버튼·채팅 아이콘이 뱃지와 같은 행에 노출되는지 확인
- [ ] 모집 마감 버튼 클릭 시 기존 확인 다이얼로그가 정상 동작하는지 확인
- [ ] 데스크탑 뷰포트에서 빈 상태와 "모집글 작성하기" 버튼이 Figma와 일치하는지 확인
- [ ] 모바일 뷰포트에서 기존 UI/동작(카드 하단 전체폭 액션 버튼, 빈 상태에 버튼 없음)이 그대로 유지되는지 확인

## Precaution

- 이 PR은 #1370/PR #1371(내가 지원한 모집글 화면 데스크탑 UI) 브랜치 위에 stacked PR로 올라갑니다. #1371이 먼저 머지되어야 합니다.
- 데스크탑에서 지원자 관리/모집마감 버튼 위치가 모바일과 달라(상단 vs 하단), `CreatedPostsListSection`에서 `useMediaQuery`로 `RecruitmentCard`의 `rightSlot`/`actionSlot` 구성을 분기했습니다.
- 실 로그인 세션·API 응답 없이는 목록을 확인하기 어려워, 로컬 검증은 목업 데이터로 렌더링하는 임시 테스트 페이지로 확인 후 제거했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
