### PR TITLE
[캠퍼스] 팀원 모집 내 프로필 학번 입력에 형식 유효성 검사가 없음

### DIFF
--- a/src/components/Team/ProfilePage/schema.ts
+++ b/src/components/Team/ProfilePage/schema.ts
@@ -1,9 +1,10 @@
 import isValidCalendarDate from 'components/Team/utils/isValidCalendarDate';
+import { MESSAGES, REGEX } from 'static/auth';
 import { z } from 'zod';
 
 // ── 기본 정보 (1단계) ──────────────────────────────────────
 // 현재 BasicInfoStep의 register(...) 인라인 룰을 그대로 옮긴 것.
-// 학번은 학부/대학원, 입학연도에 따라 자릿수가 달라 길이 조건은 두지 않고 숫자 여부만 검증한다.
+// 학번 형식은 회원가입 페이지(REGEX.STUDENT_NUMBER)와 동일하게 검증한다.
 const basicInfoSchema = z.object({
   nickname: z.string().trim().min(1, '닉네임을 입력해주세요.').max(20, '닉네임은 20자 이내로 입력해주세요.'),
   department: z.string().min(1, '학과 · 학부를 선택해주세요.'),
@@ -11,7 +12,7 @@ const basicInfoSchema = z.object({
     .string()
     .trim()
     .min(1, '학번을 작성해주세요.')
-    .regex(/^\d+$/, '학번은 숫자만 입력해주세요.'),
+    .regex(REGEX.STUDENT_NUMBER, MESSAGES.STUDENT_NUMBER.FORMAT),
 });
 
 // ── 지원서 작성 (2단계) ────────────────────────────────────


### PR DESCRIPTION
- Close #1428

## What is this PR? 🔍

- 기능 : 팀원 모집 - 내 프로필 기본 정보 입력
- issue : #1428

## Changes 📝

- `ProfilePage/schema.ts`의 `basicInfoSchema.studentNumber` 검증을 숫자 여부만 확인하던 `/^\d+$/`에서, 회원가입 페이지와 동일한 `REGEX.STUDENT_NUMBER`(`static/auth.ts`) + `MESSAGES.STUDENT_NUMBER.FORMAT`으로 교체
- `9999999999`처럼 형식에 맞지 않는 무의미한 숫자는 더 이상 통과하지 않음

## ScreenShot 📷

<!-- UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요. -->

## Test CheckList ✅

- [ ] 내 프로필 학번 필드에 `9999999999` 입력 시 형식 오류 메시지와 함께 다음 단계로 진행되지 않는지 확인
- [ ] 정상적인 학번(예: `2021136000`) 입력 시 기존과 동일하게 통과하는지 확인
- [ ] 회원가입 페이지와 동일한 에러 메시지가 노출되는지 확인

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
