### PR TITLE
[캠퍼스] 팀원 모집 채팅 READ_ONLY 분기 제거

### DIFF
--- a/src/api/team/entity.ts
+++ b/src/api/team/entity.ts
@@ -191,14 +191,11 @@ export interface MyTeamRecruitmentApplicationListResponse extends APIResponse {
 
 export type TeamChatRoomType = 'TEAM' | 'DIRECT';
 
-export type TeamChatRoomStatus = 'ACTIVE' | 'READ_ONLY';
-
 export interface TeamChatRoomListItem {
   recruitment_id: number;
   chat_room_id: number;
   room_name: string;
   room_type: TeamChatRoomType;
-  status: TeamChatRoomStatus;
   counterpart_id: number | null;
   counterpart_nickname: string | null;
   last_message_id: number | null;
@@ -219,7 +216,6 @@ export interface TeamChatRoomResponse extends APIResponse {
   chat_room_id: number;
   room_name: string;
   room_type: TeamChatRoomType;
-  status: TeamChatRoomStatus;
   member_count: number;
   max_member_count: number;
   counterpart: TeamChatCounterpart | null;
@@ -229,7 +225,6 @@ export interface TeamChatDirectRoomResponse extends APIResponse {
   chat_room_id: number;
   room_name: string;
   room_type: 'DIRECT';
-  status: TeamChatRoomStatus;
   counterpart: TeamChatCounterpart;
 }
 

--- a/src/api/team/entity.ts
+++ b/src/api/team/entity.ts
@@ -191,7 +191,7 @@ export interface MyTeamRecruitmentApplicationListResponse extends APIResponse {
 
 export type TeamChatRoomType = 'TEAM' | 'DIRECT';
 
-export type TeamChatRoomStatus = 'ACTIVE' | 'READ_ONLY';
+export type TeamChatRoomStatus = 'ACTIVE';
 
 export interface TeamChatRoomListItem {
   recruitment_id: number;

--- a/src/api/team/entity.ts
+++ b/src/api/team/entity.ts
@@ -191,7 +191,7 @@ export interface MyTeamRecruitmentApplicationListResponse extends APIResponse {
 
 export type TeamChatRoomType = 'TEAM' | 'DIRECT';
 
-export type TeamChatRoomStatus = 'ACTIVE';
+export type TeamChatRoomStatus = 'ACTIVE' | 'READ_ONLY';
 
 export interface TeamChatRoomListItem {
   recruitment_id: number;

--- a/src/components/Team/components/TeamChatRoom/index.tsx
+++ b/src/components/Team/components/TeamChatRoom/index.tsx
@@ -107,7 +107,6 @@ export default function TeamChatRoom({ recruitmentId, chatRoomId }: TeamChatRoom
     }
   }, [lastMessageId]);
 
-  const isReadOnly = chatRoom.status === 'READ_ONLY';
   const isTeamRoom = chatRoom.room_type === 'TEAM';
   const messageGroups = groupChatMessagesByDate(mergedMessages);
   const memberCount = isTeamRoom ? (
@@ -293,8 +292,7 @@ export default function TeamChatRoom({ recruitmentId, chatRoomId }: TeamChatRoom
           ))}
         </div>
         <TeamChatSendBar
-          disabled={isReadOnly || isSending || isUploading}
-          placeholder={isReadOnly ? '종료된 채팅방입니다' : undefined}
+          disabled={isSending || isUploading}
           onSend={handleSend}
           onImageSelect={handleImageSelect}
         />

--- a/src/components/Team/components/TeamChatSendBar/TeamChatSendBar.module.scss
+++ b/src/components/Team/components/TeamChatSendBar/TeamChatSendBar.module.scss
@@ -68,10 +68,6 @@
     &::placeholder {
       color: #727272;
     }
-
-    &:disabled {
-      background-color: #eee;
-    }
   }
 
   &__sendButton {

--- a/src/components/Team/components/TeamChatSendBar/index.tsx
+++ b/src/components/Team/components/TeamChatSendBar/index.tsx
@@ -5,14 +5,12 @@ import styles from './TeamChatSendBar.module.scss';
 
 interface TeamChatSendBarProps {
   disabled?: boolean;
-  placeholder?: string;
   onSend: (content: string) => void;
   onImageSelect: (file: File) => void;
 }
 
 export default function TeamChatSendBar({
   disabled = false,
-  placeholder = '메세지 보내기',
   onSend,
   onImageSelect,
 }: TeamChatSendBarProps) {
@@ -82,7 +80,7 @@ export default function TeamChatSendBar({
       <textarea
         ref={textareaRef}
         className={styles.sendBar__input}
-        placeholder={placeholder}
+        placeholder="메세지 보내기"
         aria-label="메시지 입력"
         rows={1}
         value={content}


### PR DESCRIPTION
- Close #1436

## What is this PR? 🔍

- 기능 : 팀원 모집 종료 후에도 채팅방에서 메시지를 전송할 수 있도록 READ_ONLY 분기를 제거합니다.
- issue : #1436
- 
## Changes 📝

- 채팅방 상태 타입에서 READ_ONLY를 제거
- 종료된 채팅방을 판별하던 isReadOnly 분기를 제거했습니다.
- 종료된 채팅방에서 메시지 입력창을 비활성화하던 로직과 안내 문구를 제거
- 더 이상 사용하지 않는 placeholder prop을 제거
- 비활성화된 입력창에 적용되던 회색 배경 스타일을 제거


## ScreenShot 📷


## Test CheckList ✅
- [X] 수동 마감된 모집글의 채팅방에서 메시지를 전송할 수 있는지 확인
- [X] 모집 기한이 지난 채팅방에서 메시지를 전송할 수 있는지 확인
- [X] 삭제된 모집글의 기존 채팅방에서 메시지를 전송할 수 있는지 확인

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **변경 사항**
  - 팀 채팅방 정보에서 상태값이 더 이상 제공되지 않습니다.
  - 읽기 전용 채팅방 전용 입력 제한과 종료 안내 문구가 제거되었습니다.
  - 메시지 입력창은 메시지 전송 또는 이미지 업로드 중일 때만 비활성화됩니다.
  - 입력창 기본 안내 문구가 “메세지 보내기”로 고정되었습니다.
  - 입력창 비활성화 시 표시되던 회색 배경 스타일이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->