### PR TITLE
fix: 채팅 불필요 로깅 삭제 및 내 모집글 actionButton 디자인 수정

### DIFF
--- a/scripts/notion/lib/types.ts
+++ b/scripts/notion/lib/types.ts
@@ -60,6 +60,7 @@ export const DATABASES: readonly DatabaseConfig[] = [
   { name: '버스', id: '1c39ae650b5981ecada6e03385f34894', team: 'CAMPUS' },
   { name: '배너', id: '1c29ae650b59818db23edd65c05a39b2', team: 'CAMPUS' },
   { name: '동아리', id: '1fd9ae650b5981778e7dff63a4ae7ae4', team: 'CAMPUS' },
+  { name: '팀원모집', id: 'b259ae650b5983ebbfd001d597f6b047', team: 'CAMPUS' },
 
   { name: '주변상점', id: '1be9ae650b5981b39b25f4c7c58ac3c0', team: 'BUSINESS' },
   { name: '복덕방', id: '1be9ae650b5981368084e913e80539fe', team: 'BUSINESS' },

--- a/src/components/Team/ApplicantManagement/index.tsx
+++ b/src/components/Team/ApplicantManagement/index.tsx
@@ -8,7 +8,6 @@ import LoadingSpinner from 'components/feedback/LoadingSpinner';
 import RecruitmentCard from 'components/Team/components/RecruitmentCard';
 import SubPageHeader from 'components/ui/SubPageHeader';
 import ROUTES from 'static/routes';
-import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import ApplicantCard from './components/ApplicantCard';
@@ -17,7 +16,6 @@ import styles from './ApplicantManagement.module.scss';
 export default function ApplicantManagement() {
   const router = useRouter();
   const token = useTokenState();
-  const logger = useLogger();
   const isMobile = useMediaQuery();
   const { postId } = router.query;
   const recruitmentId = typeof postId === 'string' ? postId : '';
@@ -30,11 +28,6 @@ export default function ApplicantManagement() {
   const handleGroupChatClick = () => {
     if (!data || data.recruitment.team_chat_room_id === null) return;
 
-    logger.actionEventClick({
-      team: 'CAMPUS',
-      event_label: 'team_recruitment_group_chat',
-      value: data.recruitment.title,
-    });
     router.push(ROUTES.TeamChat({ recruitmentId, chatRoomId: String(data.recruitment.team_chat_room_id) }));
   };
 

--- a/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
+++ b/src/pages/team/my-created-posts/MyCreatedPostsPage.module.scss
@@ -222,12 +222,23 @@
   }
 }
 
-// 모바일: 카드 하단 별도 행에 배치되는 전체폭 액션 버튼(actionSlot).
+.actionRow {
+  display: none;
+  gap: 12px;
+  width: 100%;
+
+  @include media.media-breakpoint(mobile) {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
 .actionButton {
   display: flex;
   flex: 1;
   align-items: center;
   justify-content: center;
+  width: 140px;
   height: 40px;
   border: 0.5px solid #b611f5;
   border-radius: 16px;

--- a/src/pages/team/my-created-posts/index.tsx
+++ b/src/pages/team/my-created-posts/index.tsx
@@ -151,7 +151,7 @@ function CreatedPostsListSection({
                     </>
                   }
                   actionSlot={
-                    <div className={styles.mobileOnly}>
+                    <div className={styles.actionRow}>
                       <button
                         type="button"
                         className={styles.actionButton}


### PR DESCRIPTION
- Close #1416 

## What is this PR? 🔍

- 기능 : 로깅 검수 중 발견한 불필요 로깅 삭제 및 모집글 actionButton 디자인을 수정했습니다
- issue : #1416 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 지원자 관리 화면의 단체 채팅 버튼에서 `team_recruitment_group_chat` 로깅을 제거했습니다. Notion 로깅 명세에 없는 이벤트로, 검수 과정에서 발견했습니다.
- "내가 작성한 모집글" 목록 카드의 "지원자 관리"/"모집 마감" 버튼이 Figma 디자인과 달리 텍스트 크기만큼만 좁게 표시되던 것을 수정했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="417" height="812" alt="image" src="https://github.com/user-attachments/assets/1f0b8e8a-32e2-454c-afea-26568974a90f" />

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] 로컬 확인
- [x] yarn lint
- [x] 로깅 최종 점검

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 모바일에서 내가 작성한 모집글 카드의 액션 버튼이 한 행에 정렬되어 더 일관된 레이아웃으로 표시됩니다.
  - 액션 버튼의 크기와 간격이 조정되어 모바일 화면에서 사용하기 편해졌습니다.

- **기타**
  - 그룹 채팅방 이동 기능은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->