### PR TITLE
[캠퍼스] 팀원 모집 프로필 로깅 명세 변경 반영

### DIFF
--- a/src/components/Team/ProfilePage/Steps/ApplicationStep/index.tsx
+++ b/src/components/Team/ProfilePage/Steps/ApplicationStep/index.tsx
@@ -1,6 +1,7 @@
 import FormField from 'components/Team/ProfilePage/components/FormField';
 import StepIndicator from 'components/Team/ProfilePage/components/StepIndicator';
 import TagInput from 'components/Team/ProfilePage/components/TagInput';
+import { PROFILE_LOG_MODE } from 'components/Team/ProfilePage/constants';
 import { PROFILE_STEPS, type ProfileFormValues, type TeamProfileFormMode } from 'components/Team/ProfilePage/types';
 import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 import useLogger from 'utils/hooks/analytics/useLogger';
@@ -15,14 +16,11 @@ interface ApplicationStepProps {
   submitLabel: string;
 }
 
-// Notion 로깅 명세의 event_label이 'edit'가 아닌 'modify'를 쓴다.
-const LOG_MODE: Record<TeamProfileFormMode, 'create' | 'modify'> = { create: 'create', edit: 'modify' };
-
 export default function ApplicationStep({ mode, onBack, onSubmit, isSubmitting, submitLabel }: ApplicationStepProps) {
   const { actionEventClick } = useLogger();
   const { control, register } = useFormContext<ProfileFormValues>();
   const { errors } = useFormState({ control });
-  const logMode = LOG_MODE[mode];
+  const logMode = PROFILE_LOG_MODE[mode];
 
   const preferredRole = useWatch({ control, name: 'preferredRole' }) ?? '';
   const introduction = useWatch({ control, name: 'introduction' }) ?? '';

--- a/src/components/Team/ProfilePage/constants.ts
+++ b/src/components/Team/ProfilePage/constants.ts
@@ -1,0 +1,7 @@
+import type { TeamProfileFormMode } from './types';
+
+// Notion 로깅 명세의 event_label이 'edit'가 아닌 'modify'를 쓴다.
+export const PROFILE_LOG_MODE: Record<TeamProfileFormMode, 'create' | 'modify'> = {
+  create: 'create',
+  edit: 'modify',
+};

--- a/src/components/Team/ProfilePage/index.tsx
+++ b/src/components/Team/ProfilePage/index.tsx
@@ -175,7 +175,7 @@ export default function TeamProfileForm({ mode }: TeamProfileFormProps) {
     if (!pendingValues) return;
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'result',
+      event_category: mode === 'create' ? 'click' : 'result',
       event_label: `team_recruitment_profile_${PROFILE_LOG_MODE[mode]}_submit_confirm`,
       value: MODE_TEXT[mode].confirmLabel,
     });

--- a/src/components/Team/ProfilePage/index.tsx
+++ b/src/components/Team/ProfilePage/index.tsx
@@ -15,6 +15,7 @@ import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import showToast from 'utils/ts/showToast';
+import { PROFILE_LOG_MODE } from './constants';
 import ApplicationStep from './Steps/ApplicationStep';
 import BasicInfoStep from './Steps/BasicInfoStep';
 import { PROFILE_STEPS, type ProfileFormValues, type ProfileStepTitle, type TeamProfileFormMode } from './types';
@@ -54,8 +55,6 @@ const MODE_TEXT: Record<
     successMessage: '프로필이 수정되었습니다.',
   },
 };
