### PR TITLE
[캠퍼스] 내가 작성한 모집글 지원자 관리 버튼이 상세 화면으로 이동함

### DIFF
--- a/src/components/Team/components/RecruitmentCard/RecruitmentCard.module.scss
+++ b/src/components/Team/components/RecruitmentCard/RecruitmentCard.module.scss
@@ -45,12 +45,15 @@
   }
 
   &__header {
-    position: relative;
-    z-index: 2;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 4px;
+  }
+
+  &__headerAction {
+    position: relative;
+    z-index: 2;
   }
 
   &__badges {

--- a/src/components/Team/components/RecruitmentCard/RecruitmentCard.module.scss
+++ b/src/components/Team/components/RecruitmentCard/RecruitmentCard.module.scss
@@ -45,6 +45,8 @@
   }
 
   &__header {
+    position: relative;
+    z-index: 2;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/components/Team/components/RecruitmentCard/index.tsx
+++ b/src/components/Team/components/RecruitmentCard/index.tsx
@@ -86,7 +86,7 @@ export default function RecruitmentCard({
       <div className={styles.card__header}>
         <RecruitmentBadges category={recruitment.category} status={recruitment.status} dDay={recruitment.d_day} />
 
-        {rightSlot}
+        {rightSlot && <div className={styles.card__headerAction}>{rightSlot}</div>}
       </div>
 
       <h2 className={styles.card__title}>{recruitment.title}</h2>


### PR DESCRIPTION
- Close #1422

## What is this PR? 🔍

- 기능 : 팀원 모집 - 내가 작성한 모집글 카드
- issue : #1422

## Changes 📝

- `RecruitmentCard.module.scss`의 `card__header`에 `position: relative; z-index: 2`를 추가해, 카드 전체를 덮는 오버레이 `Link`(`z-index: 1`)보다 위에 쌓이도록 수정
- 데스크톱용 "지원자 관리"/"모집 마감" 버튼(`rightSlot`)이 카드 상세로 이동하는 오버레이 링크에 클릭을 뺏기지 않고 정상 동작하도록 함

## ScreenShot 📷

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->

## Test CheckList ✅

- [ ] `/team/my-created-posts`에서 데스크톱 뷰포트로 "지원자 관리" 버튼 클릭 시 지원자 관리 화면으로 이동하는지 확인
- [ ] 카드의 다른 영역(제목, 정보 등) 클릭 시 여전히 모집글 상세로 이동하는지 확인
- [ ] 모바일 뷰포트(actionSlot 버튼)에서 기존 동작에 회귀가 없는지 확인

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채용 카드의 헤더가 오버레이 링크 위에 표시되도록 레이어 순서를 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->