### PR TITLE
[캠퍼스] 팀원 모집 모집글 작성 API 연동 및 지원자 관리 라우팅 버그 수정

### DIFF
--- a/src/api/team/APIDetail.ts
+++ b/src/api/team/APIDetail.ts
@@ -18,12 +18,32 @@ import {
   TeamRecruitmentApplicantListRequest,
   TeamRecruitmentApplicantListResponse,
   TeamRecruitmentApplicationStatusUpdateRequest,
+  TeamRecruitmentCreateResponse,
   TeamRecruitmentListRequest,
   TeamRecruitmentListResponse,
   TeamRecruitmentNotificationListRequest,
   TeamRecruitmentNotificationListResponse,
   TeamRecruitmentUpdateRequest,
 } from './entity';
+
+export class PostTeamRecruitment<R extends TeamRecruitmentCreateResponse> implements APIRequest<R> {
+  method = HTTP_METHOD.POST;
+
+  path = '/team-recruitments';
+
+  response!: R;
+
+  auth = true;
+
+  data: TeamRecruitmentUpdateRequest;
+
+  constructor(
+    public authorization: string,
+    data: TeamRecruitmentUpdateRequest,
+  ) {
+    this.data = data;
+  }
+}
 
 export class GetTeamRecruitmentDetail<R extends TeamRecruitmentDetailResponse> implements APIRequest<R> {
   method = HTTP_METHOD.GET;

--- a/src/api/team/entity.ts
+++ b/src/api/team/entity.ts
@@ -114,6 +114,10 @@ export type TeamRecruitmentUpdateRequest =
       roles: [];
     });
 
+export interface TeamRecruitmentCreateResponse extends APIResponse {
+  id: number;
+}
+
 export type TeamRecruitmentNotificationType =
   | 'NEW_APPLICATION'
   | 'APPLICATION_ACCEPTED'

