### PR TITLE
[캠퍼스] 팀원 모집 필터 모달이 데스크톱에서도 모바일 UI로 표시됨

### DIFF
--- a/src/components/Team/components/MyApplicationFilterPanel/MyApplicationFilterPanel.module.scss
+++ b/src/components/Team/components/MyApplicationFilterPanel/MyApplicationFilterPanel.module.scss
@@ -1,16 +1,15 @@
 @use "utils/scss/media.scss" as media;
 
-.backdrop {
-  background: transparent;
-}
-
 .panel {
   width: 390px;
   max-height: 85vh;
-  margin: auto;
+  margin: 0;
   border-radius: 16px;
   box-shadow: 0 0 20px rgb(0 0 0 / 7%);
   animation: none;
+  z-index: 30;
+  background: #fff;
+  overflow: hidden;
 }
 
 .header {
@@ -23,7 +22,7 @@
   font-family: Pretendard, sans-serif;
   font-size: 18px;
   font-weight: 600;
-  color: #b611f5;
+  color: #175c8e;
   line-height: 1.6;
 }
 
@@ -39,7 +38,7 @@
   -webkit-tap-highlight-color: transparent;
 
   &:focus-visible {
-    outline: 2px solid #b611f5;
+    outline: 2px solid #175c8e;
     outline-offset: 2px;
   }
 
@@ -81,7 +80,7 @@
   -webkit-tap-highlight-color: transparent;
 
   &:focus-visible {
-    outline: 2px solid #b611f5;
+    outline: 2px solid #175c8e;
     outline-offset: 2px;
   }
 
@@ -96,7 +95,7 @@
   height: 48px;
   border-radius: 20px;
   border: none;
-  background: #b611f5;
+  background: #175c8e;
   cursor: pointer;
   font-family: Pretendard, sans-serif;
   font-size: 16px;
@@ -107,11 +106,11 @@
   -webkit-tap-highlight-color: transparent;
 
   &:hover {
-    background: #980ac9;
+    background: #134f7a;
   }
 
   &:focus-visible {
-    outline: 2px solid #b611f5;
+    outline: 2px solid #175c8e;
     outline-offset: 2px;
   }
 }
@@ -135,6 +134,15 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+
+  > button {
+    &:hover,
+    &[aria-pressed="true"] {
+      border-color: #175c8e;
+      background: #fff;
+      color: #175c8e;
+    }
+  }
 }
 
 @include media.media-breakpoint(mobile) {
@@ -149,6 +157,38 @@
     border-radius: 32px 32px 0 0;
     box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
     animation: slide-up 0.25s ease-out;
+  }
+
+  .headerTitle {
+    color: #b611f5;
+  }
+
+  .closeButton:focus-visible {
+    outline-color: #b611f5;
+  }
+
+  .resetButton:focus-visible {
+    outline-color: #b611f5;
+  }
+
+  .applyButton {
+    background: #b611f5;
+
+    &:hover {
+      background: #980ac9;
+    }
+
+    &:focus-visible {
+      outline-color: #b611f5;
+    }
+  }
+
+  .sectionBadges > button {
+    &:hover,
+    &[aria-pressed="true"] {
+      border-color: #b611f5;
+      color: #b611f5;
+    }
   }
 }
 

--- a/src/components/Team/components/MyApplicationFilterPanel/MyApplicationFilterPanel.module.scss
+++ b/src/components/Team/components/MyApplicationFilterPanel/MyApplicationFilterPanel.module.scss
@@ -1,5 +1,16 @@
+@use "utils/scss/media.scss" as media;
+
+.backdrop {
+  background: transparent;
+}
+
 .panel {
+  width: 390px;
   max-height: 85vh;
+  margin: auto;
+  border-radius: 16px;
+  box-shadow: 0 0 20px rgb(0 0 0 / 7%);
+  animation: none;
 }
 
 .header {
@@ -124,4 +135,35 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+@include media.media-breakpoint(mobile) {
+  .backdrop {
+    background: rgb(0 0 0 / 70%);
+  }
+
+  .panel {
+    width: 100%;
+    max-height: 85vh;
+    margin: 0;
+    border-radius: 32px 32px 0 0;
+    box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
+    animation: slide-up 0.25s ease-out;
+  }
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    animation: none;
+  }
 }

