### PR TITLE
fix: 전역 css 폰트 설정에 input/textarea 추가

### DIFF
--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -25,7 +25,10 @@ body {
 }
 
 a,
-button {
+button,
+input,
+textarea,
+select {
   color: #000;
   font-family: var(--font-pretendard), sans-serif;
 }


### PR DESCRIPTION
- Close #1434 

## What is this PR? 🔍

- 기능 : textarea와 input 안의 폰트가 pretend로 공통되지 않던 부분을 수정했습니다
- issue : #1434

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 전역 css font-family에 `input`, `textarea` 요소 추가

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] yarn lint

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
