### PR TITLE
[캠퍼스] 지원자 관리 화면 데스크탑 UI 구현

### DIFF
--- a/src/components/Team/ApplicantManagement/ApplicantManagement.module.scss
+++ b/src/components/Team/ApplicantManagement/ApplicantManagement.module.scss
@@ -1,16 +1,57 @@
-.page {
-  display: flex;
-  flex-direction: column;
-  min-height: calc(100dvh - 56px);
+@use "src/utils/scss/media" as media;
+
+.mobileHeader {
+  display: none;
+
+  @include media.media-breakpoint(mobile) {
+    display: block;
+  }
+}
+
+.header {
   background: #f8f8fa;
 }
 
-.content {
+.page {
   display: flex;
-  flex: 1;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 100dvh;
+  padding: 64px 24px 96px;
+  background: #fff;
+
+  @include media.media-breakpoint(mobile) {
+    padding: 0;
+    min-height: calc(100dvh - 56px);
+    background: #f8f8fa;
+  }
+}
+
+.inner {
+  display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 20px;
+  gap: 60px;
+  width: 100%;
+  max-width: 1136px;
+
+  @include media.media-breakpoint(mobile) {
+    gap: 24px;
+    max-width: none;
+    padding: 20px;
+  }
+}
+
+.title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 500;
+  line-height: normal;
+  color: #175c8e;
+
+  @include media.media-breakpoint(mobile) {
+    display: none;
+  }
 }
 
 .error {
@@ -19,6 +60,34 @@
   font-size: 14px;
   line-height: 160%;
   text-align: center;
+}
+
+.chatButton {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  svg {
+    width: 35px;
+    height: 35px;
+
+    path {
+      stroke: #175c8e;
+    }
+
+    @include media.media-breakpoint(mobile) {
+      width: 24px;
+      height: 24px;
+
+      path {
+        stroke: #b611f5;
+      }
+    }
+  }
 }
 
 .recruitmentStatus {
@@ -32,7 +101,11 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 20px;
+
+  @include media.media-breakpoint(mobile) {
+    gap: 12px;
+  }
 
   &--empty {
     flex: 1;
@@ -42,13 +115,19 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    gap: 12px;
   }
 
   &__title {
     color: #000;
-    font-weight: 600;
-    font-size: 16px;
+    font-weight: 700;
+    font-size: 20px;
     line-height: 160%;
+
+    @include media.media-breakpoint(mobile) {
+      font-weight: 600;
+      font-size: 16px;
+    }
   }
 
   &__count {
@@ -60,7 +139,11 @@
   &__items {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 20px;
+
+    @include media.media-breakpoint(mobile) {
+      gap: 12px;
+    }
   }
 }
 
@@ -73,8 +156,13 @@
   gap: 12px;
 
   svg {
-    width: 95px;
-    height: 75px;
+    display: none;
+
+    @include media.media-breakpoint(mobile) {
+      display: block;
+      width: 95px;
+      height: 75px;
+    }
   }
 
   &__title {

--- a/src/components/Team/ApplicantManagement/components/ApplicantCard/ApplicantCard.module.scss
+++ b/src/components/Team/ApplicantManagement/components/ApplicantCard/ApplicantCard.module.scss
@@ -1,18 +1,27 @@
+@use "src/utils/scss/media" as media;
+
 .card {
   position: relative;
   display: flex;
   align-items: center;
   gap: 12px;
   width: 100%;
-  padding: 16px 20px;
+  padding: 24px;
   box-sizing: border-box;
+  border: 1px solid #e1e1e1;
   border-radius: 16px;
   background: #fff;
+
+  @include media.media-breakpoint(mobile) {
+    padding: 16px 20px;
+    border: none;
+  }
 
   &__overlayLink {
     position: absolute;
     inset: 0;
     z-index: 1;
+    border-radius: inherit;
   }
 
   &__avatar {
@@ -22,14 +31,32 @@
     align-items: center;
     justify-content: center;
     border: 0.5px solid #cacaca;
-    width: 45px;
-    height: 45px;
+    width: 50px;
+    height: 50px;
     border-radius: 300px;
     background: #fff;
 
     svg {
-      width: 28px;
-      height: 28px;
+      width: 35px;
+      height: 35px;
+
+      path {
+        stroke: #175c8e;
+      }
+
+      @include media.media-breakpoint(mobile) {
+        width: 28px;
+        height: 28px;
+
+        path {
+          stroke: #980ac9;
+        }
+      }
+    }
+
+    @include media.media-breakpoint(mobile) {
+      width: 45px;
+      height: 45px;
     }
   }
 
@@ -37,34 +64,62 @@
     display: flex;
     flex: 1 0 0;
     flex-direction: column;
-    gap: 4px;
+    gap: 8px;
     min-width: 0;
+
+    @include media.media-breakpoint(mobile) {
+      gap: 4px;
+    }
   }
 
   &__nameRow {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 8px;
+
+    @include media.media-breakpoint(mobile) {
+      justify-content: flex-start;
+    }
   }
 
   &__name {
     color: #0b0b0d;
     font-weight: 400;
-    font-size: 14px;
+    font-size: 16px;
     line-height: 160%;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 14px;
+    }
+  }
+
+  &__trailing {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 20px;
   }
 
   &__status {
     font-weight: 500;
-    font-size: 13px;
+    font-size: 14px;
     line-height: 160%;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 13px;
+    }
 
     &--pending {
       color: #727272;
     }
 
     &--accepted {
-      color: #980ac9;
+      color: #175c8e;
+
+      @include media.media-breakpoint(mobile) {
+        color: #980ac9;
+      }
     }
 
     &--rejected {
@@ -77,19 +132,45 @@
     z-index: 2;
     display: inline-flex;
     flex-shrink: 0;
+
+    svg {
+      width: 35px;
+      height: 35px;
+
+      path {
+        stroke: #175c8e;
+      }
+
+      @include media.media-breakpoint(mobile) {
+        width: 24px;
+        height: 24px;
+
+        path {
+          stroke: #b611f5;
+        }
+      }
+    }
   }
 
   &__meta {
     overflow: hidden;
     color: #727272;
-    font-size: 11px;
+    font-size: 12px;
     line-height: 160%;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    @include media.media-breakpoint(mobile) {
+      font-size: 11px;
+    }
   }
 
   &__role {
-    color: #b611f5;
+    color: #175c8e;
+
+    @include media.media-breakpoint(mobile) {
+      color: #b611f5;
+    }
   }
 
   &__chevron {

--- a/src/components/Team/ApplicantManagement/components/ApplicantCard/index.tsx
+++ b/src/components/Team/ApplicantManagement/components/ApplicantCard/index.tsx
@@ -9,6 +9,7 @@ import ProfileAvatarIcon from 'assets/svg/Team/profile-avatar-icon.svg';
 import formatApplicationStatus from 'components/Team/utils/formatApplicationStatus';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
+import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import type { TeamRecruitmentApplicant } from 'api/team/entity';
 import styles from './ApplicantCard.module.scss';
@@ -30,6 +31,7 @@ export default function ApplicantCard({ applicant, recruitmentId }: ApplicantCar
   const router = useRouter();
   const token = useTokenState();
   const logger = useLogger();
+  const isMobile = useMediaQuery();
   const { nickname, department, student_year: studentYear, role, status, can_open_direct_chat: canOpenDirectChat } =
     applicant;
 
@@ -58,6 +60,25 @@ export default function ApplicantCard({ applicant, recruitmentId }: ApplicantCar
     });
   };
 
+  const chatButton = canOpenDirectChat && (
+    <button
+      type="button"
+      className={styles.card__chat}
+      onClick={handleChatClick}
+      disabled={isCreatingChat}
+      aria-label="지원자와 채팅하기"
+    >
+      <ChatBubbleIcon aria-hidden />
+    </button>
+  );
+
+  const statusLabel = (
+    <span className={cn({ [styles.card__status]: true, [styles[STATUS_CLASS[status]]]: true })}>
+      {isMobile && '· '}
+      {formatApplicationStatus(status)}
+    </span>
+  );
+
   return (
     <div className={styles.card}>
       <Link
@@ -77,19 +98,17 @@ export default function ApplicantCard({ applicant, recruitmentId }: ApplicantCar
       <div className={styles.card__body}>
         <div className={styles.card__nameRow}>
           <span className={styles.card__name}>{nickname}님</span>
-          <span className={cn({ [styles.card__status]: true, [styles[STATUS_CLASS[status]]]: true })}>
-            · {formatApplicationStatus(status)}
-          </span>
-          {canOpenDirectChat && (
-            <button
-              type="button"
-              className={styles.card__chat}
-              onClick={handleChatClick}
-              disabled={isCreatingChat}
-              aria-label="지원자와 채팅하기"
-            >
-              <ChatBubbleIcon aria-hidden />
-            </button>
+
+          {isMobile ? (
+            <>
+              {statusLabel}
+              {chatButton}
+            </>
+          ) : (
+            <div className={styles.card__trailing}>
+              {chatButton}
+              {statusLabel}
+            </div>
           )}
         </div>
 
@@ -103,7 +122,7 @@ export default function ApplicantCard({ applicant, recruitmentId }: ApplicantCar
         </p>
       </div>
 
-      <ChevronRightIcon className={styles.card__chevron} aria-hidden />
+      {isMobile && <ChevronRightIcon className={styles.card__chevron} aria-hidden />}
     </div>
   );
 }

--- a/src/components/Team/ApplicantManagement/index.tsx
+++ b/src/components/Team/ApplicantManagement/index.tsx
@@ -9,6 +9,7 @@ import RecruitmentCard from 'components/Team/components/RecruitmentCard';
 import SubPageHeader from 'components/ui/SubPageHeader';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
+import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import ApplicantCard from './components/ApplicantCard';
 import styles from './ApplicantManagement.module.scss';
@@ -17,6 +18,7 @@ export default function ApplicantManagement() {
   const router = useRouter();
   const token = useTokenState();
   const logger = useLogger();
+  const isMobile = useMediaQuery();
   const { postId } = router.query;
   const recruitmentId = typeof postId === 'string' ? postId : '';
 
@@ -36,12 +38,27 @@ export default function ApplicantManagement() {
     router.push(ROUTES.TeamChat({ recruitmentId, chatRoomId: String(data.recruitment.team_chat_room_id) }));
   };
 
+  const groupChatButton = data?.recruitment.team_chat_available && (
+    <button
+      type="button"
+      className={styles.chatButton}
+      onClick={handleGroupChatClick}
+      aria-label="모집글 그룹 채팅방으로 이동"
+    >
+      <ChatBubbleIcon aria-hidden />
+    </button>
+  );
+
   return (
     <>
-      <SubPageHeader title="지원자 관리" />
+      <div className={styles.mobileHeader}>
+        <SubPageHeader title="지원자 관리" className={styles.header} />
+      </div>
 
-      <div className={styles.page}>
-        <div className={styles.content}>
+      <main className={styles.page}>
+        <div className={styles.inner}>
+          <h1 className={styles.title}>지원자 관리</h1>
+
           {isLoading && <LoadingSpinner size="50px" />}
 
           {!isLoading && (isError || !data) && <p className={styles.error}>지원자 목록을 불러오지 못했어요.</p>}
@@ -51,17 +68,15 @@ export default function ApplicantManagement() {
               <RecruitmentCard
                 recruitment={data.recruitment}
                 rightSlot={
-                  <span className={styles.recruitmentStatus}>
-                    {data.recruitment.status === 'RECRUITING' ? '모집 중' : '모집완료'}
-                  </span>
-                }
-                footerAction={
-                  data.recruitment.team_chat_available && (
-                    <button type="button" onClick={handleGroupChatClick} aria-label="모집글 그룹 채팅방으로 이동">
-                      <ChatBubbleIcon aria-hidden />
-                    </button>
+                  isMobile ? (
+                    <span className={styles.recruitmentStatus}>
+                      {data.recruitment.status === 'RECRUITING' ? '모집 중' : '모집완료'}
+                    </span>
+                  ) : (
+                    groupChatButton
                   )
                 }
+                footerAction={isMobile && groupChatButton}
               />
 
               <div className={cn({ [styles.list]: true, [styles['list--empty']]: data.applications.length === 0 })}>
@@ -91,7 +106,7 @@ export default function ApplicantManagement() {
             </>
           )}
         </div>
-      </div>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
- Close #1388

## What is this PR? 🔍

- 기능 : 지원자 관리 화면 데스크탑 UI
- issue : #1388

## Changes 📝

- 모집글 카드: 데스크탑에서 채팅 버튼을 상단 뱃지와 같은 행(rightSlot)에 배치, 모바일은 기존처럼 하단(footerAction)에 모집중/모집완료 뱃지와 함께 유지
- 지원자 카드: 데스크탑에서 이름/상태(+채팅 아이콘)를 좌우로 배치, 모바일은 기존 dot 상태 표기와 chevron 유지
- 지원자 카드 아바타 · 역할 라벨 · 채팅 아이콘 색상을 데스크탑 전용(#175C8E)으로 조정 (모바일은 기존 보라색 유지)
- 빈 상태(지원자 없음)에서 데스크탑은 일러스트 없이 타이틀/서브타이틀만 노출
- 기존 `RecruitmentCard`, `ApplicantCard`, `teamQueries.applicants` 등 데이터 로직은 그대로 재사용하고 `useMediaQuery` 분기로 뷰만 확장

## ScreenShot 📷

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->

## Test CheckList ✅

- [ ] 지원자 있음(승인/거절/대기) 상태에서 데스크탑 카드 레이아웃이 Figma와 일치하는지 확인
- [ ] 승인 상태에서만 채팅 아이콘이 노출되는지 확인
- [ ] role이 없는 지원자 카드에서 역할 라벨 없이 학과·학번만 표시되는지 확인
- [ ] 지원자 없음(빈 상태)에서 데스크탑은 일러스트 없이 텍스트만 노출되는지 확인
- [ ] 모바일 뷰포트(576px 이하)에서 기존 레이아웃이 그대로 유지되는지 확인

## Precaution

- Figma의 "역할 O"/"역할 X" 두 variant는 픽셀 단위로 동일한 디자인이라 하나의 레이아웃으로 구현했습니다.
- 실제 인증/데이터 없이 XHR 목업으로 데스크탑 레이아웃을 시각 검증했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 지원자 관리 페이지가 데스크톱과 모바일 화면에 맞게 반응형 레이아웃으로 개선되었습니다.
  * 지원자 카드의 정보 배치와 상태 표시가 화면 크기에 따라 최적화되었습니다.
  * 데스크톱에서는 카드와 여백, 글자 크기가 확대되어 가독성이 향상되었습니다.
  * 모바일에서는 채팅 버튼과 상태 정보가 더욱 쉽게 확인되도록 배치가 변경되었습니다.
  * 그룹 채팅 및 개별 채팅 진입 버튼의 표시 위치와 아이콘 스타일이 개선되었습니다.
  * 지원자가 없는 경우 모바일 화면에서 안내 아이콘이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->