--- a/src/api/team/index.ts
+++ b/src/api/team/index.ts
@@ -12,6 +12,7 @@ import {
   GetTeamRecruitmentApplicants,
   GetTeamRecruitmentList,
   GetTeamRecruitmentNotifications,
+  PostTeamRecruitment,
   PostTeamRecruitmentApplication,
   PostTeamRecruitmentChatMessage,
   PostTeamRecruitmentDirectChatRoom,
@@ -24,6 +25,7 @@ import {
 
 export const deleteTeamRecruitment = APIClient.of(DeleteTeamRecruitment);
 export const getTeamRecruitmentDetail = APIClient.of(GetTeamRecruitmentDetail);
+export const createTeamRecruitment = APIClient.of(PostTeamRecruitment);
 export const updateTeamRecruitment = APIClient.of(PutTeamRecruitment);
 export const getTeamRecruitmentList = APIClient.of(GetTeamRecruitmentList);
 export const getMyTeamRecruitmentApplications = APIClient.of(GetMyTeamRecruitmentApplications);

--- a/src/api/team/mutations.ts
+++ b/src/api/team/mutations.ts
@@ -9,6 +9,7 @@ import type {
   TeamRecruitmentUpdateRequest,
 } from './entity';
 import {
+  createTeamRecruitment,
   createTeamRecruitmentDirectChatRoom,
   closeTeamRecruitment,
   deleteAllTeamRecruitmentNotifications,
@@ -28,6 +29,15 @@ const invalidateNotifications = (queryClient: QueryClient) =>
   queryClient.invalidateQueries({ queryKey: teamQueryKeys.notificationsRoot });
 
 export const teamMutations = {
+  createRecruitment: (queryClient: QueryClient, token: string) =>
+    mutationOptions({
+      mutationFn: (data: TeamRecruitmentUpdateRequest) => createTeamRecruitment(token, data),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: teamQueryKeys.myCreatedRoot });
+        queryClient.invalidateQueries({ queryKey: teamQueryKeys.listRoot });
+      },
+    }),
+
   deleteRecruitment: (queryClient: QueryClient, token: string) =>
     mutationOptions({
       mutationFn: (recruitmentId: number) => deleteTeamRecruitment(token, recruitmentId),

--- a/src/components/Team/CreateTeamRecruitment/index.tsx
+++ b/src/components/Team/CreateTeamRecruitment/index.tsx
@@ -1,0 +1,34 @@
+import { useRouter } from 'next/router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { teamMutations } from 'api/team/mutations';
+import useTeamAuthGuard from 'components/Team/hooks/useTeamAuthGuard';
+import NewTeamRecruitment from 'components/Team/NewTeamRecruitment';
+import toRecruitmentRequestBody from 'components/Team/NewTeamRecruitment/toRecruitmentRequestBody';
+import ROUTES from 'static/routes';
+import useTokenState from 'utils/hooks/state/useTokenState';
+import showToast from 'utils/ts/showToast';
+import type { TeamRecruitmentFormValues } from 'components/Team/NewTeamRecruitment/schema';
+
+export default function CreateTeamRecruitment() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const token = useTokenState();
+  const { isAuthReady } = useTeamAuthGuard();
+  const { mutateAsync: createRecruitment } = useMutation(teamMutations.createRecruitment(queryClient, token));
+
+  const handleSubmit = async (values: TeamRecruitmentFormValues) => {
+    try {
+      const { id } = await createRecruitment(toRecruitmentRequestBody(values));
+      showToast('success', '모집글이 등록되었습니다.');
+      await router.replace(ROUTES.TeamDetail({ postId: String(id) }));
+    } catch (error) {
+      showToast('error', '모집글을 등록하지 못했어요. 다시 시도해 주세요.');
+      throw error;
+    }
+  };
+
+  if (!isAuthReady) return null;
+
+  return <NewTeamRecruitment onSubmit={handleSubmit} />;
+}

--- a/src/components/Team/EditTeamRecruitment/index.tsx
+++ b/src/components/Team/EditTeamRecruitment/index.tsx
@@ -4,39 +4,20 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { teamMutations } from 'api/team/mutations';
 import { teamQueries } from 'api/team/queries';
 import NewTeamRecruitment from 'components/Team/NewTeamRecruitment';
+import toRecruitmentRequestBody from 'components/Team/NewTeamRecruitment/toRecruitmentRequestBody';
 import { CATEGORY_LABEL } from 'components/Team/utils/recruitmentDisplay';
 import ROUTES from 'static/routes';
 import useTokenState from 'utils/hooks/state/useTokenState';
-import { getYyyyMmDd } from 'utils/ts/calendar';
 import showToast from 'utils/ts/showToast';
-import type {
-  TeamRecruitmentCategory,
-  TeamRecruitmentDetailResponse,
-  TeamRecruitmentMeetingType,
-  TeamRecruitmentUpdateRequest,
-} from 'api/team/entity';
+import type { TeamRecruitmentDetailResponse, TeamRecruitmentMeetingType } from 'api/team/entity';
 import type { TeamRecruitmentFormValues } from 'components/Team/NewTeamRecruitment/schema';
 import type { TeamRecruitmentProgressType } from 'components/Team/NewTeamRecruitment/types';
 import styles from './EditTeamRecruitment.module.scss';
-
-const CATEGORY_BY_LABEL: Record<string, TeamRecruitmentCategory> = {
-  공모전: 'CONTEST',
-  대외활동: 'EXTERNAL_ACTIVITY',
-  스터디: 'STUDY',
-  프로젝트: 'PROJECT',
-  기타: 'OTHER',
-};
 
 const PROGRESS_TYPE_BY_MEETING_TYPE: Record<TeamRecruitmentMeetingType, TeamRecruitmentProgressType> = {
   ONLINE: 'ONLINE',
   OFFLINE: 'OFFLINE',
   MIXED: 'HYBRID',
-};
-
-const MEETING_TYPE_BY_PROGRESS_TYPE: Record<TeamRecruitmentProgressType, TeamRecruitmentMeetingType> = {
-  ONLINE: 'ONLINE',
-  OFFLINE: 'OFFLINE',
-  HYBRID: 'MIXED',
 };
 
 const parseApiDate = (date: string) => {
@@ -63,49 +44,6 @@ const toFormValues = (recruitment: TeamRecruitmentDetailResponse): TeamRecruitme
   qualification: recruitment.qualification ?? '',
 });
 
-const toUpdateRequest = (values: TeamRecruitmentFormValues): TeamRecruitmentUpdateRequest => {
-  if (
-    !values.category ||
-    !values.progressType ||
-    !values.activityStartDate ||
-    !values.activityEndDate ||
-    !values.deadlineDate
-  ) {
-    throw new Error('필수 모집글 정보가 누락되었습니다.');
-  }
-
-  const common = {
-    category: CATEGORY_BY_LABEL[values.category],
-    title: values.title.trim(),
-    meeting_type: MEETING_TYPE_BY_PROGRESS_TYPE[values.progressType],
-    activity_start_date: getYyyyMmDd(values.activityStartDate),
-    activity_end_date: getYyyyMmDd(values.activityEndDate),
-    deadline_date: getYyyyMmDd(values.deadlineDate),
-    description: values.description.trim(),
-    related_url: values.relatedUrl.trim() || null,
-    qualification: values.qualification.trim() || null,
-  };
-
-  if (values.isRoleUnified) {
-    return {
-      ...common,
-      recruitment_type: 'GENERAL',
-      max_participants: values.unifiedMemberCount,
-      roles: [],
-    };
-  }
-
-  return {
-    ...common,
-    recruitment_type: 'ROLE_BASED',
-    roles: values.roles.map((role) => ({
-      ...(role.id !== undefined && { id: role.id }),
-      name: role.name.trim(),
-      max_participants: role.memberCount,
-    })),
-  };
-};
-
 export default function EditTeamRecruitment() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -123,7 +61,7 @@ export default function EditTeamRecruitment() {
 
   const handleSubmit = async (values: TeamRecruitmentFormValues) => {
     try {
-      await updateRecruitment(toUpdateRequest(values));
+      await updateRecruitment(toRecruitmentRequestBody(values));
       showToast('success', '모집글이 수정되었습니다.');
       await router.replace(ROUTES.TeamDetail({ postId: String(recruitmentId) }));
     } catch (error) {

--- a/src/components/Team/NewTeamRecruitment/index.tsx
+++ b/src/components/Team/NewTeamRecruitment/index.tsx
@@ -31,7 +31,7 @@ const PROGRESS_TYPE_ICON: Record<TeamRecruitmentProgressType, ComponentType> = {
 interface NewTeamRecruitmentProps {
   initialValues?: TeamRecruitmentFormValues;
   mode?: 'create' | 'edit';
-  onSubmit?: (values: TeamRecruitmentFormValues) => Promise<void>;
+  onSubmit: (values: TeamRecruitmentFormValues) => Promise<void>;
 }
 
 export default function NewTeamRecruitment({ initialValues, mode = 'create', onSubmit }: NewTeamRecruitmentProps) {
@@ -78,12 +78,6 @@ export default function NewTeamRecruitment({ initialValues, mode = 'create', onS
       event_label: isEditMode ? 'team_recruitment_post_edit_submit_confirm' : 'team_recruitment_recruit_submit_confirm',
       value: confirmLabel,
     });
-
-    if (!onSubmit) {
-      // TODO: 모집글 작성 담당 PR에서 작성 API를 연결한다.
-      closeConfirmModal();
-      return;
-    }
 
     setIsSubmitting(true);
     try {

--- a/src/components/Team/NewTeamRecruitment/toRecruitmentRequestBody.ts
+++ b/src/components/Team/NewTeamRecruitment/toRecruitmentRequestBody.ts
@@ -1,0 +1,61 @@
+import { getYyyyMmDd } from 'utils/ts/calendar';
+import type { TeamRecruitmentFormValues } from './schema';
+import type { TeamRecruitmentProgressType } from './types';
+import type { TeamRecruitmentCategory, TeamRecruitmentMeetingType, TeamRecruitmentUpdateRequest } from 'api/team/entity';
+
+export const CATEGORY_BY_LABEL: Record<string, TeamRecruitmentCategory> = {
+  공모전: 'CONTEST',
+  대외활동: 'EXTERNAL_ACTIVITY',
+  스터디: 'STUDY',
+  프로젝트: 'PROJECT',
+  기타: 'OTHER',
+};
+
+export const MEETING_TYPE_BY_PROGRESS_TYPE: Record<TeamRecruitmentProgressType, TeamRecruitmentMeetingType> = {
+  ONLINE: 'ONLINE',
+  OFFLINE: 'OFFLINE',
+  HYBRID: 'MIXED',
+};
+
+export default function toRecruitmentRequestBody(values: TeamRecruitmentFormValues): TeamRecruitmentUpdateRequest {
+  if (
+    !values.category ||
+    !values.progressType ||
+    !values.activityStartDate ||
+    !values.activityEndDate ||
+    !values.deadlineDate
+  ) {
+    throw new Error('필수 모집글 정보가 누락되었습니다.');
+  }
+
+  const common = {
+    category: CATEGORY_BY_LABEL[values.category],
+    title: values.title.trim(),
+    meeting_type: MEETING_TYPE_BY_PROGRESS_TYPE[values.progressType],
+    activity_start_date: getYyyyMmDd(values.activityStartDate),
+    activity_end_date: getYyyyMmDd(values.activityEndDate),
+    deadline_date: getYyyyMmDd(values.deadlineDate),
+    description: values.description.trim(),
+    related_url: values.relatedUrl.trim() || null,
+    qualification: values.qualification.trim() || null,
+  };
+
+  if (values.isRoleUnified) {
+    return {
+      ...common,
+      recruitment_type: 'GENERAL',
+      max_participants: values.unifiedMemberCount,
+      roles: [],
+    };
+  }
+
+  return {
+    ...common,
+    recruitment_type: 'ROLE_BASED',
+    roles: values.roles.map((role) => ({
+      ...(role.id !== undefined && { id: role.id }),
+      name: role.name.trim(),
+      max_participants: role.memberCount,
+    })),
+  };
+}

--- a/src/pages/team/TeamListPage.module.scss
+++ b/src/pages/team/TeamListPage.module.scss
@@ -341,6 +341,7 @@
 
   @include media.media-breakpoint(mobile) {
     position: fixed;
+    z-index: 10;
     right: 22px;
     bottom: 56px;
     gap: 4px;

--- a/src/pages/team/my-created-posts/index.tsx
+++ b/src/pages/team/my-created-posts/index.tsx
@@ -23,7 +23,6 @@ import useBooleanState from 'utils/hooks/state/useBooleanState';
 import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import useInfiniteScroll from 'utils/hooks/ui/useInfiniteScroll';
-import showToast from 'utils/ts/showToast';
 import type {
   MyCreatedTeamRecruitment,
   MyCreatedTeamRecruitmentListRequest,
@@ -217,8 +216,7 @@ export default function MyCreatedPostsPage() {
       value: recruitment.title,
     });
 
-    // TODO: 지원자 관리 화면 구현 전까지 준비 중 토스트로 대체한다. src/pages/team/notifications/index.tsx의 동일 TODO 참고.
-    showToast('warning', '지원자 관리 기능은 준비 중입니다.');
+    router.push(ROUTES.TeamRecruitmentApplicants({ postId: String(recruitment.id) }));
   };
 
   const handleCloseClick = (recruitment: MyCreatedTeamRecruitment) => {

--- a/src/pages/team/recruitment/new/index.tsx
+++ b/src/pages/team/recruitment/new/index.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import Head from 'next/head';
 import Layout from 'components/layout';
-import NewTeamRecruitment from 'components/Team/NewTeamRecruitment';
+import CreateTeamRecruitment from 'components/Team/CreateTeamRecruitment';
 
 function TeamRecruitmentNewPage() {
   return (
@@ -11,7 +11,7 @@ function TeamRecruitmentNewPage() {
         <meta name="description" content="팀원 모집글을 작성할 수 있습니다." />
       </Head>
 
-      <NewTeamRecruitment />
+      <CreateTeamRecruitment />
     </>
   );
 }

--- a/src/static/routes.ts
+++ b/src/static/routes.ts
@@ -66,7 +66,6 @@ const ROUTES = {
   CallvanParticipants: ({ postId }: ROUTESParams<'postId'>) => `/callvan/${postId}/participants`,
   CallvanReport: ({ postId, userId }: ROUTESParams<'postId' | 'userId'>) => `/callvan/${postId}/report/${userId}`,
   Team: () => '/team',
-  TeamRecruitmentSearch: () => '/team/recruitment/search',
   TeamRecruitmentNew: () => '/team/recruitment/new',
   TeamRecruitmentEdit: ({ postId }: ROUTESParams<'postId'>) => `/team/recruitment/${postId}/edit`,
   TeamRecruitmentApply: ({ postId, step }: ROUTESParams<'postId' | 'step'>) =>


### PR DESCRIPTION
- Close #1392 

## What is this PR? 🔍

- 기능 :팀원 모집 모집글 작성 API 연동 및 지원자 관리 라우팅 버그 수정
- issue : #1392 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
## Summary
- 모집글 작성(`POST /team-recruitments`) API를 실제로 연동했습니다. 그동안 `NewTeamRecruitment`의 create 모드는 `onSubmit`이 아예 없어 등록하기를 눌러도 확인 모달만 닫히고 아무 요청도 나가지 않았습니다.
- `my-created-posts`의 "지원자 관리" 버튼이 "준비 중입니다" 토스트만 띄우던 스텁을 실제 라우팅(`ROUTES.TeamRecruitmentApplicants`)으로 교체했습니다. 이미 구현/머지된 지원자 관리 화면이 있었는데 연결만 안 돼 있었습니다.
- 팀원 모집 목록의 모집하기 FAB 버튼이 겹쳐진 카드에 클릭을 가로채이던 z-index 문제를 수정했습니다.
- 대응하는 페이지 없이 정의만 돼 있던 `ROUTES.TeamRecruitmentSearch`를 삭제했습니다.
- `EditTeamRecruitment`에 있던 폼→요청바디 변환 로직을 `NewTeamRecruitment/toRecruitmentRequestBody.ts`로 추출해 신규 Create 플로우와 공유하도록 리팩터했습니다 (Swagger 기준 POST/PUT 요청 바디가 동일 스키마임을 확인).

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 팀 모집글 작성 기능이 추가되었습니다.
  - 작성 완료 후 성공 안내와 함께 생성된 모집글 상세 화면으로 이동합니다.
  - 모집글의 지원자 관리 화면으로 바로 이동할 수 있습니다.

- **개선**
  - 모집글 작성 및 수정 시 입력 정보가 일관되게 처리됩니다.
  - 모바일 화면에서 플로팅 작성 버튼이 다른 요소 위에 표시됩니다.

- **변경 사항**
  - 더 이상 사용되지 않는 팀 모집 검색 경로가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->