### PR TITLE
[공통] 로깅 구조 개선- 타입 안전성 및 중복 코드 정리

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,6 +121,16 @@ export default [
         },
       ],
 
+      // useLogger/useSessionLogger 모두 event_category 를 넘기지 않으면 'click' 을 기본값으로 채운다.
+      // 리터럴 'click' 을 직접 쓰면 항상 중복이므로 막는다. 동적으로 'click' 이 될 수 있는 값(조건식 등)은 잡지 않는다.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "Property[key.name='event_category'][value.type='Literal'][value.value='click']",
+          message: "event_category: 'click' 은 actionEventClick/actionSessionEvent 의 기본값이라 중복입니다. 생략하세요.",
+        },
+      ],
+
       'import/extensions': 'off',
       'react/jsx-key': 'off',
       'react/display-name': 'off',

--- a/src/components/Auth/LoginPage/components/AdditionalLink/index.tsx
+++ b/src/components/Auth/LoginPage/components/AdditionalLink/index.tsx
@@ -82,7 +82,6 @@ export default function AdditionalLink() {
             session_name: 'sign_up',
             event_label: 'start_sign_up',
             value: '회원가입 시작',
-            event_category: 'click',
           });
         }}
       >

--- a/src/components/Auth/LoginPage/components/LoginForm/index.tsx
+++ b/src/components/Auth/LoginPage/components/LoginForm/index.tsx
@@ -86,7 +86,6 @@ export default function LoginForm() {
                 session_name: 'sign_up',
                 event_label: 'start_sign_up',
                 value: '회원가입 시작',
-                event_category: 'click',
               });
             }}
           >

--- a/src/components/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
+++ b/src/components/Auth/SignupPage/Steps/MobileStudentDetailStep/index.tsx
@@ -65,7 +65,6 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
       sessionLogger.actionSessionEvent({
         event_label: 'create_account',
         value: '아이디생성',
-        event_category: 'click',
         session_name: 'sign_up',
       });
     },
@@ -90,7 +89,6 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
       sessionLogger.actionSessionEvent({
         event_label: 'create_account',
         value: '닉네임생성',
-        event_category: 'click',
         session_name: 'sign_up',
       });
     },
@@ -114,7 +112,6 @@ function MobileStudentDetailStep({ onNext }: MobileVerificationProps) {
       sessionLogger.actionSessionEvent({
         event_label: 'sign_up_completed',
         value: '회원가입완료',
-        event_category: 'click',
         session_name: 'sign_up',
       });
     },

--- a/src/components/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
+++ b/src/components/Auth/SignupPage/Steps/MobileVerificationStep/index.tsx
@@ -113,7 +113,6 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
       sessionLogger.actionSessionEvent({
         event_label: 'identity_verification',
         value: '인증완료',
-        event_category: 'click',
         session_name: 'sign_up',
       });
     },
@@ -137,7 +136,6 @@ function MobileVerification({ onNext }: MobileVerificationProps) {
       sessionLogger.actionSessionEvent({
         event_label: 'identity_verification',
         value: '인증번호 발송',
-        event_category: 'click',
         session_name: 'sign_up',
       });
     },

--- a/src/components/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
+++ b/src/components/Auth/SignupPage/Steps/StudentDetailStep/index.tsx
@@ -98,7 +98,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
       sessionLogger.actionSessionEvent({
         event_label: 'create_account',
         value: '아이디생성',
-        event_category: 'click',
         session_name: 'sign_up',
       });
     },
@@ -119,7 +118,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
       sessionLogger.actionSessionEvent({
         event_label: 'create_account',
         value: '닉네임생성',
-        event_category: 'click',
         session_name: 'sign_up',
       });
     },
@@ -180,7 +178,6 @@ function StudentDetail({ onNext, onBack }: VerificationProps) {
         sessionLogger.actionSessionEvent({
           event_label: 'sign_up_completed',
           value: '회원가입완료',
-          event_category: 'click',
           session_name: 'sign_up',
         });
       },

--- a/src/components/Auth/SignupPage/Steps/Terms/index.tsx
+++ b/src/components/Auth/SignupPage/Steps/Terms/index.tsx
@@ -29,7 +29,6 @@ export default function Terms({ onNext }: TermsProps) {
     sessionLogger.actionSessionEvent({
       event_label: 'terms_agreement',
       value: '약관동의',
-      event_category: 'click',
       session_name: 'sign_up',
     });
   };

--- a/src/components/Auth/SignupPage/Steps/VerificationStep/index.tsx
+++ b/src/components/Auth/SignupPage/Steps/VerificationStep/index.tsx
@@ -88,7 +88,6 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
     sessionLogger.actionSessionEvent({
       event_label: 'create_account',
       value: '학생',
-      event_category: 'click',
       session_name: 'sign_up',
     });
   };
@@ -99,7 +98,6 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
     sessionLogger.actionSessionEvent({
       event_label: 'create_account',
       value: '외부인',
-      event_category: 'click',
       session_name: 'sign_up',
     });
   };
@@ -220,7 +218,6 @@ function Verification({ onNext, onBack, setUserType }: VerificationProps) {
                       sessionLogger.actionSessionEvent({
                         event_label: 'identity_verification',
                         value: '인증번호 발송',
-                        event_category: 'click',
                         session_name: 'sign_up',
                       });
                     }}

