### PR TITLE
[캠퍼스] 팀원 모집 지원서 작성 화면 구현

### DIFF
--- a/src/api/team/APIDetail.ts
+++ b/src/api/team/APIDetail.ts
@@ -5,6 +5,8 @@ import {
   MyCreatedTeamRecruitmentListResponse,
   MyTeamRecruitmentApplicationListRequest,
   MyTeamRecruitmentApplicationListResponse,
+  PostTeamRecruitmentApplicationRequest,
+  PostTeamRecruitmentApplicationResponse,
   TeamRecruitmentApplicantDetailResponse,
   TeamRecruitmentDetailResponse,
   TeamChatDirectRoomResponse,
@@ -331,8 +333,6 @@ export class PostTeamRecruitmentDirectChatRoom<R extends TeamChatDirectRoomRespo
   }
 }
 
-// 204 No Content — 요청 바디·응답 바디 모두 없음.
-// PostTeamRecruitmentNotificationRead와 동일한 path-in-constructor 패턴을 따른다.
 export class PutCloseTeamRecruitment<R extends object> implements APIRequest<R> {
   method = HTTP_METHOD.PUT;
 
@@ -367,6 +367,29 @@ export class GetTeamRecruitmentApplicantDetail<R extends TeamRecruitmentApplican
     applicationId: string,
   ) {
     this.path = `/team-recruitments/${recruitmentId}/applications/${applicationId}`;
+  }
+}
+
+export class PostTeamRecruitmentApplication<R extends PostTeamRecruitmentApplicationResponse>
+  implements APIRequest<R>
+{
+  method = HTTP_METHOD.POST;
+
+  path: string;
+
+  response!: R;
+
+  auth = true;
+
+  data: PostTeamRecruitmentApplicationRequest;
+
+  constructor(
+    public authorization: string,
+    recruitmentId: number,
+    data: PostTeamRecruitmentApplicationRequest,
+  ) {
+    this.path = `/team-recruitments/${recruitmentId}/applications`;
+    this.data = data;
   }
 }
 

--- a/src/api/team/entity.ts
+++ b/src/api/team/entity.ts
@@ -288,6 +288,20 @@ export interface TeamRecruitmentApplicantDetailResponse extends APIResponse {
   can_open_direct_chat: boolean;
 }
 
+export interface PostTeamRecruitmentApplicationRequest {
+  role_id: number | null;
+  motivation: string;
+  availability: string;
+}
+
+export interface PostTeamRecruitmentApplicationResponse extends APIResponse {
+  application_id: number;
+  recruitment_id: number;
+  status: TeamApplicationStatus;
+  role: TeamApplicationRole;
+  created_at: string;
+}
+
 export type TeamRecruitmentApplicationDecision = Extract<TeamApplicationStatus, 'ACCEPTED' | 'REJECTED'>;
 
 export interface TeamRecruitmentApplicationStatusUpdateRequest {

--- a/src/api/team/index.ts
+++ b/src/api/team/index.ts
@@ -12,6 +12,7 @@ import {
   GetTeamRecruitmentApplicants,
   GetTeamRecruitmentList,
   GetTeamRecruitmentNotifications,
+  PostTeamRecruitmentApplication,
   PostTeamRecruitmentChatMessage,
   PostTeamRecruitmentDirectChatRoom,
   PostTeamRecruitmentNotificationRead,
@@ -28,6 +29,7 @@ export const getTeamRecruitmentList = APIClient.of(GetTeamRecruitmentList);
 export const getMyTeamRecruitmentApplications = APIClient.of(GetMyTeamRecruitmentApplications);
 export const getTeamRecruitmentApplicants = APIClient.of(GetTeamRecruitmentApplicants);
 export const getTeamRecruitmentApplicantDetail = APIClient.of(GetTeamRecruitmentApplicantDetail);
+export const submitTeamRecruitmentApplication = APIClient.of(PostTeamRecruitmentApplication);
 export const getTeamRecruitmentNotifications = APIClient.of(GetTeamRecruitmentNotifications);
 export const markTeamRecruitmentNotificationRead = APIClient.of(PostTeamRecruitmentNotificationRead);
 export const markAllTeamRecruitmentNotificationsRead = APIClient.of(PostTeamRecruitmentNotificationsMarkAllRead);

--- a/src/api/team/mutations.ts
+++ b/src/api/team/mutations.ts
@@ -3,6 +3,7 @@ import { mutationOptions, QueryClient } from '@tanstack/react-query';
 import showToast from 'utils/ts/showToast';
 import { teamQueryKeys } from './queries';
 import type {
+  PostTeamRecruitmentApplicationRequest,
   TeamChatMessageSendRequest,
   TeamRecruitmentApplicationDecision,
   TeamRecruitmentUpdateRequest,
@@ -14,6 +15,7 @@ import {
   deleteTeamRecruitment,
   markAllTeamRecruitmentNotificationsRead,
   markTeamRecruitmentNotificationRead,
+  submitTeamRecruitmentApplication,
   updateTeamRecruitmentApplicationStatus,
   updateTeamRecruitment,
   sendTeamRecruitmentChatMessage,
@@ -93,6 +95,24 @@ export const teamMutations = {
           showToast('error', error.message);
           return;
         }
+        sendClientError(error);
+      },
+    }),
+
+  submitApplication: (queryClient: QueryClient, token: string, recruitmentId: number) =>
+    mutationOptions({
+      mutationFn: (data: PostTeamRecruitmentApplicationRequest) =>
+        submitTeamRecruitmentApplication(token, recruitmentId, data),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: teamQueryKeys.myApplicationsRoot });
+        queryClient.invalidateQueries({ queryKey: teamQueryKeys.detailRoot });
+      },
+      onError: (error) => {
+        if (isKoinError(error)) {
+          showToast('error', error.message || '지원서 제출에 실패했습니다.');
+          return;
+        }
+        showToast('error', '지원서 제출에 실패했습니다.');
         sendClientError(error);
       },
     }),

--- a/src/components/Team/ProfilePage/components/DeptSelect/index.tsx
+++ b/src/components/Team/ProfilePage/components/DeptSelect/index.tsx
@@ -17,6 +17,7 @@ interface DeptSelectProps {
   id?: string;
   disabled?: boolean;
   ariaDescribedBy?: string;
+  className?: string;
 }
 
 export default function DeptSelect({
@@ -27,6 +28,7 @@ export default function DeptSelect({
   id,
   disabled = false,
   ariaDescribedBy,
+  className,
 }: DeptSelectProps) {
   const [isOpen, , closeMenu, triggerOpen] = useBooleanState(false);
   const { containerRef } = useOutsideClick({ onOutsideClick: closeMenu });
@@ -52,6 +54,7 @@ export default function DeptSelect({
           [styles.deptSelect__trigger]: true,
           [styles['deptSelect__trigger--opened']]: isOpen,
           [styles['deptSelect__trigger--selected']]: Boolean(selectedOption),
+          [className ?? '']: !!className,
         })}
         aria-expanded={isOpen}
         aria-haspopup="listbox"

--- a/src/components/Team/RecruitmentApplyPage/RecruitmentApplyPage.module.scss
+++ b/src/components/Team/RecruitmentApplyPage/RecruitmentApplyPage.module.scss
@@ -1,0 +1,51 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  min-height: 100dvh;
+  background: #f8f8fa;
+}
+
+.state {
+  padding: 24px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #727272;
+  text-align: center;
+}
+
+.blocked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 48px 24px;
+
+  &__message {
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #0b0b0d;
+    text-align: center;
+  }
+
+  &__link {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 48px;
+    border: 0.5px solid #b611f5;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #b611f5;
+    text-decoration: none;
+  }
+}

--- a/src/components/Team/RecruitmentApplyPage/Steps/ApplicationStep/ApplicationStep.module.scss
+++ b/src/components/Team/RecruitmentApplyPage/Steps/ApplicationStep/ApplicationStep.module.scss
@@ -1,0 +1,191 @@
+.step {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 24px;
+  width: 100%;
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0 24px;
+  }
+
+  &__footer {
+    display: flex;
+    gap: 12px;
+    box-sizing: border-box;
+    width: 100%;
+    margin-top: auto;
+    padding: 16px 24px 24px;
+  }
+
+  &__back {
+    flex: 1;
+    padding: 0 24px;
+    height: 48px;
+    border: 0.5px solid #b611f5;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #b611f5;
+    cursor: pointer;
+  }
+
+  &__submit {
+    flex: 1;
+    padding: 0 24px;
+    border: none;
+    height: 48px;
+    border-radius: 16px;
+    background: #b611f5;
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #fff;
+    cursor: pointer;
+
+    &:disabled {
+      background: #cacaca;
+      cursor: default;
+    }
+  }
+}
+
+.roles {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+
+  &__head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__label {
+    font-weight: 600;
+    line-height: 1.6;
+    color: #0b0b0d;
+  }
+
+  &__required {
+    margin-left: 2px;
+    color: #b611f5;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    list-style: none;
+  }
+
+  &__empty {
+    padding: 12px;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #727272;
+  }
+
+  &__error {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #b611f5;
+  }
+}
+
+.roleOption {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 12px;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  background: #fff;
+  cursor: pointer;
+
+  &--selected {
+    border-color: #b611f5;
+  }
+
+  &--closed {
+    background: #eee;
+    cursor: default;
+  }
+
+  &__input {
+    position: absolute;
+    width: 0;
+    height: 0;
+    margin: 0;
+    opacity: 0;
+  }
+
+  &__icon {
+    position: relative;
+    box-sizing: border-box;
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border: 1px solid #cacaca;
+    border-radius: 100px;
+  }
+
+  &__input:checked ~ &__icon {
+    border-color: #b611f5;
+  }
+
+  &__input:checked ~ &__icon::after {
+    width: 8px;
+    height: 8px;
+    border-radius: 100px;
+    background: #b611f5;
+    content: "";
+  }
+
+  &__input:focus-visible ~ &__icon {
+    outline: 2px solid #b611f5;
+    outline-offset: 2px;
+  }
+
+  &__input:disabled ~ &__name {
+    color: #cacaca;
+  }
+
+  &__name {
+    flex: 1;
+    min-width: 0;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #0b0b0d;
+    word-break: break-all;
+  }
+
+  &__count {
+    flex-shrink: 0;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #727272;
+  }
+}
+
+// Figma 기준 고정 96px (지원동기와 달리 자동 높이 조절 없음).
+.availabilityControl {
+  height: 96px;
+  resize: none;
+}

