### PR TITLE
[캠퍼스] 팀원모집 자격증 입력 글자 수를 20자로 제한 및 에러메세지 추가

### DIFF
--- a/src/components/Team/ProfilePage/components/TagInput/index.tsx
+++ b/src/components/Team/ProfilePage/components/TagInput/index.tsx
@@ -35,7 +35,6 @@ export default function TagInput({ mode, label, description, addButtonLabel, pla
       {fields.length > 0 && (
         <ul className={styles.tagInput__list}>
           {fields.map((field, index) => {
-            // edit 모드에서 이미 값이 채워진 항목은 연필 아이콘으로 수정 진입점을 보여준다 (Figma 수정 화면 기준).
             const showEditIcon = mode === 'edit' && Boolean(skills[index]?.value?.trim());
             const { ref: fieldRef, ...fieldProps } = register(`skills.${index}.value` as const);
 
@@ -45,7 +44,7 @@ export default function TagInput({ mode, label, description, addButtonLabel, pla
                   type="text"
                   className={styles.tagInput__field}
                   placeholder={placeholder}
-                  maxLength={30}
+                  maxLength={20}
                   ref={(el) => {
                     fieldRef(el);
                     inputRefs.current[field.id] = el;

--- a/src/components/Team/ProfilePage/schema.ts
+++ b/src/components/Team/ProfilePage/schema.ts
@@ -18,7 +18,7 @@ const basicInfoSchema = z.object({
 
 // ── 지원서 작성 (2단계) ────────────────────────────────────
 const skillSchema = z.object({
-  value: z.string().max(30, '기술 / 자격증은 30자 이내로 입력해주세요.'),
+  value: z.string().max(20, '기술 / 자격증은 20자 이내로 입력해주세요.'),
 });
 
 // status에 따라 필수 필드가 달라지므로 판별 유니온으로 나눈다.
@@ -62,10 +62,7 @@ const applicationSchema = z.object({
   introduction: z.string().trim().min(1, '자기소개를 작성해주세요.').max(1000, '자기소개는 1000자 이내로 입력해주세요.'),
 });
 
-// zod v4에서 ZodObject.merge()는 deprecated라 shape를 직접 펼쳐서 합친다.
 export const profileFormSchema = z.object({ ...basicInfoSchema.shape, ...applicationSchema.shape }).superRefine((data, context) => {
-  // ActivityHistoryField의 "완료" 버튼을 안 눌러 draft로 남은 활동 이력이 있으면 제출 불가.
-  // 지금 ProfilePage.handleRequestSubmit의 수동 체크(values.activities.some(status==='draft'))를 그대로 스키마로 옮긴 것.
   const hasDraftActivity = data.activities.some((activity) => activity.status === 'draft');
   if (hasDraftActivity) {
     context.addIssue({

--- a/src/components/Team/RecruitmentApplyPage/schema.ts
+++ b/src/components/Team/RecruitmentApplyPage/schema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 export const APPLY_NICKNAME_MAX_LENGTH = 20;
 export const APPLY_PREFERRED_ROLE_MAX_LENGTH = 20;
-export const APPLY_SKILL_MAX_LENGTH = 30;
+export const APPLY_SKILL_MAX_LENGTH = 20;
 export const APPLY_ACTIVITY_TITLE_MAX_LENGTH = 50;
 export const APPLY_ACTIVITY_CONTENT_MAX_LENGTH = 1000;
 export const APPLY_INTRODUCTION_MAX_LENGTH = 1000;
@@ -93,6 +93,12 @@ export const createApplicationFormSchema = (isGeneralRecruitment: boolean) =>
     const skillValues = data.skills.map((skill) => skill.value.trim());
     if (skillValues.some((value) => value === '')) {
       context.addIssue({ code: 'custom', path: ['skills'], message: '빈 항목을 삭제하거나 내용을 입력해주세요.' });
+    } else if (skillValues.some((value) => value.length > APPLY_SKILL_MAX_LENGTH)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['skills'],
+        message: `기술 / 자격증은 ${APPLY_SKILL_MAX_LENGTH}자 이내로 입력해주세요.`,
+      });
     } else if (new Set(skillValues).size !== skillValues.length) {
       context.addIssue({ code: 'custom', path: ['skills'], message: '중복되지 않은 값을 입력해주세요.' });
     }


### PR DESCRIPTION
- Close #1450 

## What is this PR? 🔍

- 기능 : 팀원 모집 지원서 및 프로필페이지의 "보유 기술 / 자격증" 항목의 글자 수 제한이 서버에서 20자로 제한이 되어있었는데 클라에서는 30자로 되어있던 부분을 수정했습니다.
- issue : #1450

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 보유 기술 / 자격증 항목의 글자 수는 디자인에도 명시되어있지 않기 때문에 서버와 맞추는게 맞다고 판단하여 서버의 기준에 맞게 수정하였습니다.
- `APPLY_SKILL_MAX_LENGTH`(RecruitmentApplyPage) 및 `ProfilePage`의 스킬 스키마 제한을 30 → **20**으로 수정
  - 입력창 `maxLength` 속성
  - zod 스키마 `.max()` / superRefine 길이 검증
 

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!--
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [x] yarn lint
- [x] yarn build
- [x] 로컬에서 제출 확인

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