-
-const LOG_MODE: Record<TeamProfileFormMode, 'create' | 'modify'> = { create: 'create', edit: 'modify' };
 
 const toRequestBody = (values: ProfileFormValues): UpsertTeamRecruitmentProfileRequest => ({
   profile_nickname: values.nickname.trim(),
@@ -177,7 +176,7 @@ export default function TeamProfileForm({ mode }: TeamProfileFormProps) {
     actionEventClick({
       team: 'CAMPUS',
       event_category: 'result',
-      event_label: `team_recruitment_profile_${LOG_MODE[mode]}_submit_confirm`,
+      event_label: `team_recruitment_profile_${PROFILE_LOG_MODE[mode]}_submit_confirm`,
       value: MODE_TEXT[mode].confirmLabel,
     });
     upsertProfile(toRequestBody(pendingValues));
@@ -187,7 +186,7 @@ export default function TeamProfileForm({ mode }: TeamProfileFormProps) {
     actionEventClick({
       team: 'CAMPUS',
       event_category: 'click',
-      event_label: `team_recruitment_profile_${LOG_MODE[mode]}_submit_cancel`,
+      event_label: `team_recruitment_profile_${PROFILE_LOG_MODE[mode]}_submit_cancel`,
       value: '취소하기',
     });
     setPendingValues(null);

--- a/src/components/Team/hooks/useActivityHistoryField.ts
+++ b/src/components/Team/hooks/useActivityHistoryField.ts
@@ -34,7 +34,6 @@ interface ActivityHistoryLoggingTitle {
 
 let activitySequence = 0;
 
-// crypto.randomUUID는 보안 컨텍스트가 아니면 undefined라 개발/스테이징 http 환경에서 터진다.
 const createActivityId = () => {
   activitySequence += 1;
   return `activity-${Date.now()}-${activitySequence}`;

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -144,7 +144,7 @@ export default function TeamListPage() {
     logger.actionEventClick({
       team: 'CAMPUS',
       event_label: 'team_recruitment_profile',
-      value: '내 프로필',
+      value: '프로필',
     });
 
     if (!token) {

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -54,13 +54,7 @@ const INITIAL_FILTER: TeamRecruitmentFilter = {
   categories: [],
 };
 
-/**
- * 서버와 클라이언트가 동일한 쿼리 키를 만들도록 요청 파라미터를 한 곳에서 생성한다.
- *
- * `undefined` 값은 넣지 않고 키 자체를 생략한다. `getServerSideProps`가 반환하는 props는
- * JSON 직렬화가 가능해야 하는데, dehydrate된 쿼리 키에 `undefined`가 들어 있으면
- * Next.js가 "`undefined` cannot be serialized as JSON" 런타임 에러를 낸다.
- */
+// SSR 직렬화 오류를 막고 쿼리 키를 일치시키기 위해 undefined 값을 제외한다.
 const createRequestParams = (filter: TeamRecruitmentFilter, keyword?: string): TeamRecruitmentInfiniteListRequest => ({
   status: filter.status,
   categories: filter.categories,


### PR DESCRIPTION
- Close #1400

## What is this PR? 🔍

- 기능 : 변경된 팀원 모집 프로필 로깅 명세 반영 및 관련 코드 정리
- issue : #1400

## Changes 📝

- 데스크톱 내 프로필 클릭 이벤트의 value를 프로필로 통일했습니다.
- 프로필 작성·수정 로깅에 사용하는 모드 매핑을 공통 상수로 분리했습니다.
- 프로필 최종 확인 이벤트의 event_category를 작성·수정 명세에 맞게 분기했습니다.
- 중복되거나 불필요한 설명 주석을 정리했습니다.

## ScreenShot 📷

- UI 변경 없음

## Test CheckList ✅

- [x] 데스크톱 내 프로필 클릭 시 team_recruitment_profile 이벤트가 호출되는지 확인
- [x] 프로필 클릭 이벤트의 value가 프로필로 전달되는지 확인
- [x] 프로필 작성 단계의 로깅 이벤트가 호출되는지 확인
- [x] 프로필 작성·수정 이벤트의 event_label, value, event_category가 명세와 일치하는지 코드 대조
- [x] corepack yarn lint 통과
- [x] corepack yarn typecheck 통과

## Precaution

- UI 및 CSS 변경은 없습니다.

## ✔️ Please check if the PR fulfills these requirements

- [X] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [X] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 팀 프로필 생성·수정 및 취소 이벤트의 로깅 값이 일관된 기준으로 기록됩니다.
  * 프로필 클릭 분석 이벤트명이 간결하게 정리되었습니다.
  * 팀 페이지 요청 처리 관련 안내가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->