--- a/src/components/Team/RecruitmentApplyPage/Steps/ApplicationStep/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/Steps/ApplicationStep/index.tsx
@@ -1,0 +1,173 @@
+import { cn } from '@bcsdlab/utils';
+import FormField from 'components/Team/ProfilePage/components/FormField';
+import StepIndicator from 'components/Team/ProfilePage/components/StepIndicator';
+import {
+  APPLY_AVAILABILITY_MAX_LENGTH,
+  APPLY_MOTIVATION_MAX_LENGTH,
+} from 'components/Team/RecruitmentApplyPage/schema';
+import { APPLY_STEPS } from 'components/Team/RecruitmentApplyPage/types';
+import { Controller, useFormContext, useFormState, useWatch } from 'react-hook-form';
+import useLogger from 'utils/hooks/analytics/useLogger';
+import type { TeamRecruitmentRole } from 'api/team/entity';
+import type { ApplicationFormValues } from 'components/Team/RecruitmentApplyPage/types';
+import styles from './ApplicationStep.module.scss';
+
+interface ApplicationStepProps {
+  roles: TeamRecruitmentRole[];
+  onBack: () => void;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+}
+
+const LOGGING_TITLE = {
+  ROLE_SELECT: 'team_recruitment_apply_role_select',
+  SUBMIT: 'team_recruitment_apply_submit',
+};
+
+export default function ApplicationStep({ roles, onBack, onSubmit, isSubmitting }: ApplicationStepProps) {
+  const { actionEventClick } = useLogger();
+  const { control, register } = useFormContext<ApplicationFormValues>();
+  const { errors } = useFormState({ control });
+
+  const motivation = useWatch({ control, name: 'motivation' }) ?? '';
+  const availability = useWatch({ control, name: 'availability' }) ?? '';
+
+  const handleSubmitClick = () => {
+    actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: LOGGING_TITLE.SUBMIT,
+      value: '지원하기',
+    });
+    onSubmit();
+  };
+
+  return (
+    <div className={styles.step}>
+      <StepIndicator steps={APPLY_STEPS} currentIndex={1} />
+
+      <div className={styles.step__body}>
+        {roles.length > 0 && (
+          <div className={styles.roles}>
+            <div className={styles.roles__head}>
+              <span className={styles.roles__label}>
+                지원 역할<span className={styles.roles__required}>*</span>
+              </span>
+            </div>
+
+            <Controller
+              control={control}
+              name="roleId"
+              render={({ field }) => (
+                <ul className={styles.roles__list}>
+                  {roles.map((role) => (
+                    <li key={role.id}>
+                      <label
+                        className={cn({
+                          [styles.roleOption]: true,
+                          [styles['roleOption--selected']]: field.value === role.id,
+                          [styles['roleOption--closed']]: role.is_closed,
+                        })}
+                      >
+                        <input
+                          type="radio"
+                          className={styles.roleOption__input}
+                          name={field.name}
+                          value={role.id}
+                          checked={field.value === role.id}
+                          disabled={role.is_closed}
+                          onBlur={field.onBlur}
+                          onChange={() => {
+                            field.onChange(role.id);
+                            actionEventClick({
+                              team: 'CAMPUS',
+                              event_category: 'click',
+                              event_label: LOGGING_TITLE.ROLE_SELECT,
+                              value: role.name,
+                            });
+                          }}
+                        />
+                        <span className={styles.roleOption__icon} aria-hidden />
+                        <span className={styles.roleOption__name}>{role.name}</span>
+                        <span className={styles.roleOption__count}>
+                          {role.is_closed ? '모집 마감' : `${role.current_participants}/${role.max_participants}명`}
+                        </span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            />
+
+            {errors.roleId?.message && <p className={styles.roles__error}>{errors.roleId.message}</p>}
+          </div>
+        )}
+
+        <FormField
+          label="지원 동기"
+          required
+          maxLength={APPLY_MOTIVATION_MAX_LENGTH}
+          currentLength={motivation.length}
+          error={errors.motivation?.message}
+        >
+          {({ controlId, controlClassName, ariaDescribedBy, ariaInvalid }) => {
+            const { ref: motivationRef, ...motivationField } = register('motivation');
+            return (
+              <textarea
+                id={controlId}
+                className={controlClassName}
+                placeholder="지원 동기를 작성해주세요."
+                maxLength={APPLY_MOTIVATION_MAX_LENGTH}
+                rows={6}
+                aria-describedby={ariaDescribedBy}
+                aria-invalid={ariaInvalid}
+                ref={(el) => {
+                  motivationRef(el);
+                  if (el) {
+                    el.style.height = 'auto';
+                    el.style.height = `${el.scrollHeight}px`;
+                  }
+                }}
+                onInput={(e) => {
+                  const el = e.currentTarget;
+                  el.style.height = 'auto';
+                  el.style.height = `${el.scrollHeight}px`;
+                }}
+                {...motivationField}
+              />
+            );
+          }}
+        </FormField>
+
+        <FormField
+          label="참여 가능 시간"
+          required
+          maxLength={APPLY_AVAILABILITY_MAX_LENGTH}
+          currentLength={availability.length}
+          error={errors.availability?.message}
+        >
+          {({ controlId, controlClassName, ariaDescribedBy, ariaInvalid }) => (
+            <textarea
+              id={controlId}
+              className={cn({ [controlClassName]: true, [styles.availabilityControl]: true })}
+              placeholder="참여 가능한 시간을 작성해주세요."
+              maxLength={APPLY_AVAILABILITY_MAX_LENGTH}
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={ariaInvalid}
+              {...register('availability')}
+            />
+          )}
+        </FormField>
+      </div>
+
+      <div className={styles.step__footer}>
+        <button type="button" className={styles.step__back} onClick={onBack}>
+          이전
+        </button>
+        <button type="button" className={styles.step__submit} onClick={handleSubmitClick} disabled={isSubmitting}>
+          지원하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Team/RecruitmentApplyPage/Steps/BasicInfoStep/BasicInfoStep.module.scss
+++ b/src/components/Team/RecruitmentApplyPage/Steps/BasicInfoStep/BasicInfoStep.module.scss
@@ -1,0 +1,226 @@
+.step {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 24px;
+  width: 100%;
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0 24px;
+  }
+
+  &__footer {
+    box-sizing: border-box;
+    width: 100%;
+    margin-top: auto;
+    padding: 16px 24px 24px;
+  }
+
+  &__submit {
+    box-sizing: border-box;
+    width: 100%;
+    height: 48px;
+    border: none;
+    border-radius: 16px;
+    background: #b611f5;
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #fff;
+    cursor: pointer;
+
+    &:disabled {
+      background: #cacaca;
+      cursor: default;
+    }
+  }
+}
+
+.loadInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+
+  &__head {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  &__title {
+    font-weight: 600;
+    line-height: 1.6;
+    color: #000;
+
+    &--highlight {
+      color: #b611f5;
+    }
+  }
+
+  &__description {
+    font-size: 12px;
+    line-height: 1.6;
+    color: #727272;
+  }
+
+  &__button {
+    width: 100%;
+    height: 40px;
+    border: 0.5px solid #b611f5;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #b611f5;
+    cursor: pointer;
+
+    &:disabled {
+      border-color: #cacaca;
+      color: #cacaca;
+      cursor: default;
+    }
+  }
+}
+
+.activity {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+
+  &__head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__label {
+    font-weight: 600;
+    line-height: 1.6;
+  }
+
+  &__description {
+    font-size: 12px;
+    line-height: 1.6;
+    color: #727272;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    list-style: none;
+  }
+
+  &__add {
+    box-sizing: border-box;
+    width: 100%;
+    height: 40px;
+    border: 0.5px solid #b611f5;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #b611f5;
+    cursor: pointer;
+  }
+}
+
+.activityCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 12px;
+  border-radius: 16px;
+  background: #fff;
+
+  &__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  &__title {
+    flex: 1;
+    min-width: 0;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.6;
+    word-break: break-all;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__edit {
+    display: inline-flex;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    padding: 2px 8px;
+    border: 0.5px solid #b611f5;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 10px;
+    line-height: 1.6;
+    color: #b811f5;
+    cursor: pointer;
+  }
+
+  &__remove {
+    display: inline-flex;
+    flex-shrink: 0;
+    cursor: pointer;
+  }
+
+  &__meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 12px 8px;
+    margin: 0;
+
+    dt {
+      font-size: 12px;
+      line-height: 1.6;
+      color: #727272;
+      white-space: nowrap;
+    }
+
+    dd {
+      font-size: 12px;
+      line-height: 1.6;
+      word-break: break-all;
+    }
+  }
+}
+
+.grayInput {
+  color: #727272;
+
+  &::placeholder {
+    color: #727272;
+  }
+}
+
+// DeptSelect가 선택된 값에 색을 진하게 덮어써서 !important로 강제한다.
+.grayDropdown {
+  color: #727272 !important;
+}
+
+// 기존 프로필 프리필(reset())은 onInput을 안 거쳐서 자동 높이 조절 JS가 안 붙는다.
+// min-height로 여유를 둬서 긴 자기소개가 프리필돼도 잘려 보이지 않게 한다.
+.introductionControl {
+  min-height: 200px;
+}

--- a/src/components/Team/RecruitmentApplyPage/Steps/BasicInfoStep/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/Steps/BasicInfoStep/index.tsx
@@ -1,0 +1,368 @@
+import { useState } from 'react';
+import { isKoinError, sendClientError } from '@bcsdlab/koin';
+import { cn } from '@bcsdlab/utils';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { getUserAcademicInfo, updateAcademicInfo } from 'api/auth';
+import { deptQueries } from 'api/dept/queries';
+import XIcon from 'assets/svg/Team/x-icon.svg';
+import DeptSelect from 'components/Team/ProfilePage/components/DeptSelect';
+import FormField from 'components/Team/ProfilePage/components/FormField';
+import StepIndicator from 'components/Team/ProfilePage/components/StepIndicator';
+import ActivityHistoryModal from 'components/Team/RecruitmentApplyPage/components/ActivityHistoryModal';
+import SkillTagInput from 'components/Team/RecruitmentApplyPage/components/SkillTagInput';
+import {
+  APPLY_INTRODUCTION_MAX_LENGTH,
+  APPLY_NICKNAME_MAX_LENGTH,
+} from 'components/Team/RecruitmentApplyPage/schema';
+import { APPLY_STEPS } from 'components/Team/RecruitmentApplyPage/types';
+import { Controller, useFieldArray, useFormContext, useFormState, useWatch } from 'react-hook-form';
+import useLogger from 'utils/hooks/analytics/useLogger';
+import useTokenState from 'utils/hooks/state/useTokenState';
+import showToast from 'utils/ts/showToast';
+import type { ApplicationFormValues, ApplyActivityValue } from 'components/Team/RecruitmentApplyPage/types';
+import styles from './BasicInfoStep.module.scss';
+
+interface BasicInfoStepProps {
+  onNext: () => void;
+}
+
+const LOGGING_TITLE = {
+  LOAD_USER_INFO: 'team_recruitment_apply_load',
+  MAJOR_SELECT: 'team_recruitment_apply_major_select',
+  SKILL_ADD: 'team_recruitment_apply_skill_add',
+  ACTIVITY_ADD: 'team_recruitment_apply_activity_add',
+  ACTIVITY_MODIFY: 'team_recruitment_apply_activity_modify',
+  NEXT: 'team_recruitment_apply_next',
+};
+
+type ActivityModalState = { mode: 'create' } | { mode: 'edit'; index: number };
+
+export default function BasicInfoStep({ onNext }: BasicInfoStepProps) {
+  const token = useTokenState();
+  const { actionEventClick } = useLogger();
+  const { control, register, setValue, trigger, getValues } = useFormContext<ApplicationFormValues>();
+  const { errors } = useFormState({ control });
+  const [activityModal, setActivityModal] = useState<ActivityModalState | null>(null);
+
+  const nickname = useWatch({ control, name: 'nickname' }) ?? '';
+  const introduction = useWatch({ control, name: 'introduction' }) ?? '';
+  const activities = useWatch({ control, name: 'activities' }) ?? [];
+  const { fields, append, remove, update } = useFieldArray({ control, name: 'activities' });
+
+  const { data: deptList } = useSuspenseQuery(deptQueries.list());
+  const deptOptionList = deptList.map((dept) => ({ label: dept.name, value: dept.name }));
+
+  const { mutate: loadUserInfo, isPending } = useMutation({
+    mutationFn: () => getUserAcademicInfo(token),
+    onSuccess: (data) => {
+      setValue('nickname', data.nickname ?? '', { shouldValidate: true });
+      setValue('studentNumber', data.student_number ?? '', { shouldValidate: true });
+
+      const isKnownDept = deptOptionList.some((option) => option.value === data.department);
+      if (isKnownDept) {
+        setValue('department', data.department, { shouldValidate: true });
+      }
+
+      showToast('success', '회원정보를 불러왔습니다.');
+    },
+    onError: (error) => {
+      if (isKoinError(error)) {
+        showToast('error', error.message || '회원정보를 불러오지 못했습니다.');
+        return;
+      }
+      showToast('error', '회원정보를 불러오지 못했습니다.');
+      sendClientError(error);
+    },
+  });
+
+  const handleLoadUserInfo = () => {
+    actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: LOGGING_TITLE.LOAD_USER_INFO,
+      value: '회원정보 불러오기',
+    });
+
+    if (!token) {
+      showToast('warning', '로그인 후 이용해주세요.');
+      return;
+    }
+    loadUserInfo();
+  };
+
+  const { mutate: saveAcademicInfo, isPending: isSaving } = useMutation({
+    mutationFn: (data: { department: string; studentNumber: string }) =>
+      updateAcademicInfo(token, { department: data.department, student_number: data.studentNumber }),
+    onSuccess: () => {
+      actionEventClick({ team: 'CAMPUS', event_category: 'click', event_label: LOGGING_TITLE.NEXT, value: '다음' });
+      onNext();
+    },
+    onError: (error) => {
+      if (isKoinError(error)) {
+        showToast('error', error.message || '학적 정보 수정에 실패했습니다.');
+        return;
+      }
+      showToast('error', '학적 정보 수정에 실패했습니다.');
+      sendClientError(error);
+    },
+  });
+
+  const handleAddActivity = () => {
+    actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: LOGGING_TITLE.ACTIVITY_ADD,
+      value: '활동 이력 추가',
+    });
+    setActivityModal({ mode: 'create' });
+  };
+
+  const handleEditActivity = (index: number) => {
+    actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: LOGGING_TITLE.ACTIVITY_MODIFY,
+      value: '수정',
+    });
+    setActivityModal({ mode: 'edit', index });
+  };
+
+  const handleActivitySubmit = (activity: ApplyActivityValue) => {
+    if (activityModal?.mode === 'edit') {
+      update(activityModal.index, activity);
+    } else {
+      append(activity);
+    }
+    setActivityModal(null);
+  };
+
+  const handleNext = async () => {
+    const isValid = await trigger([
+      'nickname',
+      'department',
+      'studentNumber',
+      'skills',
+      'activities',
+      'introduction',
+    ]);
+    if (!isValid) {
+      showToast('warning', '필수 항목을 모두 작성해주세요.');
+      return;
+    }
+
+    if (!token) {
+      showToast('warning', '로그인 후 이용해주세요.');
+      return;
+    }
+
+    const { department, studentNumber } = getValues();
+    saveAcademicInfo({ department, studentNumber });
+  };
+
+  return (
+    <div className={styles.step}>
+      <StepIndicator steps={APPLY_STEPS} currentIndex={0} />
+
+      <div className={styles.step__body}>
+        <div className={styles.loadInfo}>
+          <div className={styles.loadInfo__head}>
+            <span className={styles.loadInfo__title}>
+              <span className={styles['loadInfo__title--highlight']}>코인</span> 회원정보 불러오기
+            </span>
+            <span className={styles.loadInfo__description}>닉네임, 학과(학부), 학번</span>
+          </div>
+          <button type="button" className={styles.loadInfo__button} onClick={handleLoadUserInfo} disabled={isPending}>
+            회원정보 불러오기
+          </button>
+        </div>
+
+        <FormField
+          label="닉네임"
+          required
+          maxLength={APPLY_NICKNAME_MAX_LENGTH}
+          currentLength={nickname.length}
+          error={errors.nickname?.message}
+        >
+          {({ controlId, controlClassName, ariaDescribedBy, ariaInvalid }) => (
+            <input
+              id={controlId}
+              type="text"
+              className={cn({ [controlClassName]: true, [styles.grayInput]: true })}
+              placeholder="닉네임을 입력해주세요."
+              maxLength={APPLY_NICKNAME_MAX_LENGTH}
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={ariaInvalid}
+              {...register('nickname')}
+            />
+          )}
+        </FormField>
+
+        <FormField label="학과 · 학부" required error={errors.department?.message}>
+          {({ controlId, ariaDescribedBy }) => (
+            <Controller
+              control={control}
+              name="department"
+              render={({ field }) => (
+                <DeptSelect
+                  id={controlId}
+                  options={deptOptionList}
+                  value={field.value || null}
+                  placeholder="학과 · 학부를 선택해주세요."
+                  onChange={(event) => {
+                    field.onChange(event.target.value);
+                    actionEventClick({
+                      team: 'CAMPUS',
+                      event_category: 'click',
+                      event_label: LOGGING_TITLE.MAJOR_SELECT,
+                      value: event.target.value,
+                    });
+                  }}
+                  disabled={isSaving}
+                  ariaDescribedBy={ariaDescribedBy}
+                  className={styles.grayDropdown}
+                />
+              )}
+            />
+          )}
+        </FormField>
+
+        <FormField label="학번" required error={errors.studentNumber?.message}>
+          {({ controlId, controlClassName, ariaDescribedBy, ariaInvalid }) => (
+            <input
+              id={controlId}
+              type="text"
+              inputMode="numeric"
+              className={cn({ [controlClassName]: true, [styles.grayInput]: true })}
+              placeholder="학번을 작성해주세요."
+              maxLength={10}
+              disabled={isSaving}
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={ariaInvalid}
+              {...register('studentNumber')}
+            />
+          )}
+        </FormField>
+
+        <SkillTagInput
+          label="보유기술 / 자격증"
+          description="기술 / 자격증은 항목별로 하나씩 작성해주세요."
+          addButtonLabel="기술 / 자격증 추가"
+          placeholder="기술 / 자격증을 작성해주세요."
+          onAppend={() =>
+            actionEventClick({
+              team: 'CAMPUS',
+              event_category: 'click',
+              event_label: LOGGING_TITLE.SKILL_ADD,
+              value: '기술 / 자격증 추가',
+            })
+          }
+        />
+
+        <div className={styles.activity}>
+          <div className={styles.activity__head}>
+            <span className={styles.activity__label}>활동 이력</span>
+            <p className={styles.activity__description}>공모전, 대외활동, 자치단체 등 활동 이력을 작성해주세요.</p>
+          </div>
+
+          {fields.length > 0 && (
+            <ul className={styles.activity__list}>
+              {fields.map((field, index) => {
+                const activity = activities[index];
+                if (!activity) return null;
+
+                return (
+                  <li key={field.id} className={styles.activityCard}>
+                    <div className={styles.activityCard__head}>
+                      <span className={styles.activityCard__title}>{activity.title}</span>
+                      <div className={styles.activityCard__actions}>
+                        <button
+                          type="button"
+                          className={styles.activityCard__edit}
+                          onClick={() => handleEditActivity(index)}
+                        >
+                          수정
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.activityCard__remove}
+                          onClick={() => remove(index)}
+                          aria-label="활동 이력 삭제"
+                        >
+                          <XIcon aria-hidden />
+                        </button>
+                      </div>
+                    </div>
+                    <dl className={styles.activityCard__meta}>
+                      <dt>활동 기간</dt>
+                      <dd>{`${activity.startDate} ~ ${activity.isOngoing ? '진행 중' : (activity.endDate ?? '')}`}</dd>
+                      <dt>활동 내용</dt>
+                      <dd>{activity.content}</dd>
+                    </dl>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <button type="button" className={styles.activity__add} onClick={handleAddActivity}>
+            활동 이력 추가
+          </button>
+        </div>
+
+        <FormField
+          label="자기소개"
+          required
+          maxLength={APPLY_INTRODUCTION_MAX_LENGTH}
+          currentLength={introduction.length}
+          error={errors.introduction?.message}
+        >
+          {({ controlId, controlClassName, ariaDescribedBy, ariaInvalid }) => {
+            const { ref: introductionRef, ...introductionField } = register('introduction');
+            return (
+              <textarea
+                id={controlId}
+                className={cn({
+                  [controlClassName]: true,
+                  [styles.grayInput]: true,
+                  [styles.introductionControl]: true,
+                })}
+                placeholder="자기소개를 작성해주세요."
+                maxLength={APPLY_INTRODUCTION_MAX_LENGTH}
+                rows={6}
+                aria-describedby={ariaDescribedBy}
+                aria-invalid={ariaInvalid}
+                ref={(el) => {
+                  introductionRef(el);
+                  if (el) {
+                    el.style.height = 'auto';
+                    el.style.height = `${el.scrollHeight}px`;
+                  }
+                }}
+                onInput={(e) => {
+                  const el = e.currentTarget;
+                  el.style.height = 'auto';
+                  el.style.height = `${el.scrollHeight}px`;
+                }}
+                {...introductionField}
+              />
+            );
+          }}
+        </FormField>
+      </div>
+
+      <div className={styles.step__footer}>
+        <button type="button" className={styles.step__submit} onClick={handleNext} disabled={isSaving}>
+          다음
+        </button>
+      </div>
+
+      {activityModal && (
+        <ActivityHistoryModal
+          initialValue={activityModal.mode === 'edit' ? (activities[activityModal.index] ?? null) : null}
+          onSubmit={handleActivitySubmit}
+          onClose={() => setActivityModal(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Team/RecruitmentApplyPage/components/ActivityHistoryModal/ActivityHistoryModal.module.scss
+++ b/src/components/Team/RecruitmentApplyPage/components/ActivityHistoryModal/ActivityHistoryModal.module.scss
@@ -1,0 +1,255 @@
+.background {
+  position: fixed;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #00000026;
+  z-index: 10;
+}
+
+.sheet {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+  max-width: 480px;
+  max-height: 90dvh;
+  padding: 24px;
+  border-radius: 24px 24px 0 0;
+  background: #fff;
+  overflow-y: auto;
+  z-index: 11;
+
+  &__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  &__title {
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #0b0b0d;
+  }
+
+  &__close {
+    display: inline-flex;
+    flex-shrink: 0;
+    cursor: pointer;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+  }
+
+  &__done {
+    box-sizing: border-box;
+    width: 100%;
+    height: 48px;
+    border: none;
+    border-radius: 16px;
+    background: #b611f5;
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #fff;
+    cursor: pointer;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+
+  &__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  &__label {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #0b0b0d;
+  }
+
+  &__required {
+    margin-left: 2px;
+    color: #b611f5;
+  }
+
+  &__counter {
+    font-size: 12px;
+    line-height: 1.6;
+    color: #727272;
+  }
+
+  &__control {
+    box-sizing: border-box;
+    width: 100%;
+    height: 35px;
+    padding: 8px 12px;
+    border: 0.5px solid #cacaca;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 12px;
+    line-height: 1.6;
+    outline: none;
+
+    &::placeholder {
+      color: #727272;
+    }
+
+    &:focus {
+      border-color: #b611f5;
+    }
+  }
+
+  &__textarea {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 106px;
+    padding: 12px;
+    border: 0.5px solid #cacaca;
+    border-radius: 16px;
+    background: #fff;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #0b0b0d;
+    outline: none;
+    resize: none;
+
+    &::placeholder {
+      color: #727272;
+    }
+
+    &:focus {
+      border-color: #b611f5;
+    }
+  }
+}
+
+.period {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+
+  &__inputs {
+    display: flex;
+    flex: 1 0 0;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  &__divider {
+    flex-shrink: 0;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: #727272;
+  }
+
+  &__control {
+    box-sizing: border-box;
+    flex: 1 0 0;
+    min-width: 0;
+    height: 35px;
+    padding: 8px 12px;
+    border: 0.5px solid #cacaca;
+    border-radius: 16px;
+    background: #fff;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #727272;
+    text-align: center;
+    cursor: pointer;
+    outline: none;
+
+    &:focus {
+      border-color: #b611f5;
+    }
+
+    &:disabled {
+      background: #f8f8fa;
+      color: #cacaca;
+      cursor: default;
+    }
+  }
+}
+
+.ongoing {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  line-height: 1.6;
+  cursor: pointer;
+
+  &__input {
+    position: absolute;
+    width: 0;
+    height: 0;
+    margin: 0;
+    opacity: 0;
+  }
+
+  &__icon {
+    position: relative;
+    box-sizing: border-box;
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+
+    &::before {
+      box-sizing: border-box;
+      width: 16px;
+      height: 16px;
+      border: 1px solid #cacaca;
+      border-radius: 100px;
+      content: "";
+    }
+  }
+
+  &__input:checked ~ &__icon::before {
+    border-color: #727272;
+  }
+
+  &__input:checked ~ &__icon::after {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 8px;
+    height: 8px;
+    border-radius: 100px;
+    background: #b611f5;
+    content: "";
+    transform: translate(-50%, -50%);
+  }
+
+  &__input:focus-visible ~ &__icon::before {
+    outline: 2px solid #b611f5;
+    outline-offset: 2px;
+  }
+}

--- a/src/components/Team/RecruitmentApplyPage/components/ActivityHistoryModal/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/components/ActivityHistoryModal/index.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useState } from 'react';
+import XIcon from 'assets/svg/Team/x-icon.svg';
+import {
+  APPLY_ACTIVITY_CONTENT_MAX_LENGTH,
+  APPLY_ACTIVITY_TITLE_MAX_LENGTH,
+} from 'components/Team/RecruitmentApplyPage/schema';
+import DatePickerModal from 'components/ui/DatePickerModal';
+import useLogger from 'utils/hooks/analytics/useLogger';
+import { useEscapeKeyDown } from 'utils/hooks/ui/useEscapeKeyDown';
+import { useOutsideClick } from 'utils/hooks/ui/useOutsideClick';
+import { getYyyyMmDd } from 'utils/ts/calendar';
+import showToast from 'utils/ts/showToast';
+import type { ApplyActivityValue } from 'components/Team/RecruitmentApplyPage/types';
+import styles from './ActivityHistoryModal.module.scss';
+
+interface ActivityHistoryModalProps {
+  /** 수정할 활동 이력. 신규 작성이면 null. */
+  initialValue: ApplyActivityValue | null;
+  onSubmit: (activity: ApplyActivityValue) => void;
+  onClose: () => void;
+}
+
+type ActivityDateField = 'startDate' | 'endDate';
+
+let activitySequence = 0;
+
+const createActivityId = () => {
+  activitySequence += 1;
+  return `activity-${Date.now()}-${activitySequence}`;
+};
+
+const createEmptyActivity = (): ApplyActivityValue => ({
+  id: createActivityId(),
+  title: '',
+  startDate: '',
+  endDate: null,
+  isOngoing: false,
+  content: '',
+});
+
+export default function ActivityHistoryModal({ initialValue, onSubmit, onClose }: ActivityHistoryModalProps) {
+  const { actionEventClick } = useLogger();
+  const [draft, setDraft] = useState<ApplyActivityValue>(() => initialValue ?? createEmptyActivity());
+  const [openDateField, setOpenDateField] = useState<ActivityDateField | null>(null);
+
+  const handleDismiss = useCallback(() => {
+    if (openDateField) return;
+    onClose();
+  }, [openDateField, onClose]);
+
+  const { containerRef, backgroundRef } = useOutsideClick({ onOutsideClick: handleDismiss });
+  useEscapeKeyDown({ onEscape: handleDismiss });
+
+  const handleToggleOngoing = (checked: boolean) => {
+    setDraft((prev) => ({ ...prev, isOngoing: checked, endDate: checked ? null : prev.endDate }));
+  };
+
+  const handleDateSelect = (field: ActivityDateField) => (date: Date) => {
+    setDraft((prev) => ({ ...prev, [field]: getYyyyMmDd(date) }));
+  };
+
+  const handleDone = () => {
+    if (!draft.title.trim()) {
+      showToast('warning', '활동명을 작성해주세요.');
+      return;
+    }
+    if (!draft.startDate) {
+      showToast('warning', '활동 시작일을 선택해주세요.');
+      return;
+    }
+    if (!draft.isOngoing && !draft.endDate) {
+      showToast('warning', '활동 종료일을 선택하거나 진행 중을 선택해주세요.');
+      return;
+    }
+    if (!draft.isOngoing && draft.endDate && draft.endDate < draft.startDate) {
+      showToast('warning', '활동 종료일은 시작일 이후로 선택해주세요.');
+      return;
+    }
+    if (!draft.content.trim()) {
+      showToast('warning', '활동 내용을 작성해주세요.');
+      return;
+    }
+
+    actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: 'team_recruitment_apply_activity_modify_complete',
+      value: '수정하기',
+    });
+    onSubmit(draft);
+  };
+
+  const selectedDate = openDateField ? draft[openDateField] : null;
+
+  return (
+    <div className={styles.background} ref={backgroundRef}>
+      <div className={styles.sheet} ref={containerRef} role="dialog" aria-modal="true" aria-label="활동 이력 작성">
+        <div className={styles.sheet__head}>
+          <span className={styles.sheet__title}>활동 이력</span>
+          <button type="button" className={styles.sheet__close} onClick={onClose} aria-label="닫기">
+            <XIcon aria-hidden />
+          </button>
+        </div>
+
+        <div className={styles.sheet__body}>
+          <div className={styles.field}>
+            <label className={styles.field__label} htmlFor="apply-activity-title">
+              활동명<span className={styles.field__required}>*</span>
+            </label>
+            <input
+              id="apply-activity-title"
+              type="text"
+              className={styles.field__control}
+              placeholder="활동명을 작성해주세요."
+              maxLength={APPLY_ACTIVITY_TITLE_MAX_LENGTH}
+              value={draft.title}
+              onChange={(event) => setDraft((prev) => ({ ...prev, title: event.target.value }))}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <span className={styles.field__label}>
+              활동기간<span className={styles.field__required}>*</span>
+            </span>
+            <div className={styles.period}>
+              <div className={styles.period__inputs}>
+                <button
+                  type="button"
+                  className={styles.period__control}
+                  onClick={() => setOpenDateField('startDate')}
+                >
+                  {draft.startDate ? draft.startDate.replaceAll('-', '.') : '시작일'}
+                </button>
+                <span className={styles.period__divider}>-</span>
+                <button
+                  type="button"
+                  className={styles.period__control}
+                  disabled={draft.isOngoing}
+                  onClick={() => setOpenDateField('endDate')}
+                >
+                  {draft.endDate ? draft.endDate.replaceAll('-', '.') : '종료일'}
+                </button>
+              </div>
+              <label className={styles.ongoing}>
+                <input
+                  type="checkbox"
+                  className={styles.ongoing__input}
+                  checked={draft.isOngoing}
+                  onChange={(event) => handleToggleOngoing(event.target.checked)}
+                />
+                <span className={styles.ongoing__icon} aria-hidden />
+                진행 중
+              </label>
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <div className={styles.field__row}>
+              <label className={styles.field__label} htmlFor="apply-activity-content">
+                활동내용<span className={styles.field__required}>*</span>
+              </label>
+              <span className={styles.field__counter}>
+                {draft.content.length}/{APPLY_ACTIVITY_CONTENT_MAX_LENGTH}
+              </span>
+            </div>
+            <textarea
+              id="apply-activity-content"
+              className={styles.field__textarea}
+              placeholder="활동 내용을 간단히 작성해주세요."
+              maxLength={APPLY_ACTIVITY_CONTENT_MAX_LENGTH}
+              rows={4}
+              value={draft.content}
+              onChange={(event) => setDraft((prev) => ({ ...prev, content: event.target.value }))}
+            />
+          </div>
+        </div>
+
+        <button type="button" className={styles.sheet__done} onClick={handleDone}>
+          {initialValue ? '수정하기' : '완료'}
+        </button>
+      </div>
+
+      {openDateField && (
+        <DatePickerModal
+          selectedDate={selectedDate ? new Date(`${selectedDate}T00:00:00`) : new Date()}
+          onChange={handleDateSelect(openDateField)}
+          onClose={() => setOpenDateField(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Team/RecruitmentApplyPage/components/SkillTagInput/SkillTagInput.module.scss
+++ b/src/components/Team/RecruitmentApplyPage/components/SkillTagInput/SkillTagInput.module.scss
@@ -1,0 +1,81 @@
+.tagInput {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+
+  &__head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__label {
+    font-weight: 600;
+    line-height: 1.6;
+  }
+
+  &__description {
+    font-size: 12px;
+    line-height: 1.6;
+    color: #727272;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    list-style: none;
+  }
+
+  &__tag {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid transparent;
+    border-radius: 16px;
+    background: #fff;
+
+    &:focus-within {
+      border-color: #b611f5;
+    }
+  }
+
+  &__remove {
+    display: inline-flex;
+    flex-shrink: 0;
+    cursor: pointer;
+  }
+
+  &__field {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #0b0b0d;
+
+    &::placeholder {
+      color: #727272;
+    }
+  }
+
+  &__add {
+    box-sizing: border-box;
+    width: 100%;
+    height: 40px;
+    border: 0.5px solid #b611f5;
+    border-radius: 16px;
+    background: #fff;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #b611f5;
+    cursor: pointer;
+  }
+}

--- a/src/components/Team/RecruitmentApplyPage/components/SkillTagInput/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/components/SkillTagInput/index.tsx
@@ -1,0 +1,66 @@
+import XIcon from 'assets/svg/Team/x-icon.svg';
+import { APPLY_SKILL_MAX_LENGTH } from 'components/Team/RecruitmentApplyPage/schema';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import type { ApplicationFormValues } from 'components/Team/RecruitmentApplyPage/types';
+import styles from './SkillTagInput.module.scss';
+
+interface SkillTagInputProps {
+  label: string;
+  description: string;
+  addButtonLabel: string;
+  placeholder: string;
+  onAppend?: () => void;
+}
+
+export default function SkillTagInput({
+  label,
+  description,
+  addButtonLabel,
+  placeholder,
+  onAppend,
+}: SkillTagInputProps) {
+  const { control, register } = useFormContext<ApplicationFormValues>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'skills' });
+
+  const handleAppend = () => {
+    append({ value: '' });
+    onAppend?.();
+  };
+
+  return (
+    <div className={styles.tagInput}>
+      <div className={styles.tagInput__head}>
+        <span className={styles.tagInput__label}>{label}</span>
+        <p className={styles.tagInput__description}>{description}</p>
+      </div>
+
+      {fields.length > 0 && (
+        <ul className={styles.tagInput__list}>
+          {fields.map((field, index) => (
+            <li key={field.id} className={styles.tagInput__tag}>
+              <input
+                type="text"
+                className={styles.tagInput__field}
+                placeholder={placeholder}
+                maxLength={APPLY_SKILL_MAX_LENGTH}
+                {...register(`skills.${index}.value` as const)}
+              />
+              <button
+                type="button"
+                className={styles.tagInput__remove}
+                onClick={() => remove(index)}
+                aria-label={`${label} ${index + 1} 삭제`}
+              >
+                <XIcon aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button type="button" className={styles.tagInput__add} onClick={handleAppend}>
+        {addButtonLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Team/RecruitmentApplyPage/hooks/useApplyStep.ts
+++ b/src/components/Team/RecruitmentApplyPage/hooks/useApplyStep.ts
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import { useRouter } from 'next/router';
+import ROUTES from 'static/routes';
+
+function useApplyStep<T extends string>(
+  steps: T[],
+  defaultStep: T,
+  buildStepHref: (step: T) => string,
+  postId: string,
+) {
+  const router = useRouter();
+  const { step } = router.query as { step?: T };
+
+  const currentStep = step && steps.includes(step) ? step : defaultStep;
+
+  const nextStep = useCallback(
+    (next: T, options?: { replace: boolean }) => {
+      const href = buildStepHref(next);
+
+      if (options?.replace) {
+        router.replace(href);
+        return;
+      }
+      router.push(href);
+    },
+    [router, buildStepHref],
+  );
+
+  const goBack = useCallback(() => {
+    const currentIndex = steps.indexOf(currentStep);
+
+    if (currentIndex > 0) {
+      router.back();
+      return;
+    }
+    router.push(ROUTES.TeamDetail({ postId }));
+  }, [steps, currentStep, router, postId]);
+
+  return {
+    currentStep,
+    nextStep,
+    goBack,
+    isReady: router.isReady,
+  };
+}
+
+export default useApplyStep;

--- a/src/components/Team/RecruitmentApplyPage/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/index.tsx
@@ -168,7 +168,7 @@ export default function RecruitmentApplyPage() {
 
     if (isGeneralRecruitment) {
       roleId = null;
-      preferredRole = existingProfile?.preferred_role ?? '전체';
+      preferredRole = existingProfile?.preferred_role ?? '';
     } else {
       const selectedRole = recruitment.roles.find((role) => role.id === pendingValues.roleId);
       if (!selectedRole) {

--- a/src/components/Team/RecruitmentApplyPage/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/index.tsx
@@ -1,0 +1,268 @@
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { teamMutations } from 'api/team/mutations';
+import { teamQueries } from 'api/team/queries';
+import {
+  teamRecruitmentProfileQueries,
+  useUpsertTeamRecruitmentProfileMutation,
+} from 'api/teamRecruitmentProfile/queries';
+import LoadingSpinner from 'components/feedback/LoadingSpinner';
+import SubmitConfirmModal from 'components/Team/components/SubmitConfirmModal';
+import useTeamAuthGuard from 'components/Team/hooks/useTeamAuthGuard';
+import useApplyStep from 'components/Team/RecruitmentApplyPage/hooks/useApplyStep';
+import { createApplicationFormSchema } from 'components/Team/RecruitmentApplyPage/schema';
+import SubPageHeader from 'components/ui/SubPageHeader';
+import { FormProvider, useForm } from 'react-hook-form';
+import ROUTES from 'static/routes';
+import useLogger from 'utils/hooks/analytics/useLogger';
+import useTokenState from 'utils/hooks/state/useTokenState';
+import showToast from 'utils/ts/showToast';
+import ApplicationStep from './Steps/ApplicationStep';
+import BasicInfoStep from './Steps/BasicInfoStep';
+import { APPLY_STEPS, type ApplicationFormValues, type ApplyStepTitle } from './types';
+import type { UpsertTeamRecruitmentProfileRequest } from 'api/teamRecruitmentProfile/entity';
+import styles from './RecruitmentApplyPage.module.scss';
+
+const LOGGING_TITLE = {
+  SUBMIT_CONFIRM: 'team_recruitment_apply_submit_confirm',
+  SUBMIT_CANCEL: 'team_recruitment_apply_submit_cancel',
+};
+
+const toProfileRequestBody = (
+  values: ApplicationFormValues,
+  preferredRole: string,
+): UpsertTeamRecruitmentProfileRequest => ({
+  profile_nickname: values.nickname.trim(),
+  preferred_role: preferredRole,
+  skills: values.skills.map((skill) => skill.value.trim()).filter((skill) => skill.length > 0),
+  activities: values.activities.map((activity) => ({
+    title: activity.title.trim(),
+    started_at: activity.startDate,
+    ended_at: activity.isOngoing ? null : activity.endDate || null,
+    is_ongoing: activity.isOngoing,
+    description: activity.content.trim(),
+  })),
+  self_introduction: values.introduction.trim(),
+});
+
+export default function RecruitmentApplyPage() {
+  const router = useRouter();
+  const token = useTokenState();
+  const queryClient = useQueryClient();
+  const { actionEventClick } = useLogger();
+  const { isAuthReady } = useTeamAuthGuard();
+  const [pendingValues, setPendingValues] = useState<ApplicationFormValues | null>(null);
+
+  const postId = Array.isArray(router.query.postId) ? router.query.postId[0] : router.query.postId;
+  const recruitmentId = Number(postId);
+  const isValidRecruitmentId = Number.isInteger(recruitmentId) && recruitmentId > 0;
+
+  const buildStepHref = useCallback(
+    (step: ApplyStepTitle) => ROUTES.TeamRecruitmentApply({ postId: String(postId), step }),
+    [postId],
+  );
+  const { currentStep, nextStep, goBack, isReady } = useApplyStep<ApplyStepTitle>(
+    APPLY_STEPS,
+    '기본 정보',
+    buildStepHref,
+    String(postId),
+  );
+
+  const {
+    data: recruitment,
+    isLoading: isRecruitmentLoading,
+    isError: isRecruitmentError,
+  } = useQuery({
+    ...teamQueries.detail(recruitmentId, token),
+    enabled: router.isReady && isValidRecruitmentId,
+  });
+
+  const { data: existingProfile } = useQuery({
+    ...teamRecruitmentProfileQueries.me(token),
+    enabled: !!token,
+  });
+
+  const canApply = !!recruitment && (recruitment.can_apply || recruitment.apply_block_reason === 'PROFILE_REQUIRED');
+
+  const isGeneralRecruitment = !!recruitment && recruitment.roles.length === 0;
+
+  const schema = useMemo(() => createApplicationFormSchema(isGeneralRecruitment), [isGeneralRecruitment]);
+
+  const methods = useForm<ApplicationFormValues>({
+    resolver: zodResolver(schema),
+    mode: 'onChange',
+    defaultValues: {
+      nickname: '',
+      department: '',
+      studentNumber: '',
+      skills: [],
+      activities: [],
+      introduction: '',
+      roleId: null,
+      motivation: '',
+      availability: '',
+    },
+  });
+
+  useEffect(() => {
+    if (!existingProfile || methods.formState.isDirty) return;
+
+    methods.reset({
+      ...methods.getValues(),
+      nickname: existingProfile.profile_nickname,
+      department: existingProfile.department,
+      studentNumber: existingProfile.student_number,
+      skills: existingProfile.skills.map((skill) => ({ value: skill })),
+      activities: existingProfile.activities.map((activity) => ({
+        id: String(activity.id),
+        title: activity.title,
+        startDate: activity.started_at,
+        endDate: activity.ended_at,
+        isOngoing: activity.is_ongoing,
+        content: activity.description,
+      })),
+      introduction: existingProfile.self_introduction,
+    });
+  }, [existingProfile, methods]);
+
+  const goToFirstStep = useCallback(() => {
+    nextStep('기본 정보', { replace: true });
+  }, [nextStep]);
+
+  useEffect(() => {
+    if (!isReady || currentStep !== '지원서 작성') return;
+
+    const { nickname, department, studentNumber } = methods.getValues();
+    if (!nickname || !department || !studentNumber) {
+      showToast('warning', '기본 정보를 먼저 입력해주세요.');
+      goToFirstStep();
+    }
+  }, [isReady, currentStep, methods, goToFirstStep]);
+
+  const { mutate: upsertProfile, isPending: isProfilePending } = useUpsertTeamRecruitmentProfileMutation();
+  const { mutate: submitApplication, isPending: isApplicationPending } = useMutation(
+    teamMutations.submitApplication(queryClient, token, recruitmentId),
+  );
+  const isSubmitting = isProfilePending || isApplicationPending;
+
+  const handleRequestSubmit = methods.handleSubmit(
+    (values) => setPendingValues(values),
+    (errors) => {
+      if (errors.nickname || errors.department || errors.studentNumber || errors.activities || errors.introduction) {
+        showToast('warning', '기본 정보를 먼저 입력해주세요.');
+        goToFirstStep();
+        return;
+      }
+      showToast('warning', '필수 항목을 모두 작성해주세요.');
+    },
+  );
+
+  const handleConfirmSubmit = () => {
+    if (!pendingValues || !recruitment) return;
+
+    let roleId: number | null;
+    let preferredRole: string;
+
+    if (isGeneralRecruitment) {
+      roleId = null;
+      preferredRole = existingProfile?.preferred_role ?? '전체';
+    } else {
+      const selectedRole = recruitment.roles.find((role) => role.id === pendingValues.roleId);
+      if (!selectedRole) {
+        showToast('warning', '지원 역할을 다시 선택해주세요.');
+        return;
+      }
+      roleId = selectedRole.id;
+      preferredRole = selectedRole.name;
+    }
+
+    actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: LOGGING_TITLE.SUBMIT_CONFIRM,
+      value: '지원하기',
+    });
+
+    upsertProfile(toProfileRequestBody(pendingValues, preferredRole), {
+      onSuccess: () => {
+        submitApplication(
+          {
+            role_id: roleId,
+            motivation: pendingValues.motivation.trim(),
+            availability: pendingValues.availability.trim(),
+          },
+          {
+            onSuccess: () => {
+              setPendingValues(null);
+              showToast('success', '지원서가 제출되었습니다.');
+              router.push(ROUTES.TeamMyApplications());
+            },
+          },
+        );
+      },
+    });
+  };
+
+  const handleCancelSubmit = () => {
+    actionEventClick({
+      team: 'CAMPUS',
+      event_category: 'click',
+      event_label: LOGGING_TITLE.SUBMIT_CANCEL,
+      value: '취소하기',
+    });
+    setPendingValues(null);
+  };
+
+  if (!isAuthReady) return null;
+
+  return (
+    <div className={styles.container}>
+      <SubPageHeader title="팀원 모집 지원" />
+
+      {(!router.isReady || isRecruitmentLoading) && <p className={styles.state}>모집글을 불러오는 중입니다.</p>}
+
+      {router.isReady && !recruitment && (!isValidRecruitmentId || isRecruitmentError) && (
+        <p className={styles.state}>모집글을 불러오지 못했습니다.</p>
+      )}
+
+      {recruitment && !canApply && (
+        <div className={styles.blocked}>
+          <p className={styles.blocked__message}>지원할 수 없는 모집글이에요.</p>
+          <Link className={styles.blocked__link} href={ROUTES.TeamDetail({ postId: String(postId) })}>
+            모집글로 돌아가기
+          </Link>
+        </div>
+      )}
+
+      {recruitment && canApply && (
+        <FormProvider {...methods}>
+          <Suspense fallback={<LoadingSpinner size="50px" />}>
+            {currentStep === '기본 정보' ? (
+              <BasicInfoStep onNext={() => nextStep('지원서 작성')} />
+            ) : (
+              <ApplicationStep
+                roles={recruitment.roles}
+                onBack={goBack}
+                onSubmit={handleRequestSubmit}
+                isSubmitting={isSubmitting}
+              />
+            )}
+          </Suspense>
+        </FormProvider>
+      )}
+
+      {pendingValues && (
+        <SubmitConfirmModal
+          message="지원서를 제출하시겠어요?"
+          confirmLabel="지원하기"
+          isSubmitting={isSubmitting}
+          onConfirm={handleConfirmSubmit}
+          onCancel={handleCancelSubmit}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Team/RecruitmentApplyPage/schema.ts
+++ b/src/components/Team/RecruitmentApplyPage/schema.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+
+export const APPLY_NICKNAME_MAX_LENGTH = 20;
+export const APPLY_SKILL_MAX_LENGTH = 30;
+export const APPLY_ACTIVITY_TITLE_MAX_LENGTH = 50;
+export const APPLY_ACTIVITY_CONTENT_MAX_LENGTH = 1000;
+export const APPLY_INTRODUCTION_MAX_LENGTH = 1000;
+export const APPLY_MOTIVATION_MAX_LENGTH = 1000;
+export const APPLY_AVAILABILITY_MAX_LENGTH = 100;
+
+export const applyActivitySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  startDate: z.string(),
+  endDate: z.string().nullable(),
+  isOngoing: z.boolean(),
+  content: z.string(),
+});
+
+const applicationFormBaseSchema = z.object({
+  nickname: z.string(),
+  department: z.string(),
+  studentNumber: z.string(),
+  skills: z.array(z.object({ value: z.string() })),
+  activities: z.array(applyActivitySchema),
+  introduction: z.string(),
+  roleId: z.number().nullable(),
+  motivation: z.string(),
+  availability: z.string(),
+});
+
+export const createApplicationFormSchema = (isGeneralRecruitment: boolean) =>
+  applicationFormBaseSchema.superRefine((data, ctx) => {
+    if (data.nickname.trim() === '') {
+      ctx.addIssue({ code: 'custom', path: ['nickname'], message: '닉네임을 입력해주세요.' });
+    } else if (data.nickname.trim().length > APPLY_NICKNAME_MAX_LENGTH) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['nickname'],
+        message: `닉네임은 ${APPLY_NICKNAME_MAX_LENGTH}자 이내로 입력해주세요.`,
+      });
+    }
+
+    if (data.department.trim() === '') {
+      ctx.addIssue({ code: 'custom', path: ['department'], message: '학과 · 학부를 선택해주세요.' });
+    }
+
+    if (data.studentNumber.trim() === '') {
+      ctx.addIssue({ code: 'custom', path: ['studentNumber'], message: '학번을 작성해주세요.' });
+    }
+
+    const skillValues = data.skills.map((skill) => skill.value.trim());
+    if (skillValues.some((value) => value === '')) {
+      ctx.addIssue({ code: 'custom', path: ['skills'], message: '빈 항목을 삭제하거나 내용을 입력해주세요.' });
+    } else if (new Set(skillValues).size !== skillValues.length) {
+      ctx.addIssue({ code: 'custom', path: ['skills'], message: '중복되지 않은 값을 입력해주세요.' });
+    }
+
+    data.activities.forEach((activity, index) => {
+      if (activity.title.trim() === '') {
+        ctx.addIssue({ code: 'custom', path: ['activities', index, 'title'], message: '활동명을 작성해주세요.' });
+      }
+      if (activity.content.trim() === '') {
+        ctx.addIssue({ code: 'custom', path: ['activities', index, 'content'], message: '활동 내용을 작성해주세요.' });
+      }
+      if (!activity.startDate) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['activities', index, 'startDate'],
+          message: '활동 시작일을 선택해주세요.',
+        });
+      }
+      if (!activity.isOngoing && !activity.endDate) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['activities', index, 'endDate'],
+          message: '활동 종료일을 선택하거나 진행 중을 선택해주세요.',
+        });
+      }
+      if (!activity.isOngoing && activity.endDate && activity.endDate < activity.startDate) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['activities', index, 'endDate'],
+          message: '활동 종료일은 시작일 이후로 선택해주세요.',
+        });
+      }
+    });
+
+    if (data.introduction.trim() === '') {
+      ctx.addIssue({ code: 'custom', path: ['introduction'], message: '자기소개를 작성해주세요.' });
+    } else if (data.introduction.length > APPLY_INTRODUCTION_MAX_LENGTH) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['introduction'],
+        message: `자기소개는 ${APPLY_INTRODUCTION_MAX_LENGTH}자 이내로 입력해주세요.`,
+      });
+    }
+
+    if (!isGeneralRecruitment && data.roleId === null) {
+      ctx.addIssue({ code: 'custom', path: ['roleId'], message: '지원 역할을 선택해주세요.' });
+    }
+
+    if (data.motivation.trim() === '') {
+      ctx.addIssue({ code: 'custom', path: ['motivation'], message: '지원 동기를 작성해주세요.' });
+    } else if (data.motivation.length > APPLY_MOTIVATION_MAX_LENGTH) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['motivation'],
+        message: `지원 동기는 ${APPLY_MOTIVATION_MAX_LENGTH}자 이내로 입력해주세요.`,
+      });
+    }
+
+    if (data.availability.trim() === '') {
+      ctx.addIssue({ code: 'custom', path: ['availability'], message: '참여 가능 시간을 작성해주세요.' });
+    } else if (data.availability.length > APPLY_AVAILABILITY_MAX_LENGTH) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['availability'],
+        message: `참여 가능 시간은 ${APPLY_AVAILABILITY_MAX_LENGTH}자 이내로 입력해주세요.`,
+      });
+    }
+  });
+
+export type ApplyActivityValue = z.infer<typeof applyActivitySchema>;
+
+export type ApplicationFormValues = z.infer<typeof applicationFormBaseSchema>;

--- a/src/components/Team/RecruitmentApplyPage/types.ts
+++ b/src/components/Team/RecruitmentApplyPage/types.ts
@@ -1,0 +1,5 @@
+export type { ApplicationFormValues, ApplyActivityValue } from 'components/Team/RecruitmentApplyPage/schema';
+
+export type ApplyStepTitle = '기본 정보' | '지원서 작성';
+
+export const APPLY_STEPS: ApplyStepTitle[] = ['기본 정보', '지원서 작성'];

--- a/src/components/Team/RecruitmentDetail.tsx
+++ b/src/components/Team/RecruitmentDetail.tsx
@@ -23,7 +23,7 @@ import styles from './RecruitmentDetail.module.scss';
 
 const formatCreatedAt = (createdAt: string) => formatRecruitmentDate(createdAt.split(' ')[0]);
 
-type PrimaryActionType = 'apply' | 'profile' | 'login' | 'chat' | 'manage' | 'disabled';
+type PrimaryActionType = 'apply' | 'login' | 'chat' | 'manage' | 'disabled';
 
 interface PrimaryAction {
   type: PrimaryActionType;
@@ -49,16 +49,12 @@ const getPrimaryAction = (recruitment: TeamRecruitmentDetailResponse): PrimaryAc
     return { type: 'disabled', label: '모집 마감' };
   }
 
-  if (recruitment.can_apply) {
+  if (recruitment.can_apply || recruitment.apply_block_reason === 'PROFILE_REQUIRED') {
     return { type: 'apply', label: '지원하기' };
   }
 
   if (recruitment.apply_block_reason === 'LOGIN_REQUIRED') {
     return { type: 'login', label: '지원하기' };
-  }
-
-  if (recruitment.apply_block_reason === 'PROFILE_REQUIRED') {
-    return { type: 'profile', label: '지원하기' };
   }
 
   if (recruitment.application || recruitment.apply_block_reason === 'ALREADY_APPLIED') {
@@ -93,7 +89,7 @@ function DetailContent({ recruitment }: DetailContentProps) {
         ];
 
   const handleActionClick = () => {
-    if (primaryAction.type === 'apply' || primaryAction.type === 'login' || primaryAction.type === 'profile') {
+    if (primaryAction.type === 'apply' || primaryAction.type === 'login') {
       logger.actionEventClick({
         team: 'CAMPUS',
         event_label: 'team_recruitment_post_apply',
@@ -111,11 +107,6 @@ function DetailContent({ recruitment }: DetailContentProps) {
 
     if (primaryAction.type === 'login') {
       openLoginModal();
-      return;
-    }
-
-    if (primaryAction.type === 'profile') {
-      router.push(ROUTES.TeamProfileCreate());
       return;
     }
 
@@ -324,9 +315,7 @@ export default function RecruitmentDetail() {
     <div className={styles.page}>
       <SubPageHeader
         title="팀원 모집"
-        rightAction={
-          data?.is_author ? <OwnerActionMenu onEdit={handleEdit} onDelete={handleDeleteClick} /> : undefined
-        }
+        rightAction={data?.is_author ? <OwnerActionMenu onEdit={handleEdit} onDelete={handleDeleteClick} /> : undefined}
       />
 
       {(!router.isReady || isLoading) && <p className={styles.state}>모집글을 불러오는 중입니다.</p>}

--- a/src/components/ui/SubPageHeader/SubPageHeader.module.scss
+++ b/src/components/ui/SubPageHeader/SubPageHeader.module.scss
@@ -32,6 +32,7 @@
     line-height: 1.6;
     color: #000;
     margin: 0;
+    text-align: center;
     text-overflow: ellipsis;
     white-space: nowrap;
 

--- a/src/pages/team/TeamListPage.module.scss
+++ b/src/pages/team/TeamListPage.module.scss
@@ -5,6 +5,16 @@
   background: #f8f8fa;
 }
 
+.title {
+  margin: 0;
+  padding: 20px 22px 0;
+  color: #000;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.6;
+  text-align: center;
+}
+
 .searchRow {
   display: flex;
   align-items: center;

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -131,7 +131,7 @@ export default function TeamListPage() {
       {isMobile && <TeamListHeader />}
 
       <main className={styles.page}>
-        {!isMobile && <h1>팀원모집</h1>}
+        {!isMobile && <h1 className={styles.title}>팀원모집</h1>}
 
         <div className={styles.searchRow}>
           <SearchBar

--- a/src/pages/team/recruitment/[postId]/apply/index.tsx
+++ b/src/pages/team/recruitment/[postId]/apply/index.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import Head from 'next/head';
+import Layout from 'components/layout';
+import RecruitmentApplyPage from 'components/Team/RecruitmentApplyPage';
+
+function TeamRecruitmentApplyPage() {
+  return (
+    <>
+      <Head>
+        <title>지원서 작성 | KOIN</title>
+        <meta name="description" content="팀원 모집글에 지원서를 작성할 수 있습니다." />
+      </Head>
+
+      <RecruitmentApplyPage />
+    </>
+  );
+}
+
+TeamRecruitmentApplyPage.getLayout = (page: ReactNode) => <Layout hideLayout>{page}</Layout>;
+
+export default TeamRecruitmentApplyPage;

--- a/src/static/routes.ts
+++ b/src/static/routes.ts
@@ -69,7 +69,8 @@ const ROUTES = {
   TeamRecruitmentSearch: () => '/team/recruitment/search',
   TeamRecruitmentNew: () => '/team/recruitment/new',
   TeamRecruitmentEdit: ({ postId }: ROUTESParams<'postId'>) => `/team/recruitment/${postId}/edit`,
-  TeamRecruitmentApply: ({ postId }: ROUTESParams<'postId'>) => `/team/recruitment/${postId}/apply`,
+  TeamRecruitmentApply: ({ postId, step }: ROUTESParams<'postId' | 'step'>) =>
+    `/team/recruitment/${postId}/apply${step ? `?step=${encodeURIComponent(step)}` : ''}`,
   TeamRecruitmentApplicants: ({ postId }: ROUTESParams<'postId'>) => `/team/recruitment/${postId}/applicants`,
   TeamRecruitmentApplicantDetail: ({ postId, applicantId }: ROUTESParams<'postId' | 'applicantId'>) =>
     `/team/recruitment/${postId}/applicants/${applicantId}`,


### PR DESCRIPTION
- Close #1376 

## What is this PR? 🔍

- 기능 : 팀원모집 지원서 작성화면과 api 연결을 구현했습니다.
- issue : #1376

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 지원서 작성 2단계 위저드 구현 (`RecruitmentApplyPage`) — Step1 기본 정보(닉네임/학과·학부/학번/보유기술/활동이력/자기소개, 기존 팀원모집 프로필 프리필), Step2 지원서 작성(역할 선택/지원 동기/참여 가능 시간)
- 지원서 제출 API 연동 (`POST /team-recruitments/{recruitmentId}/applications`) — entity/APIDetail/index/mutations 신규 추가
- 제출 흐름: Step1 데이터로 팀원모집 프로필 PUT → 성공 시 지원서 POST, PUT만 성공하고 POST가 실패하면 모달 유지 후 재시도 가능
- `GetTeamRecruitmentDetail` 응답의 `can_apply`/`apply_block_reason`으로 지원 가능 여부 가드 — 직접 URL 진입 시에도 차단 화면 노출
- `PROFILE_REQUIRED`(팀원모집 프로필 없음) 사용자는 별도 프로필 작성 페이지 대신 이 지원서 작성 화면으로 바로 진입하도록 `RecruitmentDetail.tsx` 라우팅 수정 (Step1이 프로필 생성을 함께 처리하므로 기존 우회 경로 제거)
- 활동 이력 작성 바텀시트, 보유기술/자격증 태그 입력 컴포넌트 신규 구현
- zod 검증: 필수 필드, 활동 이력 항목별 필수값·기간 검증, 보유기술 빈값/중복 검증, `roleId`는 ROLE_BASED 모집글에서만 필수(스키마 팩토리로 분기)
- 분석 로깅 11종 — 회원정보 불러오기/학과 선택/기술·자격증 추가/활동이력 추가·수정·완료/다음/역할선택/지원하기/최종확인/취소
- `SubPageHeader` 타이틀 가운데 정렬 누락 수정, `/team` 데스크톱 타이틀 정렬 수정
- Step1↔Step2 이동 시 브라우저 히스토리 중복 적재 수정 
## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] yarn lint
- [x] yarn build

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 팀 모집 공고에서 지원서를 작성하고 제출할 수 있습니다.
  * 기본 정보와 지원서 작성의 2단계 입력 흐름을 제공합니다.
  * 활동 이력과 기술·자격증을 추가, 수정, 삭제할 수 있습니다.
  * 역할 선택, 지원 동기, 참여 가능 시간을 입력할 수 있습니다.
* **개선 사항**
  * 입력값 검증과 오류 안내를 강화했습니다.
  * 모집이 마감된 역할은 선택할 수 없습니다.
  * 프로필이 없는 경우에도 지원 페이지에서 필요한 정보를 입력할 수 있습니다.
  * 지원 완료 후 관련 화면이 자동으로 갱신됩니다.
* **스타일**
  * 지원 페이지와 팀 모집 화면의 레이아웃 및 제목 정렬을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->