--- a/src/components/Auth/SignupPage/index.tsx
+++ b/src/components/Auth/SignupPage/index.tsx
@@ -39,7 +39,6 @@ function SignupPage() {
     sessionLogger.actionSessionEvent({
       event_label: 'create_account',
       value: user,
-      event_category: 'click',
       session_name: 'sign_up',
     });
   };

--- a/src/components/Course/components/CourseSearchForm/index.tsx
+++ b/src/components/Course/components/CourseSearchForm/index.tsx
@@ -51,18 +51,18 @@ export default function CourseSearchForm({
 
   const handleChangeDropdown = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = e.target.value;
-    logger.actionEventClick({ team: 'User', event_label: 'application_training_all', value: selectedValue });
+    logger.actionEventClick({ team: 'USER', event_label: 'application_training_all', value: selectedValue });
     onDepartmentChange(e);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    logger.actionEventClick({ team: 'User', event_label: 'application_training_check', value: '' });
+    logger.actionEventClick({ team: 'USER', event_label: 'application_training_check', value: '' });
     onSearch();
   };
 
   const handleGoMain = () => {
-    logger.actionEventClick({ team: 'User', event_label: 'application_training_back', value: '' });
+    logger.actionEventClick({ team: 'USER', event_label: 'application_training_back', value: '' });
     router.push(ROUTES.Main());
   };
 

--- a/src/components/IndexComponents/IndexStore/index.tsx
+++ b/src/components/IndexComponents/IndexStore/index.tsx
@@ -8,6 +8,7 @@ import ROUTES from 'static/routes';
 import { ORDER_BASE_URL } from 'static/url';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
+import type { LoggingTeam } from 'lib/gtag';
 import styles from './IndexStore.module.scss';
 
 interface Category {
@@ -18,10 +19,10 @@ interface Category {
 
 interface CategoryWithEvent extends Category {
   event: {
-    team: string;
+    team: LoggingTeam;
     event_label: string;
     value: string;
-    event_category: string;
+    event_category?: string;
     previous_page: string;
     current_page: string;
   };
@@ -36,10 +37,9 @@ export default function IndexStore({ categories }: { categories: StoreCategories
   const categoriesWithEvent = categories.shop_categories.map((category: Category) => ({
     ...category,
     event: {
-      team: 'BUSINESS',
+      team: 'BUSINESS' as const,
       event_label: 'main_shop_categories',
       value: category.name,
-      event_category: 'click',
       previous_page: '메인',
       current_page: category.name,
     },

--- a/src/components/IndexComponents/IndexStore/index.tsx
+++ b/src/components/IndexComponents/IndexStore/index.tsx
@@ -22,7 +22,6 @@ interface CategoryWithEvent extends Category {
     team: LoggingTeam;
     event_label: string;
     value: string;
-    event_category?: string;
     previous_page: string;
     current_page: string;
   };

--- a/src/components/Store/StoreDetailPage/components/Review/components/DeleteModal/DeleteModal.tsx
+++ b/src/components/Store/StoreDetailPage/components/Review/components/DeleteModal/DeleteModal.tsx
@@ -14,14 +14,14 @@ export default function DeleteModal({ close, deleteMyReview, storeDetail }: Prop
 
   const loggingConfirmDeleteClick = () => {
     logger.actionEventClick({
-      team: 'BUSINSESS',
+      team: 'BUSINESS',
       event_label: 'shop_detail_view_review_delete_done',
       value: storeDetail.name,
     });
   };
   const loggingCancelDeleteClick = () => {
     logger.actionEventClick({
-      team: 'BUSINSESS',
+      team: 'BUSINESS',
       event_label: 'shop_detail_view_review_delete_cancel',
       value: storeDetail.name,
     });

--- a/src/components/Store/StoreReviewPage/ReviewForm/ReviewForm.tsx
+++ b/src/components/Store/StoreReviewPage/ReviewForm/ReviewForm.tsx
@@ -11,7 +11,7 @@ import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useImageUpload from 'utils/hooks/ui/useImageUpload';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
-import { isomorphicSessionStorage } from 'utils/ts/env';
+import getElapsedSeconds from 'utils/ts/getElapsedSeconds';
 import uuidv4 from 'utils/ts/uuidGenerater';
 import styles from './ReviewForm.module.scss';
 
@@ -67,7 +67,7 @@ function ReviewForm({ storeDetail, mutate, initialData = {} }: Props) {
 
   const reviewSuccessLogging = () => {
     const getReviewDurationTime =
-      (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterReview'))) / 1000;
+      getElapsedSeconds('enterReview');
     logger.actionEventClick({
       team: 'BUSINESS',
       event_label: 'shop_detail_view_review_write_done',

--- a/src/components/Team/ProfilePage/Steps/ApplicationStep/index.tsx
+++ b/src/components/Team/ProfilePage/Steps/ApplicationStep/index.tsx
@@ -28,7 +28,6 @@ export default function ApplicationStep({ mode, onBack, onSubmit, isSubmitting, 
   const handleSave = () => {
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: `team_recruitment_profile_${logMode}_submit`,
       value: submitLabel,
     });
@@ -71,7 +70,6 @@ export default function ApplicationStep({ mode, onBack, onSubmit, isSubmitting, 
           onAppend={() =>
             actionEventClick({
               team: 'CAMPUS',
-              event_category: 'click',
               event_label: `team_recruitment_profile_${logMode}_skill_add`,
               value: '기술 / 자격증 추가',
             })

--- a/src/components/Team/ProfilePage/index.tsx
+++ b/src/components/Team/ProfilePage/index.tsx
@@ -186,7 +186,6 @@ function ProfileFormBody({ mode, defaultValues }: ProfileFormBodyProps) {
   const handleCancelSubmit = () => {
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: `team_recruitment_profile_${PROFILE_LOG_MODE[mode]}_submit_cancel`,
       value: '취소하기',
     });

--- a/src/components/Team/RecruitmentApplyPage/Steps/ApplicationStep/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/Steps/ApplicationStep/index.tsx
@@ -35,7 +35,6 @@ export default function ApplicationStep({ roles, onBack, onSubmit, isSubmitting 
   const handleSubmitClick = () => {
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: LOGGING_TITLE.SUBMIT,
       value: '지원하기',
     });
@@ -84,7 +83,6 @@ export default function ApplicationStep({ roles, onBack, onSubmit, isSubmitting 
                             field.onChange(role.id);
                             actionEventClick({
                               team: 'CAMPUS',
-                              event_category: 'click',
                               event_label: LOGGING_TITLE.ROLE_SELECT,
                               value: role.name,
                             });

--- a/src/components/Team/RecruitmentApplyPage/Steps/BasicInfoStep/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/Steps/BasicInfoStep/index.tsx
@@ -178,7 +178,6 @@ export default function BasicInfoStep({ onNext }: BasicInfoStepProps) {
             onAppend={() =>
               actionEventClick({
                 team: 'CAMPUS',
-                event_category: 'click',
                 event_label: LOGGING_TITLE.SKILL_ADD,
                 value: '기술 / 자격증 추가',
               })

--- a/src/components/Team/RecruitmentApplyPage/index.tsx
+++ b/src/components/Team/RecruitmentApplyPage/index.tsx
@@ -180,7 +180,6 @@ export default function RecruitmentApplyPage() {
 
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: LOGGING_TITLE.SUBMIT_CONFIRM,
       value: '지원하기',
     });
@@ -208,7 +207,6 @@ export default function RecruitmentApplyPage() {
   const handleCancelSubmit = () => {
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: LOGGING_TITLE.SUBMIT_CANCEL,
       value: '취소하기',
     });

--- a/src/components/Team/hooks/useAcademicInfoStep.ts
+++ b/src/components/Team/hooks/useAcademicInfoStep.ts
@@ -53,7 +53,6 @@ export default function useAcademicInfoStep(loggingTitle: AcademicInfoLoggingTit
   const handleLoadUserInfo = () => {
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: loggingTitle.LOAD_USER_INFO,
       value: '회원정보 불러오기',
     });
@@ -69,7 +68,7 @@ export default function useAcademicInfoStep(loggingTitle: AcademicInfoLoggingTit
     mutationFn: (data: { department: string; studentNumber: string }) =>
       updateAcademicInfo(token, { department: data.department, student_number: data.studentNumber }),
     onSuccess: () => {
-      actionEventClick({ team: 'CAMPUS', event_category: 'click', event_label: loggingTitle.NEXT, value: '다음' });
+      actionEventClick({ team: 'CAMPUS', event_label: loggingTitle.NEXT, value: '다음' });
       onSaved();
     },
     onError: (error) => {
@@ -93,7 +92,6 @@ export default function useAcademicInfoStep(loggingTitle: AcademicInfoLoggingTit
   const handleMajorSelect = (value: string) => {
     actionEventClick({
       team: 'CAMPUS',
-      event_category: 'click',
       event_label: loggingTitle.MAJOR_SELECT,
       value,
     });

--- a/src/components/Team/hooks/useActivityHistoryField.ts
+++ b/src/components/Team/hooks/useActivityHistoryField.ts
@@ -76,7 +76,7 @@ export default function useActivityHistoryField(
   };
 
   const handleEdit = (index: number) => {
-    actionEventClick({ team: 'CAMPUS', event_category: 'click', event_label: loggingTitle.EDIT, value: '수정' });
+    actionEventClick({ team: 'CAMPUS', event_label: loggingTitle.EDIT, value: '수정' });
     setValue(`activities.${index}.status`, 'draft');
   };
 

--- a/src/components/TimetablePage/MainTimetablePage/DefaultPage/index.tsx
+++ b/src/components/TimetablePage/MainTimetablePage/DefaultPage/index.tsx
@@ -8,6 +8,7 @@ import TimetableList from 'components/TimetablePage/components/TimetableList';
 import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import { isomorphicSessionStorage } from 'utils/ts/env';
+import getElapsedSeconds from 'utils/ts/getElapsedSeconds';
 import styles from './DefaultPage.module.scss';
 
 interface DefaultPageProps {
@@ -27,7 +28,7 @@ export default function DefaultPage({ timetableFrameId, setCurrentFrameId }: Def
         value: 'OS스와이프',
         previous_page: '시간표',
         current_page: '메인',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterTimetablePage'))) / 1000,
+        duration_time: getElapsedSeconds('enterTimetablePage'),
       });
       history.back();
       return;
@@ -39,7 +40,7 @@ export default function DefaultPage({ timetableFrameId, setCurrentFrameId }: Def
       value: '뒤로가기버튼',
       previous_page: '시간표',
       current_page: '메인',
-      duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterTimetablePage'))) / 1000,
+      duration_time: getElapsedSeconds('enterTimetablePage'),
     });
   }, [logger]);
 

--- a/src/components/TimetablePage/components/MainTimetable/index.tsx
+++ b/src/components/TimetablePage/components/MainTimetable/index.tsx
@@ -18,7 +18,7 @@ import ROUTES from 'static/routes';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useBooleanState from 'utils/hooks/state/useBooleanState';
 import useTokenState from 'utils/hooks/state/useTokenState';
-import { isomorphicSessionStorage } from 'utils/ts/env';
+import getElapsedSeconds from 'utils/ts/getElapsedSeconds';
 import { useSemester } from 'utils/zustand/semester';
 import DownloadTimetableModal from './DownloadTimetableModal';
 import styles from './MyLectureTimetable.module.scss';
@@ -127,7 +127,7 @@ function ValidMainTimetable({ timetableFrameId }: { readonly timetableFrameId: n
         team: 'USER',
         event_label: 'timetable',
         value: '이미지저장',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterTimetablePage'))) / 1000,
+        duration_time: getElapsedSeconds('enterTimetablePage'),
       });
       openModal();
     }

--- a/src/components/cafeteria/MobileCafeteriaPage/index.tsx
+++ b/src/components/cafeteria/MobileCafeteriaPage/index.tsx
@@ -65,7 +65,6 @@ export default function MobileCafeteriaPage() {
     sessionLogger.actionSessionEvent({
       event_label: 'dining_to_shop',
       value: DINING_TYPE_MAP[diningType],
-      event_category: 'click',
       session_name: 'dining2shop',
       session_lifetime_minutes: 30,
     });

--- a/src/components/cafeteria/PCCafeteriaPage/index.tsx
+++ b/src/components/cafeteria/PCCafeteriaPage/index.tsx
@@ -45,7 +45,6 @@ function PCCafeteriaComponent() {
     sessionLogger.actionSessionEvent({
       event_label: 'dining_to_shop',
       value: DINING_TYPE_MAP[diningType],
-      event_category: 'click',
       session_name: 'dining2shop',
       session_lifetime_minutes: 30,
     });

--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -5,11 +5,13 @@ import { useRouter } from 'next/router';
 import LoginRequiredModal from 'components/modal/LoginRequiredModal';
 import { CATEGORY } from 'static/category';
 import ROUTES from 'static/routes';
+import { SHORTCUT_LOGGING_MAP } from 'utils/hooks/analytics/shortcutLoggingMap';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import useMediaQuery from 'utils/hooks/layout/useMediaQuery';
 import useModalPortal from 'utils/hooks/layout/useModalPortal';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import type { Portal } from 'components/modal/Modal/PortalProvider';
+import type { SubmenuTitle } from 'static/category';
 import styles from './Footer.module.scss';
 
 function Footer() {
@@ -26,26 +28,11 @@ function Footer() {
     return null;
   }
 
-  const logShortcut = (title: string) => {
-    const loggingMap: Record<string, { team: string; event_label: string; value: string; event_category?: string }> = {
-      공지사항: { team: 'CAMPUS', event_label: 'footer', value: '공지사항' },
-      분실물: { team: 'CAMPUS', event_label: 'footer', value: '분실물' },
-      '버스 교통편': { team: 'CAMPUS', event_label: 'footer', value: '버스 교통편' },
-      '버스 시간표': { team: 'CAMPUS', event_label: 'footer', value: '버스 시간표' },
-      식단: { team: 'CAMPUS', event_label: 'footer', value: '식단' },
-      시간표: { team: 'USER', event_label: 'footer', value: '시간표' },
-      복덕방: { team: 'BUSINESS', event_label: 'footer', value: '복덕방' },
-      주변상점: { team: 'BUSINESS', event_label: 'footer', value: '주변상점' },
-      '교내 시설물 정보': { team: 'CAMPUS', event_label: 'footer', value: '교내 시설물 정보' },
-      '학교 부서 정보': { team: 'CAMPUS', event_label: 'footer', value: '학교 부서 정보' },
-      '코인 사장님': { team: 'BUSINESS', event_label: 'footer', value: '코인 사장님' },
-      쪽지: { team: 'CAMPUS', event_label: 'footer', value: '쪽지' },
-      동아리: { team: 'CAMPUS', event_label: 'footer', value: '동아리' },
-      '팀원 모집': { team: 'CAMPUS', event_label: 'footer', value: '팀원 모집' },
-    };
+  const logShortcut = (title: SubmenuTitle) => {
+    const info = SHORTCUT_LOGGING_MAP[title];
 
-    if (loggingMap[title]) {
-      logger.actionEventClick(loggingMap[title]);
+    if (info) {
+      logger.actionEventClick({ ...info, event_label: 'footer' });
 
       if (String(pathname) === ROUTES.GraduationCalculator()) {
         logger.actionEventClick({
@@ -57,7 +44,7 @@ function Footer() {
     }
   };
 
-  const handleClickMenu = (e: React.MouseEvent<HTMLAnchorElement>, title: string) => {
+  const handleClickMenu = (e: React.MouseEvent<HTMLAnchorElement>, title: SubmenuTitle) => {
     logShortcut(title);
     if (!token && title === '쪽지') {
       e.preventDefault();

--- a/src/components/layout/Header/MobileHeader/Panel/index.tsx
+++ b/src/components/layout/Header/MobileHeader/Panel/index.tsx
@@ -13,7 +13,7 @@ import useTokenState from 'utils/hooks/state/useTokenState';
 import { useUser } from 'utils/hooks/state/useUser';
 import { useBodyScrollLock } from 'utils/hooks/ui/useBodyScrollLock';
 import { useEscapeKeyDown } from 'utils/hooks/ui/useEscapeKeyDown';
-import { isomorphicSessionStorage } from 'utils/ts/env';
+import getElapsedSeconds from 'utils/ts/getElapsedSeconds';
 import { useMobileSidebar } from 'utils/zustand/mobileSidebar';
 import type { Portal } from 'components/modal/Modal/PortalProvider';
 import styles from './Panel.module.scss';
@@ -64,7 +64,7 @@ export default function Panel({ openModal }: PanelProps) {
         value: '햄버거',
         previous_page: '시간표',
         current_page: title,
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterTimetablePage'))) / 1000,
+        duration_time: getElapsedSeconds('enterTimetablePage'),
       });
     }
   };

--- a/src/components/layout/Header/MobileHeader/index.tsx
+++ b/src/components/layout/Header/MobileHeader/index.tsx
@@ -13,6 +13,7 @@ import { useResetHeaderButton } from 'utils/hooks/layout/useResetHeaderButton';
 import useParamsHandler from 'utils/hooks/routing/useParamsHandler';
 import useMount from 'utils/hooks/state/useMount';
 import { isomorphicSessionStorage } from 'utils/ts/env';
+import getElapsedSeconds from 'utils/ts/getElapsedSeconds';
 import { backButtonTapped } from 'utils/ts/iosBridge';
 import { useHeaderTitle } from 'utils/zustand/customTitle';
 import { useHeaderButtonStore } from 'utils/zustand/headerButtonStore';
@@ -48,9 +49,8 @@ export default function MobileHeader({ openModal }: MobileHeaderProps) {
         team: 'BUSINESS',
         event_label: 'shop_detail_view_back',
         value: response.name,
-        event_category: 'click',
         current_page: isomorphicSessionStorage.getItem('cameFrom') || '',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enter_storeDetail'))) / 1000,
+        duration_time: getElapsedSeconds('enter_storeDetail'),
       }); // 상점 내 뒤로가기 버튼 로깅
       router.back();
       return;
@@ -62,7 +62,7 @@ export default function MobileHeader({ openModal }: MobileHeaderProps) {
         value: '뒤로가기버튼',
         previous_page: '시간표',
         current_page: '메인',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterTimetablePage'))) / 1000,
+        duration_time: getElapsedSeconds('enterTimetablePage'),
       });
     }
 

--- a/src/components/layout/Header/PCHeader/index.tsx
+++ b/src/components/layout/Header/PCHeader/index.tsx
@@ -7,6 +7,7 @@ import LoginRequiredModal from 'components/modal/LoginRequiredModal';
 import { CATEGORY, Category, Submenu } from 'static/category';
 import ROUTES from 'static/routes';
 import { useServerRequest } from 'utils/context/serverRequest';
+import { SHORTCUT_LOGGING_MAP } from 'utils/hooks/analytics/shortcutLoggingMap';
 import useLogger from 'utils/hooks/analytics/useLogger';
 import { useSessionLogger } from 'utils/hooks/analytics/useSessionLogger';
 import { useLogout } from 'utils/hooks/auth/useLogout';
@@ -14,7 +15,9 @@ import useModalPortal from 'utils/hooks/layout/useModalPortal';
 import useMount from 'utils/hooks/state/useMount';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import { isomorphicSessionStorage } from 'utils/ts/env';
+import getElapsedSeconds from 'utils/ts/getElapsedSeconds';
 import type { Portal } from 'components/modal/Modal/PortalProvider';
+import type { SubmenuTitle } from 'static/category';
 import styles from './PCHeader.module.scss';
 
 const ID: { [key: string]: string } = {
@@ -82,55 +85,11 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
   // 그리고 클라이언트가 마운트 후 로그인 UI로 교체한다(a → button).
   const isLoggedin = mounted ? !!token : (serverRequest?.isLoggedIn ?? false);
 
-  const logShortcut = (title: string) => {
-    const loggingMap: Record<string, { team: string; event_label: string; value: string; event_category?: string }> = {
-      공지사항: { team: 'CAMPUS', event_label: 'header', value: '공지사항' },
-      분실물: { team: 'CAMPUS', event_label: 'header', value: '분실물' },
-      '버스 교통편': { team: 'CAMPUS', event_label: 'header', value: '버스 교통편' },
-      '버스 시간표': { team: 'CAMPUS', event_label: 'header', value: '버스 시간표' },
-      식단: { team: 'CAMPUS', event_label: 'header', value: '식단' },
-      시간표: { team: 'USER', event_label: 'header', value: '시간표' },
-      복덕방: { team: 'BUSINESS', event_label: 'header', value: '복덕방' },
-      주변상점: {
-        team: 'BUSINESS',
-        event_label: 'header',
-        value: '주변상점',
-        event_category: 'click',
-      },
-      '교내 시설물 정보': {
-        team: 'CAMPUS',
-        event_label: 'header',
-        value: '교내 시설물 정보',
-        event_category: 'click',
-      },
-      '학교 부서 정보': {
-        team: 'CAMPUS',
-        event_label: 'header',
-        value: '학교 부서 정보',
-        event_category: 'click',
-      },
-      쪽지: {
-        team: 'CAMPUS',
-        event_label: 'header',
-        value: '쪽지',
-        event_category: 'click',
-      },
-      동아리: {
-        team: 'CAMPUS',
-        event_label: 'header',
-        value: '동아리',
-        event_category: 'click',
-      },
-      '팀원 모집': {
-        team: 'CAMPUS',
-        event_label: 'header',
-        value: '팀원 모집',
-        event_category: 'click',
-      },
-    };
+  const logShortcut = (title: SubmenuTitle) => {
+    const info = SHORTCUT_LOGGING_MAP[title];
 
-    if (loggingMap[title]) {
-      logger.actionEventClick(loggingMap[title]);
+    if (info) {
+      logger.actionEventClick({ ...info, event_label: 'header' });
 
       if (pathname === ROUTES.GraduationCalculator()) {
         logger.actionEventClick({
@@ -150,7 +109,7 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
         value: '로고',
         previous_page: '시간표',
         current_page: '메인',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterTimetablePage'))) / 1000,
+        duration_time: getElapsedSeconds('enterTimetablePage'),
       });
     }
     if (pathname.includes(ROUTES.Store()) && search.includes('state')) {
@@ -162,7 +121,7 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
         value: shopName.name,
         event_category: 'logo',
         current_page: isomorphicSessionStorage.getItem('cameFrom') || '전체보기',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enter_storeDetail'))) / 1000,
+        duration_time: getElapsedSeconds('enter_storeDetail'),
       });
     }
     if (pathname.includes(ROUTES.GraduationCalculator())) {
@@ -190,7 +149,7 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
     ));
   };
 
-  const handleMenuClick = (e: React.MouseEvent<HTMLAnchorElement>, title: string) => {
+  const handleMenuClick = (e: React.MouseEvent<HTMLAnchorElement>, title: SubmenuTitle) => {
     logShortcut(title);
     if (!token && title === '쪽지') {
       e.preventDefault();
@@ -288,7 +247,6 @@ export default function PCHeader({ openModal }: PCHeaderProps) {
                     session_name: 'sign_up',
                     event_label: 'header',
                     value: '회원가입 시작',
-                    event_category: 'click',
                   });
                 }}
               >

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -1,5 +1,7 @@
+export type LoggingTeam = 'CAMPUS' | 'BUSINESS' | 'USER';
+
 type GTagEvent = {
-  team: string;
+  team: LoggingTeam;
   event_category: string;
   event_label: string;
   value: string;

--- a/src/pages/auth/signup/[id].tsx
+++ b/src/pages/auth/signup/[id].tsx
@@ -40,7 +40,6 @@ function SignupPage() {
     sessionLogger.actionSessionEvent({
       event_label: 'create_account',
       value: user,
-      event_category: 'click',
       session_name: 'sign_up',
     });
   };

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -23,10 +23,10 @@ import useLogger from 'utils/hooks/analytics/useLogger';
 import useModalPortal from 'utils/hooks/layout/useModalPortal';
 import useTokenState from 'utils/hooks/state/useTokenState';
 import type { Portal } from 'components/modal/Modal/PortalProvider';
+import type { LoggingTeam } from 'lib/gtag';
 import styles from './CategoryPage.module.scss';
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
-type CategoryLoggingTeam = 'USER' | 'CAMPUS' | 'BUSINESS';
 type CategoryEventLabel =
   | 'category_team_recruitment'
   | 'category_lost_and_found'
@@ -43,7 +43,7 @@ type CategoryEventLabel =
   | 'category_koin_for_business';
 
 interface CategoryLogging {
-  team: CategoryLoggingTeam;
+  team: LoggingTeam;
   event_label: CategoryEventLabel;
   value: string;
 }

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -33,7 +33,7 @@ function OpenCoursesTableContent({ searchParams, onAddCourse }: OpenCoursesTable
   const { data: courses } = useSuspenseQuery(courseQueries.search(searchParams));
 
   const handleAddOpenCourse = (course: PreCourse) => {
-    logger.actionEventClick({ team: 'User', event_label: 'application_training_apply', value: '' });
+    logger.actionEventClick({ team: 'USER', event_label: 'application_training_apply', value: '' });
     onAddCourse(course);
   };
 
@@ -45,7 +45,9 @@ function OpenCoursesTableContent({ searchParams, onAddCourse }: OpenCoursesTable
       title="개설강좌 정보"
       data={courses}
       columns={columns}
-      getRowKey={(course) => `${course.lecture_info.lecture_code}-${course.class_number}-${course.professor}-${course.class_time_raw.join(',')}`}
+      getRowKey={(course) =>
+        `${course.lecture_info.lecture_code}-${course.class_number}-${course.professor}-${course.class_time_raw.join(',')}`
+      }
     />
   );
 }
@@ -61,7 +63,7 @@ function PreCoursesTableContent({ token, timetableFrameId, onAddCourse }: PreCou
   const { data: preCourses } = useSuspenseQuery(courseQueries.preCourseList(token, timetableFrameId));
 
   const handleAddPreCourse = (course: PreCourse) => {
-    logger.actionEventClick({ team: 'User', event_label: 'application_training_pre_apply', value: '' });
+    logger.actionEventClick({ team: 'USER', event_label: 'application_training_pre_apply', value: '' });
     onAddCourse(course);
   };
 

--- a/src/pages/store/[id].tsx
+++ b/src/pages/store/[id].tsx
@@ -34,6 +34,7 @@ import useTokenState from 'utils/hooks/state/useTokenState';
 import useScrollToTop from 'utils/hooks/ui/useScrollToTop';
 import { isomorphicSessionStorage } from 'utils/ts/env';
 import getDayOfWeek from 'utils/ts/getDayOfWeek';
+import getElapsedSeconds from 'utils/ts/getElapsedSeconds';
 import {
   isNotFoundKoinError,
   STORE_DETAIL_ISR_REVALIDATE_SECONDS,
@@ -162,14 +163,14 @@ function StoreDetailPage({ id }: Props) {
         value: '',
         previous_page: '리뷰',
         current_page: '전화',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterReviewPage'))) / 1000,
+        duration_time: getElapsedSeconds('enterReviewPage'),
       });
     }
     logger.actionEventClick({
       team: 'BUSINESS',
       event_label: `${storeType}_call`,
       value: storeDetail!.name,
-      duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enter_storeDetail'))) / 1000,
+      duration_time: getElapsedSeconds('enter_storeDetail'),
     });
   };
 
@@ -178,7 +179,6 @@ function StoreDetailPage({ id }: Props) {
       team: 'BUSINESS',
       event_label: 'shop_picture',
       value: storeDetail!.name,
-      event_category: 'click',
     });
     portalManager.open((portalOption: Portal) => (
       <ImageModal imageList={img} imageIndex={index} onClose={portalOption.close} />
@@ -192,7 +192,7 @@ function StoreDetailPage({ id }: Props) {
         value: storeDetail.name,
         previous_page: '리뷰',
         current_page: '전체보기',
-        duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterReviewPage'))) / 1000,
+        duration_time: getElapsedSeconds('enterReviewPage'),
       });
     }
     logger.actionEventClick({
@@ -201,7 +201,7 @@ function StoreDetailPage({ id }: Props) {
       value: storeDetail!.name,
       event_category: 'ShopList',
       current_page: isomorphicSessionStorage.getItem('cameFrom') || '전체보기',
-      duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enter_storeDetail'))) / 1000,
+      duration_time: getElapsedSeconds('enter_storeDetail'),
     });
   };
   const onClickEventList = () => {
@@ -209,7 +209,6 @@ function StoreDetailPage({ id }: Props) {
       team: 'BUSINESS',
       event_label: 'shop_detail_view_event',
       value: `${storeDetail.name}`,
-      event_category: 'click',
     });
   };
   const onClickReviewList = () => {
@@ -217,7 +216,6 @@ function StoreDetailPage({ id }: Props) {
       team: 'BUSINESS',
       event_label: 'shop_detail_view_review',
       value: `${storeDetail.name}`,
-      event_category: 'click',
     });
   };
   const copyAccount = async (account: string) => {
@@ -266,7 +264,7 @@ function StoreDetailPage({ id }: Props) {
           value: storeDetail.name,
           previous_page: '리뷰',
           current_page: searchParams.get('state') || '메뉴',
-          duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enterReviewPage'))) / 1000,
+          duration_time: getElapsedSeconds('enterReviewPage'),
         });
         isomorphicSessionStorage.removeItem('enterReviewPage');
       }
@@ -283,7 +281,7 @@ function StoreDetailPage({ id }: Props) {
           value: storeDetail.name,
           event_category: 'swipe',
           current_page: isomorphicSessionStorage.getItem('cameFrom') || '전체보기',
-          duration_time: (new Date().getTime() - Number(isomorphicSessionStorage.getItem('enter_storeDetail'))) / 1000,
+          duration_time: getElapsedSeconds('enter_storeDetail'),
         });
       };
       window.addEventListener('popstate', handlePopState);

--- a/src/utils/hooks/analytics/shortcutLoggingMap.ts
+++ b/src/utils/hooks/analytics/shortcutLoggingMap.ts
@@ -1,0 +1,24 @@
+import type { LoggingTeam } from 'lib/gtag';
+import type { SubmenuTitle } from 'static/category';
+
+interface ShortcutLoggingInfo {
+  team: LoggingTeam;
+  value: string;
+}
+
+export const SHORTCUT_LOGGING_MAP: Partial<Record<SubmenuTitle, ShortcutLoggingInfo>> = {
+  공지사항: { team: 'CAMPUS', value: '공지사항' },
+  분실물: { team: 'CAMPUS', value: '분실물' },
+  '버스 교통편': { team: 'CAMPUS', value: '버스 교통편' },
+  '버스 시간표': { team: 'CAMPUS', value: '버스 시간표' },
+  식단: { team: 'CAMPUS', value: '식단' },
+  시간표: { team: 'USER', value: '시간표' },
+  복덕방: { team: 'BUSINESS', value: '복덕방' },
+  주변상점: { team: 'BUSINESS', value: '주변상점' },
+  '교내 시설물 정보': { team: 'CAMPUS', value: '교내 시설물 정보' },
+  '학교 부서 정보': { team: 'CAMPUS', value: '학교 부서 정보' },
+  '코인 사장님': { team: 'BUSINESS', value: '코인 사장님' },
+  쪽지: { team: 'CAMPUS', value: '쪽지' },
+  동아리: { team: 'CAMPUS', value: '동아리' },
+  '팀원 모집': { team: 'CAMPUS', value: '팀원 모집' },
+};

--- a/src/utils/hooks/analytics/useLogger.ts
+++ b/src/utils/hooks/analytics/useLogger.ts
@@ -1,8 +1,9 @@
 import { useRef } from 'react';
 import * as gtag from 'lib/gtag';
+import type { LoggingTeam } from 'lib/gtag';
 
 type ActionLoggerProps = {
-  team: string;
+  team: LoggingTeam;
   event_label: string;
   value: string;
   event_category?: string;
@@ -13,7 +14,7 @@ type ActionLoggerProps = {
 };
 
 type LoggerEventProps = {
-  team: string;
+  team: LoggingTeam;
   event_category: string;
   event_label: string;
   value: string;

--- a/src/utils/hooks/auth/usePhoneVerification.ts
+++ b/src/utils/hooks/auth/usePhoneVerification.ts
@@ -129,7 +129,6 @@ function usePhoneVerification({ phoneNumber, onNext, step }: UsePhoneVerificatio
         sessionLogger.actionSessionEvent({
           event_label: 'identity_verification',
           value: '인증완료',
-          event_category: 'click',
           session_name: 'sign_up',
         });
       }

--- a/src/utils/hooks/auth/useUserInfoUpdate.ts
+++ b/src/utils/hooks/auth/useUserInfoUpdate.ts
@@ -30,7 +30,6 @@ const useUserInfoUpdate = <T = unknown>(userType: UserType, options: UserUpdateO
       logger.actionEventClick({
         event_label: 'user_info',
         value: '정보수정 완료',
-        event_category: 'click',
         team: 'USER',
       });
     },
@@ -42,7 +41,6 @@ const useUserInfoUpdate = <T = unknown>(userType: UserType, options: UserUpdateO
       logger.actionEventClick({
         event_label: 'user_info',
         value: '정보수정 실패',
-        event_category: 'click',
         team: 'USER',
       });
     },

--- a/src/utils/ts/getElapsedSeconds.ts
+++ b/src/utils/ts/getElapsedSeconds.ts
@@ -1,0 +1,7 @@
+import { isomorphicSessionStorage } from 'utils/ts/env';
+
+const getElapsedSeconds = (entryTimeKey: string) => (
+  (new Date().getTime() - Number(isomorphicSessionStorage.getItem(entryTimeKey))) / 1000
+);
+
+export default getElapsedSeconds;


### PR DESCRIPTION
- Close #1442

## What is this PR? 🔍

- 기능 : 로깅 구조 개선 — 타입 안전성 확보 및 중복 코드 정리
- issue : #1442

## Changes 📝

- `team` 필드를 `string` → `LoggingTeam`(`'CAMPUS' | 'BUSINESS' | 'USER'`) 유니온 타입으로 좁혀 오타가 컴파일 단계에서 잡히도록 수정
- GA4에 이미 유입된 오타/케이싱 오염 수정: `BUSINSESS` → `BUSINESS`, `'User'` → `'USER'`
- `duration_time` 계산 로직을 7개 파일 중복에서 공용 헬퍼 `getElapsedSeconds`로 추출
- Footer/PCHeader에 각각 정의돼 있던 `loggingMap`을 공용 상수 `shortcutLoggingMap`으로 통합
- `event_category: 'click'` 중복 명시(로거 기본값과 동일) 전체 제거
- 재발 방지를 위한 ESLint `no-restricted-syntax` 규칙 추가 (`event_category: 'click'` 리터럴 명시 금지)

## ScreenShot 📷

<!-- 로깅 내부 구현 변경으로 UI 변경 없음 -->

## Test CheckList ✅

- [ ] `yarn typecheck` 통과 확인
- [ ] `yarn lint` 통과 확인 (신규 no-restricted-syntax 규칙 포함)
- [ ] Footer/PCHeader 단축 메뉴 클릭 시 GA4 이벤트가 기존과 동일하게 (team/value/event_label) 전송되는지 확인
- [ ] 시간표/상점 상세/리뷰 작성 페이지에서 `duration_time`이 정상적으로 계산되는지 확인

## Precaution

- `team: 'User'` → `'USER'`, `team: 'BUSINSESS'` → `'BUSINESS'` 변경은 GA4에 실제로 적재되는 값이 바뀌는 의도된 변경입니다. 변경 시점 이후로 기존 `'User'`/`'BUSINSESS'` 버킷은 신규 이벤트를 받지 않습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **분석 및 로깅 개선**
  - 클릭 이벤트의 중복 카테고리 정보가 정리되어 분석 데이터가 일관되게 수집됩니다.
  - 팀 식별값이 표준화되고, 상점 관련 팀 값 오류가 수정되었습니다.
  - 페이지 체류 시간이 공통 방식으로 계산됩니다.

- **기타 개선**
  - 헤더와 푸터의 단축 메뉴 로깅 기준이 통합되었습니다.
  - 이벤트 데이터의 허용 팀 값 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->