### PR TITLE
[캠퍼스] 역할 입력칸 글자 초과 현상 해결 및 입력란 크기 수정

### DIFF
--- a/src/components/Team/NewTeamRecruitment/components/RoleField/RoleField.module.scss
+++ b/src/components/Team/NewTeamRecruitment/components/RoleField/RoleField.module.scss
@@ -179,11 +179,11 @@
       }
 
       span {
-        flex: 1;
-        min-width: 0;
+        flex: none;
         text-align: right;
         font-size: 12px;
         color: #727272;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/Team/NewTeamRecruitment/components/RoleField/RoleField.module.scss
+++ b/src/components/Team/NewTeamRecruitment/components/RoleField/RoleField.module.scss
@@ -166,7 +166,6 @@
       }
 
       input {
-        flex: 1;
         min-width: 0;
         border: none;
         background: transparent;

--- a/src/components/Team/NewTeamRecruitment/components/RoleField/RoleField.module.scss
+++ b/src/components/Team/NewTeamRecruitment/components/RoleField/RoleField.module.scss
@@ -166,6 +166,7 @@
       }
 
       input {
+        flex: 1;
         min-width: 0;
         border: none;
         background: transparent;

--- a/src/components/Team/NewTeamRecruitment/components/RoleField/index.tsx
+++ b/src/components/Team/NewTeamRecruitment/components/RoleField/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { cn } from '@bcsdlab/utils';
 import MinusIcon from 'assets/svg/Team/minus-sign.svg';
 import PlusIcon from 'assets/svg/Team/plus.svg';
@@ -15,6 +16,39 @@ import styles from './RoleField.module.scss';
 interface RoleFieldProps {
   control: Control<TeamRecruitmentFormValues>;
   eventLabel: string;
+}
+
+interface RoleNameInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function RoleNameInput({ value, onChange }: RoleNameInputProps) {
+  const isComposingRef = useRef(false);
+
+  const commit = (raw: string) => {
+    onChange(raw.slice(0, TEAM_RECRUITMENT_ROLE_NAME_MAX_LENGTH));
+  };
+
+  return (
+    <input
+      type="text"
+      value={value}
+      placeholder="역할명"
+      maxLength={TEAM_RECRUITMENT_ROLE_NAME_MAX_LENGTH}
+      onCompositionStart={() => {
+        isComposingRef.current = true;
+      }}
+      onCompositionEnd={(event) => {
+        isComposingRef.current = false;
+        commit(event.currentTarget.value);
+      }}
+      onChange={(event) => {
+        if (isComposingRef.current) return;
+        commit(event.target.value);
+      }}
+    />
+  );
 }
 
 export default function RoleField({ control, eventLabel }: RoleFieldProps) {
@@ -111,13 +145,7 @@ export default function RoleField({ control, eventLabel }: RoleFieldProps) {
               name={`roles.${index}.name`}
               render={({ field }) => (
                 <div className={styles['field__row-name']}>
-                  <input
-                    type="text"
-                    value={field.value}
-                    placeholder="역할명"
-                    maxLength={TEAM_RECRUITMENT_ROLE_NAME_MAX_LENGTH}
-                    onChange={field.onChange}
-                  />
+                  <RoleNameInput value={field.value} onChange={field.onChange} />
                   <span>
                     {field.value.length}/{TEAM_RECRUITMENT_ROLE_NAME_MAX_LENGTH}
                   </span>

--- a/src/components/Team/NewTeamRecruitment/components/RoleField/index.tsx
+++ b/src/components/Team/NewTeamRecruitment/components/RoleField/index.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { cn } from '@bcsdlab/utils';
 import MinusIcon from 'assets/svg/Team/minus-sign.svg';
 import PlusIcon from 'assets/svg/Team/plus.svg';
@@ -24,28 +23,14 @@ interface RoleNameInputProps {
 }
 
 function RoleNameInput({ value, onChange }: RoleNameInputProps) {
-  const isComposingRef = useRef(false);
-
-  const commit = (raw: string) => {
-    onChange(raw.slice(0, TEAM_RECRUITMENT_ROLE_NAME_MAX_LENGTH));
-  };
-
   return (
     <input
       type="text"
       value={value}
       placeholder="역할명"
       maxLength={TEAM_RECRUITMENT_ROLE_NAME_MAX_LENGTH}
-      onCompositionStart={() => {
-        isComposingRef.current = true;
-      }}
-      onCompositionEnd={(event) => {
-        isComposingRef.current = false;
-        commit(event.currentTarget.value);
-      }}
       onChange={(event) => {
-        if (isComposingRef.current) return;
-        commit(event.target.value);
+        onChange(event.target.value.slice(0, TEAM_RECRUITMENT_ROLE_NAME_MAX_LENGTH));
       }}
     />
   );


### PR DESCRIPTION
- Close #1430 

## What is this PR? 🔍

- 기능 : 역할입력칸에 글자 초과 현상 제거 및 input 크기를 수정했습니다
- issue : #1430

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 역할명 입력란이 컨테이너 폭의 절반 정도만 채워지던 문제를 수정했습니다.
- ref 방식으로 변경했을 당시 역할명 10자 제한이 조합중에는 정확히 지켜지지 않던 문제를 수정했습니다.
  - 조합 여부와 상관없이 `onChange`마다 항상 `slice(0, 10)`으로 값을 강제 고정하도록 정리했습니다.
## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="264" height="159" alt="image" src="https://github.com/user-attachments/assets/d32fb8e8-3de8-40d6-b203-d22f3665a90d" />

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] yarn lint
- [x] yarn build
- [x] 10글자 제한 확인

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 역할명 입력란이 설정된 최대 글자 수를 초과하지 않도록 제한됩니다.
  - 역할명 입력 행의 텍스트가 줄바꿈되지 않아 화면 구성이 안정적으로 표시됩니다.
  - 입력 영역과 주변 정보의 불필요한 확장을 방지해 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->