### PR TITLE
fix: 팀원 모집 목록 hydration 오류 수정

### DIFF
--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -118,7 +118,6 @@ export default function TeamListPage() {
       event_label: 'team_recruitment_search',
       value: keyword,
     });
-
     setSearchKeyword(keyword || undefined);
   };
 
@@ -128,7 +127,6 @@ export default function TeamListPage() {
       event_label: 'team_recruitment_filter',
       value: '필터',
     });
-
     setIsFilterOpen(true);
   };
 
@@ -153,7 +151,6 @@ export default function TeamListPage() {
       redirectToLogin(router.asPath);
       return;
     }
-
     router.push(ROUTES.TeamRecruitmentNew());
   };
 
@@ -195,24 +192,14 @@ export default function TeamListPage() {
             {appliedFilter.status !== DEFAULT_TEAM_RECRUITMENT_FILTER.status && (
               <AppliedFilterChip
                 label={getFilterLabel(TEAM_RECRUITMENT_FILTER_STATUS_OPTIONS, appliedFilter.status)}
-                onRemove={() =>
-                  setAppliedFilter((previous) => ({
-                    ...previous,
-                    status: 'ALL',
-                  }))
-                }
+                onRemove={() => setAppliedFilter((previous) => ({ ...previous, status: 'ALL' }))}
               />
             )}
 
             {appliedFilter.sort !== DEFAULT_TEAM_RECRUITMENT_FILTER.sort && (
               <AppliedFilterChip
                 label={getFilterLabel(TEAM_RECRUITMENT_FILTER_SORT_OPTIONS, appliedFilter.sort)}
-                onRemove={() =>
-                  setAppliedFilter((previous) => ({
-                    ...previous,
-                    sort: 'LATEST_DESC',
-                  }))
-                }
+                onRemove={() => setAppliedFilter((previous) => ({ ...previous, sort: 'LATEST_DESC' }))}
               />
             )}
 
@@ -232,12 +219,7 @@ export default function TeamListPage() {
             {appliedFilter.meetingType && (
               <AppliedFilterChip
                 label={getFilterLabel(TEAM_RECRUITMENT_FILTER_MEETING_TYPE_OPTIONS, appliedFilter.meetingType)}
-                onRemove={() =>
-                  setAppliedFilter((previous) => ({
-                    ...previous,
-                    meetingType: undefined,
-                  }))
-                }
+                onRemove={() => setAppliedFilter((previous) => ({ ...previous, meetingType: undefined }))}
               />
             )}
           </div>
@@ -255,7 +237,6 @@ export default function TeamListPage() {
           {!isLoading && (isError || recruitments.length === 0) && (
             <div className={styles.empty}>
               <EmptyRecruitment />
-
               <p className={styles.empty__message}>
                 {isError ? '모집글을 불러오지 못했습니다.' : '조건에 맞는 모집글이 없어요.'}
               </p>

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
+import type { GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { dehydrate, QueryClient, useInfiniteQuery } from '@tanstack/react-query';
 
 import { teamQueries, type TeamRecruitmentInfiniteListRequest } from 'api/team/queries';
 import EmptyRecruitment from 'assets/svg/common/sleep-bbico.svg';
@@ -24,10 +25,11 @@ import SearchBar from 'components/ui/SearchBar';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
-import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useInfiniteScroll from 'utils/hooks/ui/useInfiniteScroll';
 import { redirectToLogin } from 'utils/ts/auth';
+import { parseServerSideParams } from 'utils/ts/parseServerSideParams';
+import { withCacheControl } from 'utils/ts/withCacheControl';
 import styles from './TeamListPage.module.scss';
 
 interface AppliedFilterChipProps {
@@ -47,28 +49,57 @@ function AppliedFilterChip({ label, onRemove }: AppliedFilterChipProps) {
 const getFilterLabel = <T extends string>(options: { value: T; label: string }[], value: T) =>
   options.find((option) => option.value === value)?.label ?? value;
 
+const INITIAL_FILTER: TeamRecruitmentFilter = {
+  ...DEFAULT_TEAM_RECRUITMENT_FILTER,
+  categories: [],
+};
+
+/**
+ * 서버와 클라이언트가 동일한 쿼리 키를 만들도록 요청 파라미터를 한 곳에서 생성한다.
+ *
+ * `undefined` 값은 넣지 않고 키 자체를 생략한다. `getServerSideProps`가 반환하는 props는
+ * JSON 직렬화가 가능해야 하는데, dehydrate된 쿼리 키에 `undefined`가 들어 있으면
+ * Next.js가 "`undefined` cannot be serialized as JSON" 런타임 에러를 낸다.
+ */
+const createRequestParams = (filter: TeamRecruitmentFilter, keyword?: string): TeamRecruitmentInfiniteListRequest => ({
+  status: filter.status,
+  categories: filter.categories,
+  sort: filter.sort,
+  ...(keyword ? { keyword } : {}),
+  ...(filter.meetingType ? { meetingType: filter.meetingType } : {}),
+});
+
+const INITIAL_REQUEST_PARAMS = createRequestParams(INITIAL_FILTER);
+
+export const getServerSideProps = withCacheControl(async (context: GetServerSidePropsContext, cacheControl) => {
+  const { token } = parseServerSideParams(context);
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchInfiniteQuery(teamQueries.infiniteList(INITIAL_REQUEST_PARAMS, token));
+
+  if (!token) {
+    cacheControl.enablePublicCache();
+  }
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
+});
+
 export default function TeamListPage() {
   const router = useRouter();
   const token = useTokenState();
   const isMobile = useMediaQuery();
-  const isMounted = useMount();
   const logger = useLogger();
 
   const [searchTitle, setSearchTitle] = useState('');
   const [searchKeyword, setSearchKeyword] = useState<string>();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [appliedFilter, setAppliedFilter] = useState<TeamRecruitmentFilter>(() => ({
-    ...DEFAULT_TEAM_RECRUITMENT_FILTER,
-    categories: [],
-  }));
+  const [appliedFilter, setAppliedFilter] = useState<TeamRecruitmentFilter>(() => ({ ...INITIAL_FILTER }));
 
-  const requestParams: TeamRecruitmentInfiniteListRequest = {
-    keyword: searchKeyword,
-    status: appliedFilter.status,
-    categories: appliedFilter.categories,
-    meetingType: appliedFilter.meetingType,
-    sort: appliedFilter.sort,
-  };
+  const requestParams = createRequestParams(appliedFilter, searchKeyword);
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
     teamQueries.infiniteList(requestParams, token),
@@ -76,7 +107,6 @@ export default function TeamListPage() {
 
   const recruitments = data?.pages.flatMap((page) => page.recruitments) ?? [];
   const totalCount = data?.pages[0]?.total_count ?? 0;
-  const isInitialLoading = !isMounted || isLoading;
 
   const scrollTriggerRef = useInfiniteScroll(fetchNextPage, hasNextPage, isFetchingNextPage);
 
@@ -88,6 +118,7 @@ export default function TeamListPage() {
       event_label: 'team_recruitment_search',
       value: keyword,
     });
+
     setSearchKeyword(keyword || undefined);
   };
 
@@ -97,6 +128,7 @@ export default function TeamListPage() {
       event_label: 'team_recruitment_filter',
       value: '필터',
     });
+
     setIsFilterOpen(true);
   };
 
@@ -121,6 +153,7 @@ export default function TeamListPage() {
       redirectToLogin(router.asPath);
       return;
     }
+
     router.push(ROUTES.TeamRecruitmentNew());
   };
 
@@ -162,14 +195,24 @@ export default function TeamListPage() {
             {appliedFilter.status !== DEFAULT_TEAM_RECRUITMENT_FILTER.status && (
               <AppliedFilterChip
                 label={getFilterLabel(TEAM_RECRUITMENT_FILTER_STATUS_OPTIONS, appliedFilter.status)}
-                onRemove={() => setAppliedFilter((previous) => ({ ...previous, status: 'ALL' }))}
+                onRemove={() =>
+                  setAppliedFilter((previous) => ({
+                    ...previous,
+                    status: 'ALL',
+                  }))
+                }
               />
             )}
 
             {appliedFilter.sort !== DEFAULT_TEAM_RECRUITMENT_FILTER.sort && (
               <AppliedFilterChip
                 label={getFilterLabel(TEAM_RECRUITMENT_FILTER_SORT_OPTIONS, appliedFilter.sort)}
-                onRemove={() => setAppliedFilter((previous) => ({ ...previous, sort: 'LATEST_DESC' }))}
+                onRemove={() =>
+                  setAppliedFilter((previous) => ({
+                    ...previous,
+                    sort: 'LATEST_DESC',
+                  }))
+                }
               />
             )}
 
@@ -189,31 +232,37 @@ export default function TeamListPage() {
             {appliedFilter.meetingType && (
               <AppliedFilterChip
                 label={getFilterLabel(TEAM_RECRUITMENT_FILTER_MEETING_TYPE_OPTIONS, appliedFilter.meetingType)}
-                onRemove={() => setAppliedFilter((previous) => ({ ...previous, meetingType: undefined }))}
+                onRemove={() =>
+                  setAppliedFilter((previous) => ({
+                    ...previous,
+                    meetingType: undefined,
+                  }))
+                }
               />
             )}
           </div>
         )}
 
-        <p className={styles.totalCount}>전체({isMounted ? totalCount : 0})</p>
+        <p className={styles.totalCount}>전체({totalCount})</p>
 
         <div className={styles.content}>
-          {isInitialLoading && (
+          {isLoading && (
             <p className={styles.loadingState} role="status">
               모집글을 불러오는 중입니다.
             </p>
           )}
 
-          {!isInitialLoading && (isError || recruitments.length === 0) && (
+          {!isLoading && (isError || recruitments.length === 0) && (
             <div className={styles.empty}>
               <EmptyRecruitment />
+
               <p className={styles.empty__message}>
                 {isError ? '모집글을 불러오지 못했습니다.' : '조건에 맞는 모집글이 없어요.'}
               </p>
             </div>
           )}
 
-          {!isInitialLoading && !isError && recruitments.length > 0 && (
+          {!isLoading && !isError && recruitments.length > 0 && (
             <div className={styles.list}>
               {recruitments.map((recruitment) => (
                 <RecruitmentCard

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -24,6 +24,7 @@ import SearchBar from 'components/ui/SearchBar';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
+import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useInfiniteScroll from 'utils/hooks/ui/useInfiniteScroll';
 import { redirectToLogin } from 'utils/ts/auth';
@@ -50,6 +51,7 @@ export default function TeamListPage() {
   const router = useRouter();
   const token = useTokenState();
   const isMobile = useMediaQuery();
+  const isMounted = useMount();
   const logger = useLogger();
 
   const [searchTitle, setSearchTitle] = useState('');
@@ -74,6 +76,7 @@ export default function TeamListPage() {
 
   const recruitments = data?.pages.flatMap((page) => page.recruitments) ?? [];
   const totalCount = data?.pages[0]?.total_count ?? 0;
+  const isInitialLoading = !isMounted || isLoading;
 
   const scrollTriggerRef = useInfiniteScroll(fetchNextPage, hasNextPage, isFetchingNextPage);
 
@@ -192,16 +195,16 @@ export default function TeamListPage() {
           </div>
         )}
 
-        <p className={styles.totalCount}>전체({totalCount})</p>
+        <p className={styles.totalCount}>전체({isMounted ? totalCount : 0})</p>
 
         <div className={styles.content}>
-          {isLoading && (
+          {isInitialLoading && (
             <p className={styles.loadingState} role="status">
               모집글을 불러오는 중입니다.
             </p>
           )}
 
-          {!isLoading && (isError || recruitments.length === 0) && (
+          {!isInitialLoading && (isError || recruitments.length === 0) && (
             <div className={styles.empty}>
               <EmptyRecruitment />
               <p className={styles.empty__message}>
@@ -210,7 +213,7 @@ export default function TeamListPage() {
             </div>
           )}
 
-          {!isLoading && !isError && recruitments.length > 0 && (
+          {!isInitialLoading && !isError && recruitments.length > 0 && (
             <div className={styles.list}>
               {recruitments.map((recruitment) => (
                 <RecruitmentCard


### PR DESCRIPTION
Close #1382

## What is this PR? 🔍

- 기능 : 팀원 모집 목록의 hydration 오류를 수정합니다.
- issue : #1382

## Changes 📝

- 서버와 클라이언트의 최초 렌더링을 동일한 로딩 상태로 통일했습니다.
- 마운트 전 전체 모집글 개수를 `0`으로 표시하도록 처리했습니다.
- 마운트 이후 API 상태에 따라 모집글 목록과 빈 화면을 렌더링하도록 수정했습니다.

## ScreenShot 📷

<img width="1477" height="1153" alt="image" src="https://github.com/user-attachments/assets/13143e3b-0e79-4211-8084-22e14b731d2a" />
<img width="2549" height="1274" alt="image" src="https://github.com/user-attachments/assets/a1c300b9-f815-477c-8400-2e76537488e4" />


## Test CheckList ✅

- [X] `/team` 직접 접근 시 hydration 오류가 발생하지 않는지 확인
- [X] `/team` 새로고침 시 hydration 오류가 발생하지 않는지 확인
- [X] 데이터 로딩 후 모집글 목록과 빈 상태가 정상적으로 표시되는지 확인

## Precaution

- React Query의 기존 조회 및 필터 동작은 변경하지 않았습니다.
- 운영 브랜치가 아닌 `develop`에서 발견된 오류를 수정합니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] This is a `fix` branch targeting `develop`, not a production hotfix branch.
- [x] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팀 페이지에서 초기 필터가 적용된 게시글 목록을 서버에서 미리 불러와, 페이지 진입 시 콘텐츠를 더 빠르게 확인할 수 있습니다.
  * 인증 없이도 공개 게시글 목록을 원활하게 불러옵니다.

* **버그 수정**
  * 팀 페이지의 초기 로딩 상태 표시를 개선했습니다.
  * 데이터 로딩 전 게시글 수가 일시적으로 잘못 표시되지 않도록 수정했습니다.
  * 빈 상태, 오류 상태 및 게시글 목록이 적절한 시점에 표시됩니다.
## Changes 📝

- `getServerSideProps`에서 팀원 모집 목록 데이터를 prefetch하도록 수정했습니다.
- React Query의 `dehydrate`를 통해 서버에서 조회한 데이터를 클라이언트에 전달하도록 수정했습니다.
- 서버와 클라이언트가 동일한 query key를 사용하도록 요청 파라미터 생성을 공통화했습니다.
- 기존 `useMount` 기반 hydration 우회 처리를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->