--- a/src/components/Team/components/MyApplicationFilterPanel/index.tsx
+++ b/src/components/Team/components/MyApplicationFilterPanel/index.tsx
@@ -94,7 +94,13 @@ export default function MyApplicationFilterPanel({
   };
 
   return (
-    <BottomModal isOpen={isOpen} onClose={onClose} className={styles.panel} aria-label="필터">
+    <BottomModal
+      isOpen={isOpen}
+      onClose={onClose}
+      className={styles.panel}
+      backdropClassName={styles.backdrop}
+      aria-label="필터"
+    >
       <BottomModalHeader className={styles.header}>
         <span className={styles.headerTitle}>필터</span>
         <button type="button" className={styles.closeButton} onClick={onClose} aria-label="필터 닫기">

--- a/src/components/Team/components/MyApplicationFilterPanel/index.tsx
+++ b/src/components/Team/components/MyApplicationFilterPanel/index.tsx
@@ -2,8 +2,12 @@ import { useEffect, useState } from 'react';
 import SpinIcon from 'assets/svg/Callvan/spin.svg';
 import CloseIcon from 'assets/svg/close-icon-black.svg';
 import StatusBadge from 'components/Callvan/components/StatusBadge';
+import Portal from 'components/Portal';
 import BottomModal, { BottomModalContent, BottomModalFooter, BottomModalHeader } from 'components/ui/BottomModal';
 import useLogger from 'utils/hooks/analytics/useLogger';
+import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
+import { useBodyScrollLock } from 'utils/hooks/ui/useBodyScrollLock';
+import { useOutsideClick } from 'utils/hooks/ui/useOutsideClick';
 import type { TeamApplicationStatus, TeamRecruitmentSort } from 'api/team/entity';
 import styles from './MyApplicationFilterPanel.module.scss';
 
@@ -21,6 +25,7 @@ const SORT_OPTIONS: { value: TeamRecruitmentSort; label: string }[] = [
 interface MyApplicationFilterPanelProps {
   isOpen: boolean;
   onClose: () => void;
+  anchorRect: DOMRect | null;
   statuses: TeamApplicationStatus[];
   sort: TeamRecruitmentSort;
   onApply: (filter: { statuses: TeamApplicationStatus[]; sort: TeamRecruitmentSort }) => void;
@@ -29,14 +34,19 @@ interface MyApplicationFilterPanelProps {
 export default function MyApplicationFilterPanel({
   isOpen,
   onClose,
+  anchorRect,
   statuses,
   sort,
   onApply,
 }: MyApplicationFilterPanelProps) {
   const logger = useLogger();
+  const isMobile = useMediaQuery();
 
   const [localStatuses, setLocalStatuses] = useState<TeamApplicationStatus[]>(statuses);
   const [localSort, setLocalSort] = useState<TeamRecruitmentSort>(sort);
+
+  const { containerRef } = useOutsideClick<HTMLDivElement>({ onOutsideClick: onClose });
+  useBodyScrollLock(!isMobile && isOpen);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -93,14 +103,8 @@ export default function MyApplicationFilterPanel({
     });
   };
 
-  return (
-    <BottomModal
-      isOpen={isOpen}
-      onClose={onClose}
-      className={styles.panel}
-      backdropClassName={styles.backdrop}
-      aria-label="필터"
-    >
+  const body = (
+    <>
       <BottomModalHeader className={styles.header}>
         <span className={styles.headerTitle}>필터</span>
         <button type="button" className={styles.closeButton} onClick={onClose} aria-label="필터 닫기">
@@ -148,6 +152,36 @@ export default function MyApplicationFilterPanel({
           적용하기
         </button>
       </BottomModalFooter>
-    </BottomModal>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomModal
+        isOpen={isOpen}
+        onClose={onClose}
+        className={styles.panel}
+        backdropClassName={styles.backdrop}
+        aria-label="필터"
+      >
+        {body}
+      </BottomModal>
+    );
+  }
+
+  if (!anchorRect) return null;
+
+  return (
+    <Portal>
+      <div
+        ref={containerRef}
+        className={styles.panel}
+        style={{ position: 'fixed', top: anchorRect.bottom + 8, right: window.innerWidth - anchorRect.right }}
+        role="dialog"
+        aria-label="필터"
+      >
+        {body}
+      </div>
+    </Portal>
   );
 }

--- a/src/components/Team/components/MyCreatedPostFilterPanel/MyCreatedPostFilterPanel.module.scss
+++ b/src/components/Team/components/MyCreatedPostFilterPanel/MyCreatedPostFilterPanel.module.scss
@@ -1,16 +1,15 @@
 @use "utils/scss/media.scss" as media;
 
-.backdrop {
-  background: transparent;
-}
-
 .panel {
   width: 390px;
   max-height: 85vh;
-  margin: auto;
+  margin: 0;
   border-radius: 16px;
   box-shadow: 0 0 20px rgb(0 0 0 / 7%);
   animation: none;
+  z-index: 30;
+  background: #fff;
+  overflow: hidden;
 }
 
 .header {
@@ -22,7 +21,7 @@
 .headerTitle {
   font-size: 18px;
   font-weight: 600;
-  color: #b611f5;
+  color: #175c8e;
   line-height: 1.6;
 }
 
@@ -38,7 +37,7 @@
   -webkit-tap-highlight-color: transparent;
 
   &:focus-visible {
-    outline: 2px solid #b611f5;
+    outline: 2px solid #175c8e;
     outline-offset: 2px;
   }
 
@@ -78,7 +77,7 @@
   -webkit-tap-highlight-color: transparent;
 
   &:focus-visible {
-    outline: 2px solid #b611f5;
+    outline: 2px solid #175c8e;
     outline-offset: 2px;
   }
 
@@ -93,7 +92,7 @@
   height: 48px;
   border-radius: 20px;
   border: none;
-  background: #b611f5;
+  background: #175c8e;
   cursor: pointer;
   font-weight: 600;
   color: #fff;
@@ -102,11 +101,11 @@
   -webkit-tap-highlight-color: transparent;
 
   &:hover {
-    background: #980ac9;
+    background: #134f7a;
   }
 
   &:focus-visible {
-    outline: 2px solid #b611f5;
+    outline: 2px solid #175c8e;
     outline-offset: 2px;
   }
 }
@@ -128,6 +127,15 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+
+  > button {
+    &:hover,
+    &[aria-pressed="true"] {
+      border-color: #175c8e;
+      background: #fff;
+      color: #175c8e;
+    }
+  }
 }
 
 @include media.media-breakpoint(mobile) {
@@ -142,6 +150,38 @@
     border-radius: 32px 32px 0 0;
     box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
     animation: slide-up 0.25s ease-out;
+  }
+
+  .headerTitle {
+    color: #b611f5;
+  }
+
+  .closeButton:focus-visible {
+    outline-color: #b611f5;
+  }
+
+  .resetButton:focus-visible {
+    outline-color: #b611f5;
+  }
+
+  .applyButton {
+    background: #b611f5;
+
+    &:hover {
+      background: #980ac9;
+    }
+
+    &:focus-visible {
+      outline-color: #b611f5;
+    }
+  }
+
+  .sectionBadges > button {
+    &:hover,
+    &[aria-pressed="true"] {
+      border-color: #b611f5;
+      color: #b611f5;
+    }
   }
 }
 

--- a/src/components/Team/components/MyCreatedPostFilterPanel/MyCreatedPostFilterPanel.module.scss
+++ b/src/components/Team/components/MyCreatedPostFilterPanel/MyCreatedPostFilterPanel.module.scss
@@ -1,5 +1,16 @@
+@use "utils/scss/media.scss" as media;
+
+.backdrop {
+  background: transparent;
+}
+
 .panel {
+  width: 390px;
   max-height: 85vh;
+  margin: auto;
+  border-radius: 16px;
+  box-shadow: 0 0 20px rgb(0 0 0 / 7%);
+  animation: none;
 }
 
 .header {
@@ -117,4 +128,35 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+@include media.media-breakpoint(mobile) {
+  .backdrop {
+    background: rgb(0 0 0 / 70%);
+  }
+
+  .panel {
+    width: 100%;
+    max-height: 85vh;
+    margin: 0;
+    border-radius: 32px 32px 0 0;
+    box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
+    animation: slide-up 0.25s ease-out;
+  }
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    animation: none;
+  }
 }

--- a/src/components/Team/components/MyCreatedPostFilterPanel/index.tsx
+++ b/src/components/Team/components/MyCreatedPostFilterPanel/index.tsx
@@ -2,8 +2,12 @@ import { useEffect, useState } from 'react';
 import SpinIcon from 'assets/svg/Callvan/spin.svg';
 import CloseIcon from 'assets/svg/close-icon-black.svg';
 import StatusBadge from 'components/Callvan/components/StatusBadge';
+import Portal from 'components/Portal';
 import BottomModal, { BottomModalContent, BottomModalFooter, BottomModalHeader } from 'components/ui/BottomModal';
 import useLogger from 'utils/hooks/analytics/useLogger';
+import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
+import { useBodyScrollLock } from 'utils/hooks/ui/useBodyScrollLock';
+import { useOutsideClick } from 'utils/hooks/ui/useOutsideClick';
 import type { TeamRecruitmentSort, TeamRecruitmentStatusFilter } from 'api/team/entity';
 import styles from './MyCreatedPostFilterPanel.module.scss';
 
@@ -21,6 +25,7 @@ const SORT_OPTIONS: { value: TeamRecruitmentSort; label: string }[] = [
 interface MyCreatedPostFilterPanelProps {
   isOpen: boolean;
   onClose: () => void;
+  anchorRect: DOMRect | null;
   status: TeamRecruitmentStatusFilter;
   sort: TeamRecruitmentSort;
   onApply: (filter: { status: TeamRecruitmentStatusFilter; sort: TeamRecruitmentSort }) => void;
@@ -29,14 +34,19 @@ interface MyCreatedPostFilterPanelProps {
 export default function MyCreatedPostFilterPanel({
   isOpen,
   onClose,
+  anchorRect,
   status,
   sort,
   onApply,
 }: MyCreatedPostFilterPanelProps) {
   const logger = useLogger();
+  const isMobile = useMediaQuery();
 
   const [localStatus, setLocalStatus] = useState<TeamRecruitmentStatusFilter>(status);
   const [localSort, setLocalSort] = useState<TeamRecruitmentSort>(sort);
+
+  const { containerRef } = useOutsideClick<HTMLDivElement>({ onOutsideClick: onClose });
+  useBodyScrollLock(!isMobile && isOpen);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -84,14 +94,8 @@ export default function MyCreatedPostFilterPanel({
     });
   };
 
-  return (
-    <BottomModal
-      isOpen={isOpen}
-      onClose={onClose}
-      className={styles.panel}
-      backdropClassName={styles.backdrop}
-      aria-label="필터"
-    >
+  const body = (
+    <>
       <BottomModalHeader className={styles.header}>
         <span className={styles.headerTitle}>필터</span>
         <button type="button" className={styles.closeButton} onClick={onClose} aria-label="필터 닫기">
@@ -138,6 +142,36 @@ export default function MyCreatedPostFilterPanel({
           적용하기
         </button>
       </BottomModalFooter>
-    </BottomModal>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomModal
+        isOpen={isOpen}
+        onClose={onClose}
+        className={styles.panel}
+        backdropClassName={styles.backdrop}
+        aria-label="필터"
+      >
+        {body}
+      </BottomModal>
+    );
+  }
+
+  if (!anchorRect) return null;
+
+  return (
+    <Portal>
+      <div
+        ref={containerRef}
+        className={styles.panel}
+        style={{ position: 'fixed', top: anchorRect.bottom + 8, right: window.innerWidth - anchorRect.right }}
+        role="dialog"
+        aria-label="필터"
+      >
+        {body}
+      </div>
+    </Portal>
   );
 }

--- a/src/components/Team/components/MyCreatedPostFilterPanel/index.tsx
+++ b/src/components/Team/components/MyCreatedPostFilterPanel/index.tsx
@@ -85,7 +85,13 @@ export default function MyCreatedPostFilterPanel({
   };
 
   return (
-    <BottomModal isOpen={isOpen} onClose={onClose} className={styles.panel} aria-label="필터">
+    <BottomModal
+      isOpen={isOpen}
+      onClose={onClose}
+      className={styles.panel}
+      backdropClassName={styles.backdrop}
+      aria-label="필터"
+    >
       <BottomModalHeader className={styles.header}>
         <span className={styles.headerTitle}>필터</span>
         <button type="button" className={styles.closeButton} onClick={onClose} aria-label="필터 닫기">

--- a/src/components/ui/BottomModal/BottomModal.module.scss
+++ b/src/components/ui/BottomModal/BottomModal.module.scss
@@ -1,24 +1,37 @@
+@use "src/utils/scss/media" as media;
+
 .backdrop {
   position: fixed;
   inset: 0;
   z-index: 20;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: center;
+  align-items: center;
   background: rgb(0 0 0 / 70%);
+
+  @include media.media-breakpoint(mobile) {
+    justify-content: flex-end;
+  }
 }
 
 .modal {
   width: 100%;
-  max-width: none;
+  max-width: 400px;
   border: 0;
   padding: 0;
   margin: 0;
   background: #fff;
-  border-radius: 32px 32px 0 0;
+  border-radius: 16px;
   box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
   outline: none;
-  animation: slide-up 0.25s ease-out;
+  animation: fade-in 0.15s ease-out;
+
+  @include media.media-breakpoint(mobile) {
+    max-width: none;
+    border-radius: 32px 32px 0 0;
+    animation: slide-up 0.25s ease-out;
+  }
 }
 
 @keyframes slide-up {
@@ -27,6 +40,18 @@
   }
 
   to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
     transform: translateY(0);
   }
 }

--- a/src/components/ui/BottomModal/BottomModal.module.scss
+++ b/src/components/ui/BottomModal/BottomModal.module.scss
@@ -1,37 +1,24 @@
-@use "src/utils/scss/media" as media;
-
 .backdrop {
   position: fixed;
   inset: 0;
   z-index: 20;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-end;
   background: rgb(0 0 0 / 70%);
-
-  @include media.media-breakpoint(mobile) {
-    justify-content: flex-end;
-  }
 }
 
 .modal {
   width: 100%;
-  max-width: 400px;
+  max-width: none;
   border: 0;
   padding: 0;
   margin: 0;
   background: #fff;
-  border-radius: 16px;
+  border-radius: 32px 32px 0 0;
   box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
   outline: none;
-  animation: fade-in 0.15s ease-out;
-
-  @include media.media-breakpoint(mobile) {
-    max-width: none;
-    border-radius: 32px 32px 0 0;
-    animation: slide-up 0.25s ease-out;
-  }
+  animation: slide-up 0.25s ease-out;
 }
 
 @keyframes slide-up {
@@ -40,18 +27,6 @@
   }
 
   to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-
-  to {
-    opacity: 1;
     transform: translateY(0);
   }
 }

--- a/src/pages/team/my-applications/index.tsx
+++ b/src/pages/team/my-applications/index.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -36,8 +36,8 @@ const APPLICATION_STATUS_CLASS = {
 
 interface ApplicationsListSectionProps {
   requestParams: MyTeamRecruitmentApplicationListRequest;
-  onFilterOpen: () => void;
-  onChatClick: (application: MyTeamRecruitmentApplication) => React.MouseEventHandler<HTMLButtonElement>;
+  onFilterOpen: (anchorRect: DOMRect) => void;
+  onChatClick: (application: MyTeamRecruitmentApplication) => MouseEventHandler<HTMLButtonElement>;
 }
 
 function ApplicationsListSection({ requestParams, onFilterOpen, onChatClick }: ApplicationsListSectionProps) {
@@ -52,9 +52,9 @@ function ApplicationsListSection({ requestParams, onFilterOpen, onChatClick }: A
 
   const scrollTriggerRef = useInfiniteScroll(fetchNextPage, hasNextPage, isFetchingNextPage);
 
-  const handleFilterOpen = () => {
+  const handleFilterOpen: MouseEventHandler<HTMLButtonElement> = (event) => {
     logger.actionEventClick({ team: 'CAMPUS', event_label: 'team_recruitment_applied_post_filter', value: '필터' });
-    onFilterOpen();
+    onFilterOpen(event.currentTarget.getBoundingClientRect());
   };
 
   return (
@@ -127,6 +127,7 @@ export default function MyApplicationsPage() {
   const router = useRouter();
 
   const [isFilterOpen, openFilter, closeFilter] = useBooleanState(false);
+  const [filterAnchorRect, setFilterAnchorRect] = useState<DOMRect | null>(null);
   const [requestParams, setRequestParams] = useState<MyTeamRecruitmentApplicationListRequest>({
     statuses: [],
     sort: 'LATEST_DESC',
@@ -137,7 +138,7 @@ export default function MyApplicationsPage() {
   };
 
   const handleChatClick =
-    (application: MyTeamRecruitmentApplication): React.MouseEventHandler<HTMLButtonElement> =>
+    (application: MyTeamRecruitmentApplication): MouseEventHandler<HTMLButtonElement> =>
     (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -181,7 +182,10 @@ export default function MyApplicationsPage() {
             <Suspense fallback={null}>
               <ApplicationsListSection
                 requestParams={requestParams}
-                onFilterOpen={openFilter}
+                onFilterOpen={(anchorRect) => {
+                  setFilterAnchorRect(anchorRect);
+                  openFilter();
+                }}
                 onChatClick={handleChatClick}
               />
             </Suspense>
@@ -192,7 +196,11 @@ export default function MyApplicationsPage() {
       {isFilterOpen && (
         <MyApplicationFilterPanel
           isOpen={isFilterOpen}
-          onClose={closeFilter}
+          onClose={() => {
+            closeFilter();
+            setFilterAnchorRect(null);
+          }}
+          anchorRect={filterAnchorRect}
           statuses={requestParams.statuses ?? []}
           sort={requestParams.sort ?? 'LATEST_DESC'}
           onApply={handleApplyFilter}

--- a/src/pages/team/my-created-posts/index.tsx
+++ b/src/pages/team/my-created-posts/index.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -30,10 +30,10 @@ import styles from './MyCreatedPostsPage.module.scss';
 
 interface CreatedPostsListSectionProps {
   requestParams: MyCreatedTeamRecruitmentListRequest;
-  onFilterOpen: () => void;
+  onFilterOpen: (anchorRect: DOMRect) => void;
   onApplicantClick: (recruitment: MyCreatedTeamRecruitment) => void;
   onCloseClick: (recruitment: MyCreatedTeamRecruitment) => void;
-  onChatClick: (recruitment: MyCreatedTeamRecruitment) => React.MouseEventHandler<HTMLButtonElement>;
+  onChatClick: (recruitment: MyCreatedTeamRecruitment) => MouseEventHandler<HTMLButtonElement>;
 }
 
 function CreatedPostsListSection({
@@ -54,13 +54,13 @@ function CreatedPostsListSection({
 
   const scrollTriggerRef = useInfiniteScroll(fetchNextPage, hasNextPage, isFetchingNextPage);
 
-  const handleFilterOpen = () => {
+  const handleFilterOpen: MouseEventHandler<HTMLButtonElement> = (event) => {
     logger.actionEventClick({ team: 'CAMPUS', event_label: 'team_recruitment_created_post_filter', value: '필터' });
-    onFilterOpen();
+    onFilterOpen(event.currentTarget.getBoundingClientRect());
   };
 
   const handleApplicantClick =
-    (recruitment: MyCreatedTeamRecruitment): React.MouseEventHandler<HTMLButtonElement> =>
+    (recruitment: MyCreatedTeamRecruitment): MouseEventHandler<HTMLButtonElement> =>
     (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -68,7 +68,7 @@ function CreatedPostsListSection({
     };
 
   const handleCloseClick =
-    (recruitment: MyCreatedTeamRecruitment): React.MouseEventHandler<HTMLButtonElement> =>
+    (recruitment: MyCreatedTeamRecruitment): MouseEventHandler<HTMLButtonElement> =>
     (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -186,6 +186,7 @@ export default function MyCreatedPostsPage() {
   const queryClient = useQueryClient();
 
   const [isFilterOpen, openFilter, closeFilter] = useBooleanState(false);
+  const [filterAnchorRect, setFilterAnchorRect] = useState<DOMRect | null>(null);
   const [requestParams, setRequestParams] = useState<MyCreatedTeamRecruitmentListRequest>({
     status: 'ALL',
     sort: 'LATEST_DESC',
@@ -243,7 +244,7 @@ export default function MyCreatedPostsPage() {
   };
 
   const handleChatClick =
-    (recruitment: MyCreatedTeamRecruitment): React.MouseEventHandler<HTMLButtonElement> =>
+    (recruitment: MyCreatedTeamRecruitment): MouseEventHandler<HTMLButtonElement> =>
     (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -287,7 +288,10 @@ export default function MyCreatedPostsPage() {
             <Suspense fallback={null}>
               <CreatedPostsListSection
                 requestParams={requestParams}
-                onFilterOpen={openFilter}
+                onFilterOpen={(anchorRect) => {
+                  setFilterAnchorRect(anchorRect);
+                  openFilter();
+                }}
                 onApplicantClick={handleApplicantClick}
                 onCloseClick={handleCloseClick}
                 onChatClick={handleChatClick}
@@ -300,7 +304,11 @@ export default function MyCreatedPostsPage() {
       {isFilterOpen && (
         <MyCreatedPostFilterPanel
           isOpen={isFilterOpen}
-          onClose={closeFilter}
+          onClose={() => {
+            closeFilter();
+            setFilterAnchorRect(null);
+          }}
+          anchorRect={filterAnchorRect}
           status={requestParams.status ?? 'ALL'}
           sort={requestParams.sort ?? 'LATEST_DESC'}
           onApply={handleApplyFilter}


### PR DESCRIPTION
- Close #1426

## What is this PR? 🔍

- 기능 : 팀원 모집 - 내가 작성한 모집글 / 내가 지원한 모집글 필터
- issue : #1426

## Changes 📝

- Figma 디자인 확인 결과 필터 패널은 화면 중앙 다이얼로그가 아니라 **"필터" 버튼 바로 아래에 오른쪽 정렬로 앵커링되는 드롭다운**이 맞는 스펙이었음 (파란색 `#175c8e` 헤더/버튼 배색 포함)
- 데스크톱: 필터 버튼 클릭 시 `getBoundingClientRect()`로 버튼 위치를 측정해 그 아래에 앵커링된 패널을 `Portal`로 렌더링 (배경 딤 없음, `useOutsideClick`으로 바깥 클릭 시 닫힘, `useBodyScrollLock`으로 앵커 위치 밀림 방지)
  - 버튼(`CreatedPostsListSection`/`ApplicationsListSection`, Suspense 하위)과 패널(페이지 최상단)이 서로 다른 컴포넌트 트리에 있어 CSS만으로는 앵커링이 불가능해 좌표 측정 방식을 사용함
- 모바일은 기존 `BottomModal` 하단 시트를 그대로 유지 (`useMediaQuery`로 분기)
- 색상을 회색조 mobile 팔레트(`#b611f5`)에서 데스크톱 기본값은 파란색(`#175c8e`)으로, 모바일에서만 보라색으로 override하도록 정리 (`RecruitmentFilterPanel`과 동일한 배색 컨벤션)
- 앵커드 패널에 `background:#fff`, `overflow:hidden`이 빠져 있어 뒤 카드의 테두리가 비쳐 보이던 문제 수정
- `지원자 관리`/채팅 버튼(`z-index:2`)이 필터 패널 위로 올라오던 문제를 패널 `z-index:30`으로 수정

## ScreenShot 📷

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->

## Test CheckList ✅

- [ ] 데스크톱에서 "필터" 버튼 클릭 시 버튼 바로 아래 오른쪽 정렬로 패널이 뜨는지 확인 (내가 작성한 모집글 / 내가 지원한 모집글 둘 다)
- [ ] 패널이 카드 목록 위에 올바르게 겹치고, 뒤 카드 테두리가 비쳐 보이지 않는지 확인
- [ ] 패널 바깥을 클릭하면 닫히는지 확인
- [ ] 모바일 뷰포트(≤576px)에서 기존과 동일하게 하단 시트로 표시되는지 확인

## Precaution

- `BottomModal` 공용 컴포넌트는 원상태로 유지했고, 변경 범위를 필터 패널 2곳 + 각 페이지의 필터 버튼 클릭 핸들러로 한정했습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 팀 지원서 및 작성 게시물의 필터 패널이 데스크톱에서 버튼 위치에 맞춰 표시되는 팝오버로 개선되었습니다.
  * 모바일에서는 기존 하단 시트 형태로 제공됩니다.
  * 패널 외부 클릭 시 닫히며, 열린 동안 배경 스크롤이 제한됩니다.

* **스타일**
  * 필터 패널의 색상, 여백, 모서리, 그림자 및 버튼 상태 디자인이 개선되었습니다.
  * 모바일 전용 백드롭과 슬라이드 애니메이션이 적용되었습니다.
  * 동작 줄이기 설정에서는 애니메이션이 비활성화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->