### PR TITLE
[캠퍼스] 팀원 모집글 검색 및 필터 기능 구현

### DIFF
--- a/src/components/Team/components/RecruitmentFilterPanel/RecruitmentFilterPanel.module.scss
+++ b/src/components/Team/components/RecruitmentFilterPanel/RecruitmentFilterPanel.module.scss
@@ -1,0 +1,102 @@
+.panel {
+  max-height: 85vh;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.headerTitle {
+  color: #b611f5;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionTitle {
+  margin: 0;
+  color: #000;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+.sectionBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.footer {
+  display: flex;
+  gap: 12px;
+}
+
+.resetButton,
+.applyButton {
+  height: 48px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.resetButton {
+  display: flex;
+  flex: 1;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #b611f5;
+  background: #fff;
+  color: #b611f5;
+
+  svg {
+    width: 20px;
+    height: 20px;
+
+    path {
+      fill: #b611f5;
+    }
+  }
+}
+
+.applyButton {
+  flex: 2;
+  border: none;
+  background: #b611f5;
+  color: #fff;
+}

--- a/src/components/Team/components/RecruitmentFilterPanel/index.tsx
+++ b/src/components/Team/components/RecruitmentFilterPanel/index.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState } from 'react';
+import SpinIcon from 'assets/svg/Callvan/spin.svg';
+import CloseIcon from 'assets/svg/close-icon-black.svg';
+import StatusBadge from 'components/Callvan/components/StatusBadge';
+import BottomModal, { BottomModalContent, BottomModalFooter, BottomModalHeader } from 'components/ui/BottomModal';
+import type {
+  TeamRecruitmentCategory,
+  TeamRecruitmentMeetingType,
+  TeamRecruitmentSort,
+  TeamRecruitmentStatusFilter,
+} from 'api/team/entity';
+import styles from './RecruitmentFilterPanel.module.scss';
+
+const STATUS_OPTIONS: { value: TeamRecruitmentStatusFilter; label: string }[] = [
+  { value: 'ALL', label: '전체' },
+  { value: 'RECRUITING', label: '모집 중' },
+  { value: 'CLOSED', label: '모집 완료' },
+];
+
+const SORT_OPTIONS: { value: TeamRecruitmentSort; label: string }[] = [
+  { value: 'LATEST_DESC', label: '최신순' },
+  { value: 'DEADLINE_ASC', label: '마감 임박순' },
+];
+
+const CATEGORY_OPTIONS: { value: TeamRecruitmentCategory; label: string }[] = [
+  { value: 'CONTEST', label: '공모전' },
+  { value: 'EXTERNAL_ACTIVITY', label: '대외활동' },
+  { value: 'STUDY', label: '스터디' },
+  { value: 'PROJECT', label: '프로젝트' },
+  { value: 'OTHER', label: '기타' },
+];
+
+const MEETING_TYPE_OPTIONS: { value: TeamRecruitmentMeetingType; label: string }[] = [
+  { value: 'ONLINE', label: '온라인' },
+  { value: 'OFFLINE', label: '오프라인' },
+  { value: 'MIXED', label: '온·오프라인' },
+];
+
+export interface TeamRecruitmentFilter {
+  status: TeamRecruitmentStatusFilter;
+  categories: TeamRecruitmentCategory[];
+  meetingType?: TeamRecruitmentMeetingType;
+  sort: TeamRecruitmentSort;
+}
+
+export const DEFAULT_TEAM_RECRUITMENT_FILTER: TeamRecruitmentFilter = {
+  status: 'ALL',
+  categories: [],
+  meetingType: undefined,
+  sort: 'LATEST_DESC',
+};
+
+interface RecruitmentFilterPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  filter: TeamRecruitmentFilter;
+  onApply: (filter: TeamRecruitmentFilter) => void;
+}
+
+const copyFilter = (filter: TeamRecruitmentFilter): TeamRecruitmentFilter => ({
+  ...filter,
+  categories: [...filter.categories],
+});
+
+export default function RecruitmentFilterPanel({
+  isOpen,
+  onClose,
+  filter,
+  onApply,
+}: RecruitmentFilterPanelProps) {
+  return (
+    <BottomModal isOpen={isOpen} onClose={onClose} className={styles.panel} aria-label="모집글 필터">
+      <RecruitmentFilterPanelContent filter={filter} onClose={onClose} onApply={onApply} />
+    </BottomModal>
+  );
+}
+
+function RecruitmentFilterPanelContent({
+  onClose,
+  filter,
+  onApply,
+}: Omit<RecruitmentFilterPanelProps, 'isOpen'>) {
+  const [draftFilter, setDraftFilter] = useState<TeamRecruitmentFilter>(() => copyFilter(filter));
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleToggleCategory = (category: TeamRecruitmentCategory) => {
+    setDraftFilter((prev) => {
+      const categories = prev.categories.includes(category)
+        ? prev.categories.filter((item) => item !== category)
+        : [...prev.categories, category];
+
+      return {
+        ...prev,
+        categories: categories.length === CATEGORY_OPTIONS.length ? [] : categories,
+      };
+    });
+  };
+
+  const handleReset = () => {
+    setDraftFilter(copyFilter(DEFAULT_TEAM_RECRUITMENT_FILTER));
+  };
+
+  const handleApply = () => {
+    onApply(copyFilter(draftFilter));
+    onClose();
+  };
+
+  return (
+    <>
+      <BottomModalHeader className={styles.header}>
+        <span className={styles.headerTitle}>필터</span>
+        <button type="button" className={styles.closeButton} onClick={onClose} aria-label="필터 닫기">
+          <CloseIcon />
+        </button>
+      </BottomModalHeader>
+
+      <BottomModalContent className={styles.content}>
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>모집 상태</h3>
+          <div className={styles.sectionBadges}>
+            {STATUS_OPTIONS.map((option) => (
+              <StatusBadge
+                key={option.value}
+                label={option.label}
+                isActive={draftFilter.status === option.value}
+                onClick={() => setDraftFilter((prev) => ({ ...prev, status: option.value }))}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>정렬</h3>
+          <div className={styles.sectionBadges}>
+            {SORT_OPTIONS.map((option) => (
+              <StatusBadge
+                key={option.value}
+                label={option.label}
+                isActive={draftFilter.sort === option.value}
+                onClick={() => setDraftFilter((prev) => ({ ...prev, sort: option.value }))}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>카테고리</h3>
+          <div className={styles.sectionBadges}>
+            <StatusBadge
+              label="전체"
+              isActive={draftFilter.categories.length === 0}
+              onClick={() => setDraftFilter((prev) => ({ ...prev, categories: [] }))}
+            />
+            {CATEGORY_OPTIONS.map((option) => (
+              <StatusBadge
+                key={option.value}
+                label={option.label}
+                isActive={draftFilter.categories.includes(option.value)}
+                onClick={() => handleToggleCategory(option.value)}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>진행 방식</h3>
+          <div className={styles.sectionBadges}>
+            <StatusBadge
+              label="전체"
+              isActive={draftFilter.meetingType === undefined}
+              onClick={() => setDraftFilter((prev) => ({ ...prev, meetingType: undefined }))}
+            />
+            {MEETING_TYPE_OPTIONS.map((option) => (
+              <StatusBadge
+                key={option.value}
+                label={option.label}
+                isActive={draftFilter.meetingType === option.value}
+                onClick={() => setDraftFilter((prev) => ({ ...prev, meetingType: option.value }))}
+              />
+            ))}
+          </div>
+        </section>
+      </BottomModalContent>
+
+      <BottomModalFooter className={styles.footer}>
+        <button type="button" className={styles.resetButton} onClick={handleReset}>
+          초기화
+          <SpinIcon />
+        </button>
+        <button type="button" className={styles.applyButton} onClick={handleApply}>
+          적용하기
+        </button>
+      </BottomModalFooter>
+    </>
+  );
+}

--- a/src/components/Team/components/RecruitmentFilterPanel/index.tsx
+++ b/src/components/Team/components/RecruitmentFilterPanel/index.tsx
@@ -97,7 +97,7 @@ function RecruitmentFilterPanelContent({
   }, [onClose]);
 
   const logFilterEvent = (eventLabel: string, value: string) => {
-    logger.actionEventClick({ team: 'CAMPUS', event_category: 'click', event_label: eventLabel, value });
+    logger.actionEventClick({ team: 'CAMPUS', event_label: eventLabel, value });
   };
 
   const handleSelectStatus = (status: TeamRecruitmentStatusFilter, label: string) => {

--- a/src/components/Team/components/RecruitmentFilterPanel/index.tsx
+++ b/src/components/Team/components/RecruitmentFilterPanel/index.tsx
@@ -3,6 +3,7 @@ import SpinIcon from 'assets/svg/Callvan/spin.svg';
 import CloseIcon from 'assets/svg/close-icon-black.svg';
 import StatusBadge from 'components/Callvan/components/StatusBadge';
 import BottomModal, { BottomModalContent, BottomModalFooter, BottomModalHeader } from 'components/ui/BottomModal';
+import useLogger from 'utils/hooks/analytics/useLogger';
 import type {
   TeamRecruitmentCategory,
   TeamRecruitmentMeetingType,
@@ -83,6 +84,7 @@ function RecruitmentFilterPanelContent({
   filter,
   onApply,
 }: Omit<RecruitmentFilterPanelProps, 'isOpen'>) {
+  const logger = useLogger();
   const [draftFilter, setDraftFilter] = useState<TeamRecruitmentFilter>(() => copyFilter(filter));
 
   useEffect(() => {
@@ -94,7 +96,26 @@ function RecruitmentFilterPanelContent({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
-  const handleToggleCategory = (category: TeamRecruitmentCategory) => {
+  const logFilterEvent = (eventLabel: string, value: string) => {
+    logger.actionEventClick({ team: 'CAMPUS', event_category: 'click', event_label: eventLabel, value });
+  };
+
+  const handleSelectStatus = (status: TeamRecruitmentStatusFilter, label: string) => {
+    setDraftFilter((prev) => ({ ...prev, status }));
+    logFilterEvent('team_recruitment_filter_status', label);
+  };
+
+  const handleSelectSort = (sort: TeamRecruitmentSort, label: string) => {
+    setDraftFilter((prev) => ({ ...prev, sort }));
+    logFilterEvent('team_recruitment_filter_sort', label);
+  };
+
+  const handleSelectAllCategories = () => {
+    setDraftFilter((prev) => ({ ...prev, categories: [] }));
+    logFilterEvent('team_recruitment_filter_category', '전체');
+  };
+
+  const handleToggleCategory = (category: TeamRecruitmentCategory, label: string) => {
     setDraftFilter((prev) => {
       const categories = prev.categories.includes(category)
         ? prev.categories.filter((item) => item !== category)
@@ -105,15 +126,23 @@ function RecruitmentFilterPanelContent({
         categories: categories.length === TEAM_RECRUITMENT_FILTER_CATEGORY_OPTIONS.length ? [] : categories,
       };
     });
+    logFilterEvent('team_recruitment_filter_category', label);
+  };
+
+  const handleSelectMeetingType = (meetingType: TeamRecruitmentMeetingType | undefined, label: string) => {
+    setDraftFilter((prev) => ({ ...prev, meetingType }));
+    logFilterEvent('team_recruitment_filter_method', label);
   };
 
   const handleReset = () => {
     setDraftFilter(copyFilter(DEFAULT_TEAM_RECRUITMENT_FILTER));
+    logFilterEvent('team_recruitment_filter_reset', '초기화');
   };
 
   const handleApply = () => {
     onApply(copyFilter(draftFilter));
     onClose();
+    logFilterEvent('team_recruitment_filter_apply', '적용하기');
   };
 
   return (
@@ -134,7 +163,7 @@ function RecruitmentFilterPanelContent({
                 key={option.value}
                 label={option.label}
                 isActive={draftFilter.status === option.value}
-                onClick={() => setDraftFilter((prev) => ({ ...prev, status: option.value }))}
+                onClick={() => handleSelectStatus(option.value, option.label)}
               />
             ))}
           </div>
@@ -148,7 +177,7 @@ function RecruitmentFilterPanelContent({
                 key={option.value}
                 label={option.label}
                 isActive={draftFilter.sort === option.value}
-                onClick={() => setDraftFilter((prev) => ({ ...prev, sort: option.value }))}
+                onClick={() => handleSelectSort(option.value, option.label)}
               />
             ))}
           </div>
@@ -160,14 +189,14 @@ function RecruitmentFilterPanelContent({
             <StatusBadge
               label="전체"
               isActive={draftFilter.categories.length === 0}
-              onClick={() => setDraftFilter((prev) => ({ ...prev, categories: [] }))}
+              onClick={handleSelectAllCategories}
             />
             {TEAM_RECRUITMENT_FILTER_CATEGORY_OPTIONS.map((option) => (
               <StatusBadge
                 key={option.value}
                 label={option.label}
                 isActive={draftFilter.categories.includes(option.value)}
-                onClick={() => handleToggleCategory(option.value)}
+                onClick={() => handleToggleCategory(option.value, option.label)}
               />
             ))}
           </div>
@@ -179,14 +208,14 @@ function RecruitmentFilterPanelContent({
             <StatusBadge
               label="전체"
               isActive={draftFilter.meetingType === undefined}
-              onClick={() => setDraftFilter((prev) => ({ ...prev, meetingType: undefined }))}
+              onClick={() => handleSelectMeetingType(undefined, '전체')}
             />
             {TEAM_RECRUITMENT_FILTER_MEETING_TYPE_OPTIONS.map((option) => (
               <StatusBadge
                 key={option.value}
                 label={option.label}
                 isActive={draftFilter.meetingType === option.value}
-                onClick={() => setDraftFilter((prev) => ({ ...prev, meetingType: option.value }))}
+                onClick={() => handleSelectMeetingType(option.value, option.label)}
               />
             ))}
           </div>

--- a/src/components/Team/components/RecruitmentFilterPanel/index.tsx
+++ b/src/components/Team/components/RecruitmentFilterPanel/index.tsx
@@ -11,18 +11,18 @@ import type {
 } from 'api/team/entity';
 import styles from './RecruitmentFilterPanel.module.scss';
 
-const STATUS_OPTIONS: { value: TeamRecruitmentStatusFilter; label: string }[] = [
+export const TEAM_RECRUITMENT_FILTER_STATUS_OPTIONS: { value: TeamRecruitmentStatusFilter; label: string }[] = [
   { value: 'ALL', label: '전체' },
   { value: 'RECRUITING', label: '모집 중' },
   { value: 'CLOSED', label: '모집 완료' },
 ];
 
-const SORT_OPTIONS: { value: TeamRecruitmentSort; label: string }[] = [
+export const TEAM_RECRUITMENT_FILTER_SORT_OPTIONS: { value: TeamRecruitmentSort; label: string }[] = [
   { value: 'LATEST_DESC', label: '최신순' },
   { value: 'DEADLINE_ASC', label: '마감 임박순' },
 ];
 
-const CATEGORY_OPTIONS: { value: TeamRecruitmentCategory; label: string }[] = [
+export const TEAM_RECRUITMENT_FILTER_CATEGORY_OPTIONS: { value: TeamRecruitmentCategory; label: string }[] = [
   { value: 'CONTEST', label: '공모전' },
   { value: 'EXTERNAL_ACTIVITY', label: '대외활동' },
   { value: 'STUDY', label: '스터디' },
@@ -30,7 +30,10 @@ const CATEGORY_OPTIONS: { value: TeamRecruitmentCategory; label: string }[] = [
   { value: 'OTHER', label: '기타' },
 ];
 
-const MEETING_TYPE_OPTIONS: { value: TeamRecruitmentMeetingType; label: string }[] = [
+export const TEAM_RECRUITMENT_FILTER_MEETING_TYPE_OPTIONS: {
+  value: TeamRecruitmentMeetingType;
+  label: string;
+}[] = [
   { value: 'ONLINE', label: '온라인' },
   { value: 'OFFLINE', label: '오프라인' },
   { value: 'MIXED', label: '온·오프라인' },
@@ -99,7 +102,7 @@ function RecruitmentFilterPanelContent({
 
       return {
         ...prev,
-        categories: categories.length === CATEGORY_OPTIONS.length ? [] : categories,
+        categories: categories.length === TEAM_RECRUITMENT_FILTER_CATEGORY_OPTIONS.length ? [] : categories,
       };
     });
   };
@@ -126,7 +129,7 @@ function RecruitmentFilterPanelContent({
         <section className={styles.section}>
           <h3 className={styles.sectionTitle}>모집 상태</h3>
           <div className={styles.sectionBadges}>
-            {STATUS_OPTIONS.map((option) => (
+            {TEAM_RECRUITMENT_FILTER_STATUS_OPTIONS.map((option) => (
               <StatusBadge
                 key={option.value}
                 label={option.label}
@@ -140,7 +143,7 @@ function RecruitmentFilterPanelContent({
         <section className={styles.section}>
           <h3 className={styles.sectionTitle}>정렬</h3>
           <div className={styles.sectionBadges}>
-            {SORT_OPTIONS.map((option) => (
+            {TEAM_RECRUITMENT_FILTER_SORT_OPTIONS.map((option) => (
               <StatusBadge
                 key={option.value}
                 label={option.label}
@@ -159,7 +162,7 @@ function RecruitmentFilterPanelContent({
               isActive={draftFilter.categories.length === 0}
               onClick={() => setDraftFilter((prev) => ({ ...prev, categories: [] }))}
             />
-            {CATEGORY_OPTIONS.map((option) => (
+            {TEAM_RECRUITMENT_FILTER_CATEGORY_OPTIONS.map((option) => (
               <StatusBadge
                 key={option.value}
                 label={option.label}
@@ -178,7 +181,7 @@ function RecruitmentFilterPanelContent({
               isActive={draftFilter.meetingType === undefined}
               onClick={() => setDraftFilter((prev) => ({ ...prev, meetingType: undefined }))}
             />
-            {MEETING_TYPE_OPTIONS.map((option) => (
+            {TEAM_RECRUITMENT_FILTER_MEETING_TYPE_OPTIONS.map((option) => (
               <StatusBadge
                 key={option.value}
                 label={option.label}

--- a/src/pages/team/TeamListPage.module.scss
+++ b/src/pages/team/TeamListPage.module.scss
@@ -39,6 +39,35 @@
   }
 }
 
+.appliedFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0 22px 12px;
+}
+
+.appliedFilterChip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 30px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 40px;
+  background: #c358fc;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 160%;
+  cursor: pointer;
+
+  svg {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+  }
+}
+
 .totalCount {
   margin: 0;
   padding: 0 22px 12px;

--- a/src/pages/team/TeamListPage.module.scss
+++ b/src/pages/team/TeamListPage.module.scss
@@ -83,6 +83,18 @@
   padding: 0 22px;
 }
 
+.loadingState {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  color: #727272;
+  font-size: 14px;
+  line-height: 160%;
+  text-align: center;
+}
+
 .list {
   display: flex;
   flex-direction: column;

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -60,16 +60,13 @@ export default function TeamListPage() {
     categories: [],
   }));
 
-  const requestParams = useMemo<TeamRecruitmentInfiniteListRequest>(
-    () => ({
-      keyword: searchKeyword,
-      status: appliedFilter.status,
-      categories: appliedFilter.categories,
-      meetingType: appliedFilter.meetingType,
-      sort: appliedFilter.sort,
-    }),
-    [appliedFilter, searchKeyword],
-  );
+  const requestParams: TeamRecruitmentInfiniteListRequest = {
+    keyword: searchKeyword,
+    status: appliedFilter.status,
+    categories: appliedFilter.categories,
+    meetingType: appliedFilter.meetingType,
+    sort: appliedFilter.sort,
+  };
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
     teamQueries.infiniteList(requestParams, token),
@@ -85,7 +82,6 @@ export default function TeamListPage() {
 
     logger.actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: 'team_recruitment_search',
       value: keyword,
     });
@@ -95,7 +91,6 @@ export default function TeamListPage() {
   const handleFilterClick = () => {
     logger.actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: 'team_recruitment_filter',
       value: '필터',
     });
@@ -115,7 +110,6 @@ export default function TeamListPage() {
   const handleRecruitClick = () => {
     logger.actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: 'team_recruitment_recruit',
       value: '모집하기',
     });

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -186,7 +186,11 @@ export default function TeamListPage() {
         <p className={styles.totalCount}>전체({totalCount})</p>
 
         <div className={styles.content}>
-          {isLoading && <p>모집글을 불러오는 중입니다.</p>}
+          {isLoading && (
+            <p className={styles.loadingState} role="status">
+              모집글을 불러오는 중입니다.
+            </p>
+          )}
 
           {!isLoading && (isError || recruitments.length === 0) && (
             <div className={styles.empty}>

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -1,15 +1,24 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { teamQueries } from 'api/team/queries';
+import { teamQueries, type TeamRecruitmentInfiniteListRequest } from 'api/team/queries';
 import EmptyRecruitment from 'assets/svg/common/sleep-bbico.svg';
 import FilterIcon from 'assets/svg/Team/filter.svg';
 import PencilIcon from 'assets/svg/Team/pencil.svg';
+import XIcon from 'assets/svg/Team/x.svg';
 import Layout from 'components/layout';
 import RecruitmentCard from 'components/Team/components/RecruitmentCard';
+import RecruitmentFilterPanel, {
+  DEFAULT_TEAM_RECRUITMENT_FILTER,
+  TEAM_RECRUITMENT_FILTER_CATEGORY_OPTIONS,
+  TEAM_RECRUITMENT_FILTER_MEETING_TYPE_OPTIONS,
+  TEAM_RECRUITMENT_FILTER_SORT_OPTIONS,
+  TEAM_RECRUITMENT_FILTER_STATUS_OPTIONS,
+  type TeamRecruitmentFilter,
+} from 'components/Team/components/RecruitmentFilterPanel';
 import TeamListHeader from 'components/Team/components/TeamListHeader';
 import SearchBar from 'components/ui/SearchBar';
 import ROUTES from 'static/routes';
@@ -18,11 +27,24 @@ import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useInfiniteScroll from 'utils/hooks/ui/useInfiniteScroll';
 import { redirectToLogin } from 'utils/ts/auth';
-import showToast from 'utils/ts/showToast';
-import type { TeamRecruitmentListRequest } from 'api/team/entity';
 import styles from './TeamListPage.module.scss';
 
-type TeamListFilter = Omit<TeamRecruitmentListRequest, 'page' | 'limit'>;
+interface AppliedFilterChipProps {
+  label: string;
+  onRemove: () => void;
+}
+
+function AppliedFilterChip({ label, onRemove }: AppliedFilterChipProps) {
+  return (
+    <button type="button" className={styles.appliedFilterChip} onClick={onRemove} aria-label={`${label} 필터 해제`}>
+      <span>{label}</span>
+      <XIcon aria-hidden />
+    </button>
+  );
+}
+
+const getFilterLabel = <T extends string>(options: { value: T; label: string }[], value: T) =>
+  options.find((option) => option.value === value)?.label ?? value;
 
 export default function TeamListPage() {
   const router = useRouter();
@@ -31,10 +53,23 @@ export default function TeamListPage() {
   const logger = useLogger();
 
   const [searchTitle, setSearchTitle] = useState('');
-  const [requestParams, setRequestParams] = useState<TeamListFilter>({
-    status: 'ALL',
-    sort: 'LATEST_DESC',
-  });
+  const [searchKeyword, setSearchKeyword] = useState<string>();
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [appliedFilter, setAppliedFilter] = useState<TeamRecruitmentFilter>(() => ({
+    ...DEFAULT_TEAM_RECRUITMENT_FILTER,
+    categories: [],
+  }));
+
+  const requestParams = useMemo<TeamRecruitmentInfiniteListRequest>(
+    () => ({
+      ...(searchKeyword && { keyword: searchKeyword }),
+      status: appliedFilter.status,
+      ...(appliedFilter.categories.length > 0 && { categories: appliedFilter.categories }),
+      ...(appliedFilter.meetingType && { meetingType: appliedFilter.meetingType }),
+      sort: appliedFilter.sort,
+    }),
+    [appliedFilter, searchKeyword],
+  );
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
     teamQueries.infiniteList(requestParams, token),
@@ -49,14 +84,18 @@ export default function TeamListPage() {
     const keyword = searchTitle.trim();
 
     logger.actionEventClick({ team: 'CAMPUS', event_label: 'team_recruitment_search', value: keyword });
-
-    setRequestParams((previous) => ({
-      ...previous,
-      keyword: keyword || undefined,
-    }));
+    setSearchKeyword(keyword || undefined);
   };
 
-  const handleFilterClick = () => showToast('warning', '필터 기능은 준비 중입니다.');
+  const handleFilterApply = (filter: TeamRecruitmentFilter) => {
+    setAppliedFilter(filter);
+  };
+
+  const hasAppliedFilter =
+    appliedFilter.status !== DEFAULT_TEAM_RECRUITMENT_FILTER.status ||
+    appliedFilter.categories.length > 0 ||
+    appliedFilter.meetingType !== DEFAULT_TEAM_RECRUITMENT_FILTER.meetingType ||
+    appliedFilter.sort !== DEFAULT_TEAM_RECRUITMENT_FILTER.sort;
 
   const handleRecruitClick = () => {
     logger.actionEventClick({
@@ -94,11 +133,55 @@ export default function TeamListPage() {
             size="small"
           />
 
-          <button type="button" className={styles.filterButton} onClick={handleFilterClick}>
+          <button
+            type="button"
+            className={styles.filterButton}
+            onClick={() => setIsFilterOpen(true)}
+            aria-haspopup="dialog"
+            aria-expanded={isFilterOpen}
+          >
             <span className={styles.filterButton__label}>필터</span>
             <FilterIcon />
           </button>
         </div>
+
+        {hasAppliedFilter && (
+          <div className={styles.appliedFilters}>
+            {appliedFilter.status !== DEFAULT_TEAM_RECRUITMENT_FILTER.status && (
+              <AppliedFilterChip
+                label={getFilterLabel(TEAM_RECRUITMENT_FILTER_STATUS_OPTIONS, appliedFilter.status)}
+                onRemove={() => setAppliedFilter((previous) => ({ ...previous, status: 'ALL' }))}
+              />
+            )}
+
+            {appliedFilter.sort !== DEFAULT_TEAM_RECRUITMENT_FILTER.sort && (
+              <AppliedFilterChip
+                label={getFilterLabel(TEAM_RECRUITMENT_FILTER_SORT_OPTIONS, appliedFilter.sort)}
+                onRemove={() => setAppliedFilter((previous) => ({ ...previous, sort: 'LATEST_DESC' }))}
+              />
+            )}
+
+            {appliedFilter.categories.map((category) => (
+              <AppliedFilterChip
+                key={category}
+                label={getFilterLabel(TEAM_RECRUITMENT_FILTER_CATEGORY_OPTIONS, category)}
+                onRemove={() =>
+                  setAppliedFilter((previous) => ({
+                    ...previous,
+                    categories: previous.categories.filter((item) => item !== category),
+                  }))
+                }
+              />
+            ))}
+
+            {appliedFilter.meetingType && (
+              <AppliedFilterChip
+                label={getFilterLabel(TEAM_RECRUITMENT_FILTER_MEETING_TYPE_OPTIONS, appliedFilter.meetingType)}
+                onRemove={() => setAppliedFilter((previous) => ({ ...previous, meetingType: undefined }))}
+              />
+            )}
+          </div>
+        )}
 
         <p className={styles.totalCount}>전체({totalCount})</p>
 
@@ -136,6 +219,13 @@ export default function TeamListPage() {
           <PencilIcon />
         </button>
       </main>
+
+      <RecruitmentFilterPanel
+        isOpen={isFilterOpen}
+        onClose={() => setIsFilterOpen(false)}
+        filter={appliedFilter}
+        onApply={handleFilterApply}
+      />
     </>
   );
 }

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -83,8 +83,23 @@ export default function TeamListPage() {
   const handleSearch = () => {
     const keyword = searchTitle.trim();
 
-    logger.actionEventClick({ team: 'CAMPUS', event_label: 'team_recruitment_search', value: keyword });
+    logger.actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: 'team_recruitment_search',
+      value: keyword,
+    });
     setSearchKeyword(keyword || undefined);
+  };
+
+  const handleFilterClick = () => {
+    logger.actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: 'team_recruitment_filter',
+      value: '필터',
+    });
+    setIsFilterOpen(true);
   };
 
   const handleFilterApply = (filter: TeamRecruitmentFilter) => {
@@ -136,7 +151,7 @@ export default function TeamListPage() {
           <button
             type="button"
             className={styles.filterButton}
-            onClick={() => setIsFilterOpen(true)}
+            onClick={handleFilterClick}
             aria-haspopup="dialog"
             aria-expanded={isFilterOpen}
           >

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -62,10 +62,10 @@ export default function TeamListPage() {
 
   const requestParams = useMemo<TeamRecruitmentInfiniteListRequest>(
     () => ({
-      ...(searchKeyword && { keyword: searchKeyword }),
+      keyword: searchKeyword,
       status: appliedFilter.status,
-      ...(appliedFilter.categories.length > 0 && { categories: appliedFilter.categories }),
-      ...(appliedFilter.meetingType && { meetingType: appliedFilter.meetingType }),
+      categories: appliedFilter.categories,
+      meetingType: appliedFilter.meetingType,
       sort: appliedFilter.sort,
     }),
     [appliedFilter, searchKeyword],


### PR DESCRIPTION
- Close #1377

## What is this PR? 🔍

- 기능 : 팀원 모집글 검색 및 필터 기능 구현
- issue : #1377

## Changes 📝

- 검색 버튼과 Enter 입력을 통한 모집글 검색
- 검색어 공백 제거 및 빈 검색어 입력 시 검색 조건 해제
- 모집 상태, 정렬, 카테고리, 진행 방식 필터 구현
- 필터 임시값과 적용값 분리 및 적용·초기화 기능 구현
- 검색·필터 조건에 따른 재조회 및 무한 스크롤 연동
- 적용된 필터 표시와 검색·필터 결과 없음 UI 반영
- 검색 및 필터 로깅 추가


## ScreenShot 📷

<img width="505" height="841" alt="image" src="https://github.com/user-attachments/assets/ee1d95b6-9373-4c71-933c-4736915d6231" />

<img width="491" height="829" alt="image" src="https://github.com/user-attachments/assets/4aed6c86-f1fb-4680-8a7e-fe77fa73776d" />
<img width="491" height="836" alt="image" src="https://github.com/user-attachments/assets/a0d23152-7a88-4a05-9f1d-214f56f2435b" />

<img width="506" height="832" alt="image" src="https://github.com/user-attachments/assets/1fc7fa25-1f95-4692-a981-d027f277ee96" />

## Test CheckList ✅

- [X] 검색 버튼과 Enter 입력으로 검색되는지 확인
- [X] 앞뒤 공백 제거 및 빈 검색어 검색 시 keyword가 제거되는지 확인
- [X] 필터 적용과 초기화가 정상적으로 동작하는지 확인
- [X] 필터 변경 시 첫 페이지부터 다시 조회되는지 확인
- [X] 검색·필터 조건을 유지하며 무한 스크롤이 동작하는지 확인
- [X] 적용된 필터 제거 및 결과 없음 화면이 정상적으로 표시되는지 확인
- [ ] 검색·필터 로깅이 명세대로 발생하는지 확인
- [X] `corepack yarn lint`
- [X] `corepack yarn typecheck`

## Precaution

- 필터 닫기와 적용된 필터 제거 동작은 로깅 명세에 없어 별도 이벤트를 추가하지 않았습니다.
- mock 파일은 포함하지 않았습니다.

## ✔️ Please check if the PR fulfills these requirements

- [X] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [X] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팀 모집글 목록에서 모집 상태, 정렬, 카테고리, 진행 방식으로 필터링할 수 있습니다.
  * 적용된 필터를 칩으로 확인하고 개별 삭제할 수 있습니다.
  * 검색어와 필터 조건을 함께 사용해 모집글을 찾을 수 있습니다.
  * 필터 패널을 초기화하거나 적용하고, `Esc` 키로 닫을 수 있습니다.

* **개선**
  * 모집글을 불러오는 동안 안내 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->